### PR TITLE
Optimize SQL query to improve log pagination performance

### DIFF
--- a/backend/pkg/repository/clickhouse/dao_log_chart.go
+++ b/backend/pkg/repository/clickhouse/dao_log_chart.go
@@ -30,7 +30,8 @@ func calculateInterval(interval int64, timeField string) (string, int64) {
 func chartSQL(req *request.LogQueryRequest) (string, int64) {
 	group, interval := calculateInterval((req.EndTime-req.StartTime)/1000000, req.TimeField)
 	condition := NewQueryCondition(req.StartTime, req.EndTime, req.TimeField, req.Query)
-	sql := fmt.Sprintf("SELECT count(*) as count, %s as timeline FROM `%s`.`%s` WHERE %s GROUP BY %s ORDER BY %s ASC",
+	sql := fmt.Sprintf("SELECT count(`%s`) as count, %s as timeline FROM `%s`.`%s` WHERE %s GROUP BY %s ORDER BY %s ASC",
+		req.TimeField,
 		group,
 		req.DataBase,
 		req.TableName,

--- a/backend/pkg/repository/clickhouse/dao_query_all_log.go
+++ b/backend/pkg/repository/clickhouse/dao_query_all_log.go
@@ -18,7 +18,7 @@ func (ch *chRepo) QueryAllLogs(req *request.LogQueryRequest) ([]map[string]any, 
 	bySql := NewByLimitBuilder().
 		OrderBy(fmt.Sprintf("`%s`", req.TimeField), false).
 		Limit(req.PageSize).
-		Offset((req.PageNum - 1) * req.PageSize).
+		Offset(req.PageNum).
 		String()
 	sql := fmt.Sprintf(querySQl, req.DataBase, req.TableName, condition, bySql)
 

--- a/backend/pkg/services/log/service_query_log.go
+++ b/backend/pkg/services/log/service_query_log.go
@@ -14,6 +14,21 @@ import (
 )
 
 func (s *service) QueryLog(req *request.LogQueryRequest) (*response.LogQueryResponse, error) {
+	offset := (req.PageNum - 1) * req.PageSize
+	if offset > 10000 {
+		logcharts, _ := s.GetLogChart(req)
+		var count = 0
+		for _, chart := range logcharts.Histograms {
+			count += int(chart.Count)
+			if count > offset {
+				offset = count - int(chart.Count)
+				req.StartTime = chart.From
+				break
+			}
+		}
+	}
+
+	req.PageNum = offset
 	logs, sql, err := s.chRepo.QueryAllLogs(req)
 	res := &response.LogQueryResponse{Query: sql}
 	if err != nil {

--- a/backend/pkg/services/log/service_query_log.go
+++ b/backend/pkg/services/log/service_query_log.go
@@ -14,6 +14,7 @@ import (
 )
 
 func (s *service) QueryLog(req *request.LogQueryRequest) (*response.LogQueryResponse, error) {
+	// calculate offset, if offset > 10000, calculate from histogram
 	offset := (req.PageNum - 1) * req.PageSize
 	if offset > 10000 {
 		logcharts, _ := s.GetLogChart(req)
@@ -21,7 +22,7 @@ func (s *service) QueryLog(req *request.LogQueryRequest) (*response.LogQueryResp
 		for _, chart := range logcharts.Histograms {
 			count += int(chart.Count)
 			if count > offset {
-				offset = count - int(chart.Count)
+				offset = offset - count + int(chart.Count)
 				req.StartTime = chart.From
 				break
 			}


### PR DESCRIPTION
### Problem:
The current implementation of the log pagination query results in performance issues when querying large amounts of data. This is due to inefficient SQL queries that do not scale well with large datasets.

### Solution:
This PR optimizes the SQL query used for log pagination by:
- Calculate the query offset, The bucket log count within the time range, locate the new query interval, and update the offset.

### References:
- Related issue: #161 
