### PR TITLE
fix: Check data permission compatible with non-clustered scenarios.

### DIFF
--- a/backend/pkg/repository/database/dao.go
+++ b/backend/pkg/repository/database/dao.go
@@ -185,9 +185,6 @@ func New(zapLogger *zap.Logger) (repo Repo, err error) {
 	if err = driver.InitSQL(daoRepo.db, &AlertMetricsData{}); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initApi(); err != nil {
-		return nil, err
-	}
 	if err = daoRepo.initRole(); err != nil {
 		return nil, err
 	}
@@ -207,9 +204,6 @@ func New(zapLogger *zap.Logger) (repo Repo, err error) {
 		return nil, err
 	}
 	if err = daoRepo.initFeatureMenuItems(); err != nil {
-		return nil, err
-	}
-	if err = daoRepo.initFeatureAPI(); err != nil {
 		return nil, err
 	}
 	if err = daoRepo.initPermissions(); err != nil {

--- a/backend/pkg/services/data/datasource_permission_test.go
+++ b/backend/pkg/services/data/datasource_permission_test.go
@@ -1,0 +1,73 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package data
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/CloudDetail/apo/backend/config"
+	"github.com/CloudDetail/apo/backend/pkg/logger"
+	"github.com/CloudDetail/apo/backend/pkg/model"
+	"github.com/CloudDetail/apo/backend/pkg/repository/database"
+	"github.com/CloudDetail/apo/backend/pkg/repository/kubernetes"
+	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+var s *service
+
+func init() {
+	_, filename, _, _ := runtime.Caller(0)
+	projectRoot := filepath.Join(filepath.Dir(filename), "..", "..", "..")
+	err := os.Chdir(projectRoot)
+	if err != nil {
+		panic(err)
+	}
+	zapLog := logger.NewLogger(logger.WithLevel("debug"))
+
+	dbRepo, err := database.New(zapLog)
+	if err != nil {
+		panic(err)
+	}
+
+	cfg := config.Get()
+	promeRepo, err := prometheus.New(zapLog, cfg.Promethues.Address, cfg.Promethues.Storage)
+	if err != nil {
+		panic(err)
+	}
+
+	k8sRepo, err := kubernetes.New(zapLog, cfg.Kubernetes.AuthType, cfg.Kubernetes.AuthFilePath, config.MetadataSettings{})
+	if err != nil {
+		panic(err)
+	}
+	s = &service{
+		dbRepo:   dbRepo,
+		promRepo: promeRepo,
+		k8sRepo:  k8sRepo,
+	}
+}
+
+func TestDataSourcePermission(t *testing.T) {
+	if s == nil {
+		t.Fatal("service is nil")
+		return
+	}
+
+	namespaceList := []string{}
+
+	anonymousUser, err := s.dbRepo.GetAnonymousUser()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = s.CheckDatasourcePermission(anonymousUser.UserID, 0, &namespaceList, nil, model.DATASOURCE_CATEGORY_APM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.Equal(t, "", namespaceList[len(namespaceList)-1])
+}

--- a/backend/pkg/services/data/service_check_datasource_permission.go
+++ b/backend/pkg/services/data/service_check_datasource_permission.go
@@ -125,6 +125,8 @@ func (s *service) CheckDatasourcePermission(userID, groupID int64, namespaces, s
 	// Fill with datasource which user is authorized to view.
 	if len(namespacesSlice) == 0 && len(servicesSlice) == 0 {
 		if namespaces != nil && len(namespaceDs) > 0 {
+			// Compatible with non-clustered scenarios
+			namespaceDs = append(namespaceDs, "")
 			setInterface(namespaces, namespaceDs)
 		} else if services != nil && len(serviceDs) > 0 {
 			setInterface(services, serviceDs)


### PR DESCRIPTION
## Summary by Sourcery

Ensure data permission checks are compatible with non-clustered scenarios by appending an empty string to the namespace list when no specific namespaces or services are provided.

Bug Fixes:
- Fix data permission check to work correctly in non-clustered environments by adding a fallback to an empty string namespace.

Tests:
- Add a test case to verify data source permissions in non-clustered scenarios.