### PR TITLE
fix: supports set maximum concurrency for dify workflow

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -88,6 +88,7 @@ type Config struct {
 			AlertCheck        string `mapstructure:"alert_check"`
 			AlertEventAnalyze string `mapstructure:"alert_event_analyze"`
 		} `mapstructure:"flow_ids"`
+		MaxConcurrency int `mapstructure:"max_concurrency"`
 	} `mapstructure:"dify"`
 }
 

--- a/backend/pkg/router/router.go
+++ b/backend/pkg/router/router.go
@@ -138,6 +138,7 @@ func NewHTTPServer(logger *zap.Logger) (*Server, error) {
 	r.alertWorkflow = workflow.New(r.ch, difyClient, difyConfig.APIKeys.AlertCheck, difyConfig.User, r.logger)
 	r.alertWorkflow.EventAnalyzeFlowId = difyConfig.FlowIDs.AlertEventAnalyze
 	r.alertWorkflow.CheckId = difyConfig.FlowIDs.AlertCheck
+	r.alertWorkflow.MaxConcurrency = difyConfig.MaxConcurrency
 	r.alertWorkflow.Run(context.Background())
 
 	// Set API routing

--- a/backend/pkg/router/router.go
+++ b/backend/pkg/router/router.go
@@ -139,7 +139,10 @@ func NewHTTPServer(logger *zap.Logger) (*Server, error) {
 	r.alertWorkflow.EventAnalyzeFlowId = difyConfig.FlowIDs.AlertEventAnalyze
 	r.alertWorkflow.CheckId = difyConfig.FlowIDs.AlertCheck
 	r.alertWorkflow.MaxConcurrency = difyConfig.MaxConcurrency
-	r.alertWorkflow.Run(context.Background())
+	err = r.alertWorkflow.Run(context.Background())
+	if err != nil {
+		r.logger.Error("alertCheck workflow is not running", zap.Error(err))
+	}
 
 	// Set API routing
 	setApiRouter(r)

--- a/backend/pkg/services/integration/workflow/alert_workflow.go
+++ b/backend/pkg/services/integration/workflow/alert_workflow.go
@@ -37,7 +37,8 @@ type AlertWorkflow struct {
 	EventAnalyzeFlowId string
 	CheckId            string
 
-	logger *zap.Logger
+	MaxConcurrency int
+	logger         *zap.Logger
 }
 
 func New(chRepo clickhouse.Repo, client *DifyClient, apiKey string, user string, logger *zap.Logger) *AlertWorkflow {
@@ -54,12 +55,19 @@ func New(chRepo clickhouse.Repo, client *DifyClient, apiKey string, user string,
 }
 
 func (c *AlertWorkflow) Run(ctx context.Context) error {
+	if len(c.difyAPIKey) == 0 {
+		return nil
+	}
+
+	if c.MaxConcurrency <= 0 {
+		c.MaxConcurrency = 2
+	}
+
 	ctab := cron.New()
 	_, err := ctab.AddFunc("*/5 * * * *", func() {
 		err := c.Submit()
 		if err != nil {
-			// TODO deal with err
-			panic(err)
+			c.logger.Error("failed to store workflow record", zap.Error(err))
 		}
 	})
 	if err != nil {
@@ -70,6 +78,10 @@ func (c *AlertWorkflow) Run(ctx context.Context) error {
 }
 
 func (c *AlertWorkflow) AddAlertEvent(event *alert.AlertEvent) {
+	if len(c.difyAPIKey) == 0 {
+		return
+	}
+
 	if event.Status == alert.StatusResolved {
 		return
 	}
@@ -84,6 +96,9 @@ func (c *AlertWorkflow) AddAlertEvent(event *alert.AlertEvent) {
 }
 
 func (c *AlertWorkflow) AddAlertEvents(events []alert.AlertEvent) {
+	if len(c.difyAPIKey) == 0 {
+		return
+	}
 	c.AddMutex.Lock()
 	defer c.AddMutex.Unlock()
 
@@ -99,18 +114,13 @@ func (c *AlertWorkflow) AddAlertEvents(events []alert.AlertEvent) {
 	}
 }
 
-type eventCheckResult struct {
-	event  *alert.AlertEvent
-	record model.WorkflowRecord
-}
-
 func (c *AlertWorkflow) worker(
 	events <-chan alert.AlertEvent,
 	results chan<- model.WorkflowRecord,
 	startTime int64, endTime int64,
 	wg *sync.WaitGroup) {
 	defer wg.Done()
-	for event := range events { // 从通道获取任务
+	for event := range events {
 		inputs, _ := json.Marshal(map[string]interface{}{
 			"alert":     event.Name,
 			"params":    event.TagsInStr(),
@@ -121,9 +131,7 @@ func (c *AlertWorkflow) worker(
 		resp, err := c.alertCheck(&DifyRequest{Inputs: inputs}, c.authorization, c.user)
 
 		if err != nil {
-			// TODO deal with error
 			c.logger.Error("failed to to alert check", zap.Error(err))
-			// panic(err)
 			continue
 		}
 
@@ -141,6 +149,7 @@ func (c *AlertWorkflow) worker(
 	}
 }
 
+// Submit cached alert events to Dify to execute the workflow
 func (c *AlertWorkflow) Submit() error {
 	c.AddMutex.Lock()
 	submitEvents := c.PrepareToRun
@@ -163,11 +172,10 @@ func (c *AlertWorkflow) Submit() error {
 	var wg sync.WaitGroup
 	var results = make(chan model.WorkflowRecord)
 
-	// 每次提交最多跑4min, 其他数据暂不计算
 	endTime := time.Now()
 	startTime := endTime.Add(-15 * time.Minute).UnixMicro()
 	var events = make(chan alert.AlertEvent)
-	for i := 0; i < 10; i++ {
+	for i := 0; i < c.MaxConcurrency; i++ {
 		wg.Add(1)
 		go c.worker(events, results, startTime, endTime.UnixMicro(), &wg)
 	}
@@ -205,20 +213,20 @@ func (c *AlertWorkflow) Submit() error {
 	return c.chRepo.AddWorkflowRecords(context.Background(), records)
 }
 
-type AlertCheckRespose struct {
+type AlertCheckResponse struct {
 	resp *CompletionResponse
 }
 
-func (r *AlertCheckRespose) WorkflowRunID() string {
+func (r *AlertCheckResponse) WorkflowRunID() string {
 	return r.resp.WorkflowRunID
 }
 
 // UnixMicro Timestamp
-func (r *AlertCheckRespose) CreatedAt() int64 {
+func (r *AlertCheckResponse) CreatedAt() int64 {
 	return r.resp.Data.CreatedAt * 1e6
 }
 
-func (r *AlertCheckRespose) IsValidOrDefault(defaultV string) string {
+func (r *AlertCheckResponse) IsValidOrDefault(defaultV string) string {
 	var res map[string]string
 	err := json.Unmarshal(r.resp.Data.Outputs, &res)
 	if err != nil {

--- a/backend/pkg/services/integration/workflow/dify.go
+++ b/backend/pkg/services/integration/workflow/dify.go
@@ -30,14 +30,14 @@ func NewDifyClient(client *http.Client, url string) *DifyClient {
 	}
 }
 
-func (c *DifyClient) alertCheck(req *DifyRequest, authorization string, user string) (*AlertCheckRespose, error) {
+func (c *DifyClient) alertCheck(req *DifyRequest, authorization string, user string) (*AlertCheckResponse, error) {
 	req.ResponseMode = "blocking"
 	resp, err := c.WorkflowsRun(req, authorization, user)
 	if err != nil {
 		return nil, err
 	}
 	if resp, ok := resp.(*CompletionResponse); ok {
-		return &AlertCheckRespose{resp}, err
+		return &AlertCheckResponse{resp}, err
 	}
 	return nil, fmt.Errorf("alertCheck must be run in blocking mode")
 }


### PR DESCRIPTION
- supports set maximum concurrency for dify workflow, default is 2
- stop executing workflow if dify APIKey is empty

## Summary by Sourcery

Configures the maximum concurrency for Dify workflows and prevents workflow execution when the Dify API key is empty.