### PR TITLE
Feat/optimize alert check workflow

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -97,7 +97,9 @@ type Config struct {
 			AlertCheck        string `mapstructure:"alert_check"`
 			AlertEventAnalyze string `mapstructure:"alert_event_analyze"`
 		} `mapstructure:"flow_ids"`
-		MaxConcurrency int `mapstructure:"max_concurrency"`
+		MaxConcurrency int    `mapstructure:"max_concurrency"`
+		CacheMinutes   int    `mapstructure:"cache_minutes"`
+		Sampling       string `mapstructure:"sampling"`
 	} `mapstructure:"dify"`
 }
 

--- a/backend/pkg/model/workflow_records.go
+++ b/backend/pkg/model/workflow_records.go
@@ -13,5 +13,6 @@ type WorkflowRecord struct {
 	Input  string `json:"input" ch:"input"`
 	Output string `json:"output" ch:"output"`
 
-	CreatedAt int64 `json:"createdAt" ch:"created_at"`
+	CreatedAt   int64 `json:"createdAt" ch:"created_at"`
+	RoundedTime int64 `json:"-" ch:"rounded_time"`
 }

--- a/backend/pkg/repository/clickhouse/dao.go
+++ b/backend/pkg/repository/clickhouse/dao.go
@@ -106,7 +106,7 @@ type Repo interface {
 	GetFlameGraphData(startTime, endTime int64, nodeName string, pid, tid int64, sampleType, spanId, traceId string) (*[]FlameGraphData, error)
 
 	AddWorkflowRecords(ctx context.Context, records []model.WorkflowRecord) error
-	GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest) ([]alert.AEventWithWRecord, int64, error)
+	GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error)
 
 	integration.Input
 }

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -27,7 +27,8 @@ const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD = `WITH paged_alerts AS (
 	%s
 ),
 filtered_workflows AS (
-    SELECT *
+    SELECT *,
+	%s as rounded_time_e
     FROM workflow_records
     %s
 )
@@ -44,7 +45,7 @@ SELECT
     ae.status,
     ae.tags,
 	ae.source,
-    toStartOfFiveMinutes(ae.received_time) + INTERVAL 5 MINUTE AS rounded_time,
+    %s AS rounded_time,
     wr.workflow_run_id,
     wr.workflow_id,
     wr.workflow_name,
@@ -55,7 +56,7 @@ SELECT
     END as is_valid
 FROM paged_alerts AS ae
 LEFT JOIN filtered_workflows AS wr
-ON ae.alert_id = wr.ref AND rounded_time = toStartOfFiveMinutes(wr.created_at)
+ON ae.alert_id = wr.ref AND rounded_time = wr.rounded_time_e
 %s`
 
 const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD_VALID_FIRST = `WITH paged_alerts AS (
@@ -71,7 +72,8 @@ filtered_workflows AS (
       WHEN output = 'false' THEN 2
       WHEN output = 'true' THEN 1
       ELSE 0
-    END as importance
+    END as importance,
+	%s as rounded_time_e
     FROM workflow_records
     %s
 )
@@ -88,7 +90,7 @@ SELECT
     ae.status,
     ae.tags,
 	ae.source,
-    toStartOfFiveMinutes(ae.received_time) + INTERVAL 5 MINUTE AS rounded_time,
+    %s AS rounded_time,
     wr.workflow_run_id,
     wr.workflow_id,
     wr.workflow_name,
@@ -100,8 +102,19 @@ SELECT
     END as is_valid
 FROM paged_alerts AS ae
 LEFT JOIN filtered_workflows AS wr
-ON ae.alert_id = wr.ref AND rounded_time = toStartOfFiveMinutes(wr.created_at)
+ON ae.alert_id = wr.ref AND ae.rounded_time = wr.rounded_time_e
 %s`
+
+func getWorkflowRecordRoundedTime(cacheMinutes int) string {
+	return fmt.Sprintf(`CASE
+	  WHEN rounded_time > 0 THEN rounded_time
+	  ELSE toStartOfInterval(wr.created_at, INTERVAL %d MINUTE)
+	END`, cacheMinutes)
+}
+
+func getEventRoundedTime(cacheMinutes int) string {
+	return fmt.Sprintf(`toStartOfInterval(ae.received_time, INTERVAL %d MINUTE) + INTERVAL %d MINUTE`, cacheMinutes, cacheMinutes)
+}
 
 func sortbyParam(sortBy string) ([]string, []bool) {
 	if len(sortBy) == 0 {
@@ -136,7 +149,7 @@ func sortbyParam(sortBy string) ([]string, []bool) {
 	return fields, ascs
 }
 
-func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest) ([]alert.AEventWithWRecord, int64, error) {
+func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error) {
 	alertFilter := NewQueryBuilder().
 		Between("received_time", req.StartTime/1e6, req.EndTime/1e6)
 
@@ -154,14 +167,14 @@ func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchR
 		return nil, 0, err
 	}
 
-	sql, values := getSqlAndValueForSortedAlertEvent(req)
+	sql, values := getSqlAndValueForSortedAlertEvent(req, cacheMinutes)
 
 	result := make([]alert.AEventWithWRecord, 0)
 	err = ch.conn.Select(context.Background(), &result, sql, values...)
 	return result, int64(count), err
 }
 
-func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest) (string, []any) {
+func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest, cacheMinutes int) (string, []any) {
 	alertFilter := NewQueryBuilder().
 		Between("received_time", req.StartTime/1e6, req.EndTime/1e6)
 
@@ -195,7 +208,9 @@ func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest) (st
 	if hasInValid {
 		sql = fmt.Sprintf(SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD_VALID_FIRST,
 			alertFilter.String(),
+			getWorkflowRecordRoundedTime(cacheMinutes),
 			recordFilter.String(),
+			getEventRoundedTime(cacheMinutes),
 			alertOrder.String(),
 		)
 	} else {
@@ -204,8 +219,11 @@ func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest) (st
 			finalOrder.OrderBy(field, ascs[idx])
 		}
 		sql = fmt.Sprintf(SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD,
-			alertFilter.String(), alertOrder.String(),
+			alertFilter.String(),
+			alertOrder.String(),
+			getWorkflowRecordRoundedTime(cacheMinutes),
 			recordFilter.String(),
+			getEventRoundedTime(cacheMinutes),
 			finalOrder.String(),
 		)
 	}

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -102,13 +102,13 @@ SELECT
     END as is_valid
 FROM paged_alerts AS ae
 LEFT JOIN filtered_workflows AS wr
-ON ae.alert_id = wr.ref AND ae.rounded_time = wr.rounded_time_e
+ON ae.alert_id = wr.ref AND rounded_time = wr.rounded_time_e
 %s`
 
 func getWorkflowRecordRoundedTime(cacheMinutes int) string {
 	return fmt.Sprintf(`CASE
 	  WHEN rounded_time > 0 THEN rounded_time
-	  ELSE toStartOfInterval(wr.created_at, INTERVAL %d MINUTE)
+	  ELSE toStartOfInterval(created_at, INTERVAL %d MINUTE)
 	END`, cacheMinutes)
 }
 

--- a/backend/pkg/repository/clickhouse/dao_workflow_records.go
+++ b/backend/pkg/repository/clickhouse/dao_workflow_records.go
@@ -12,7 +12,7 @@ import (
 
 func (ch *chRepo) AddWorkflowRecords(ctx context.Context, records []model.WorkflowRecord) error {
 	batch, err := ch.conn.PrepareBatch(ctx, `
-		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at)
+		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at, rounded_time)
 		VALUES
 	`)
 	if err != nil {
@@ -27,6 +27,7 @@ func (ch *chRepo) AddWorkflowRecords(ctx context.Context, records []model.Workfl
 			record.Input,
 			record.Output,
 			time.UnixMicro(record.CreatedAt),
+			time.UnixMicro(record.RoundedTime),
 		); err != nil {
 			continue
 		}

--- a/backend/pkg/repository/database/dao_data_group.go
+++ b/backend/pkg/repository/database/dao_data_group.go
@@ -5,6 +5,7 @@ package database
 
 import (
 	"context"
+
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -22,6 +22,9 @@ func (s *service) AlertEventList(req *request.AlertEventSearchRequest) (*respons
 
 	for i := 0; i < len(events); i++ {
 		s.fillWorkflowParams(&events[i])
+		if events[i].Status == alert.StatusResolved && events[i].IsValid == "unknown" {
+			events[i].IsValid = "skipped"
+		}
 	}
 
 	req.Pagination.Total = count

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -15,25 +15,25 @@ import (
 )
 
 func (s *service) AlertEventList(req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
-	events, count, err := s.chRepo.GetAlertEventWithWorkflowRecord(req)
+	events, count, err := s.chRepo.GetAlertEventWithWorkflowRecord(req, s.alertWorkflow.AlertCheck.CacheMinutes)
 	if err != nil {
 		return nil, err
 	}
 
 	for i := 0; i < len(events); i++ {
-		s.fillWorkflowParmas(&events[i])
+		s.fillWorkflowParams(&events[i])
 	}
 
 	req.Pagination.Total = count
 	return &response.AlertEventSearchResponse{
 		EventList:                   events,
 		Pagination:                  req.Pagination,
-		AlertEventAnalyzeWorkflowID: s.alertWorkflow.EventAnalyzeFlowId,
-		AlertCheckID:                s.alertWorkflow.CheckId,
+		AlertEventAnalyzeWorkflowID: s.alertWorkflow.AnalyzeFlowId,
+		AlertCheckID:                s.alertWorkflow.AlertCheck.FlowId,
 	}, nil
 }
 
-func (s *service) fillWorkflowParmas(record *alert.AEventWithWRecord) {
+func (s *service) fillWorkflowParams(record *alert.AEventWithWRecord) {
 
 	startTime := record.ReceivedTime.Add(-15 * time.Minute)
 	endTime := record.ReceivedTime

--- a/backend/pkg/services/integration/workflow/alert_check.go
+++ b/backend/pkg/services/integration/workflow/alert_check.go
@@ -44,7 +44,7 @@ func newAlertCheck(cfg *AlertCheckCfg, logger *zap.Logger) alertCheck {
 			logger:        logger,
 			eventInput:    newInputChan(),
 		}
-	case "latest":
+	case "last":
 		return &sampleWithLatestRecord{
 			logger:        logger,
 			AlertCheckCfg: cfg,

--- a/backend/pkg/services/integration/workflow/alert_check.go
+++ b/backend/pkg/services/integration/workflow/alert_check.go
@@ -1,0 +1,357 @@
+package workflow
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/CloudDetail/apo/backend/pkg/model"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/robfig/cron/v3"
+	"go.uber.org/zap"
+)
+
+const MAX_CACHE_SIZE = 100
+
+type AlertCheckCfg struct {
+	FlowId        string
+	FlowName      string
+	APIKey        string
+	Authorization string
+	User          string
+
+	Sampling       string
+	CacheMinutes   int
+	MaxConcurrency int
+}
+
+type alertCheck interface {
+	Run(ctx context.Context, client *DifyClient) (<-chan model.WorkflowRecord, error)
+	AddEvents(events []alert.AlertEvent)
+}
+
+func newAlertCheck(cfg *AlertCheckCfg, logger *zap.Logger) alertCheck {
+	switch strings.ToLower(cfg.Sampling) {
+	case "no", "false", "disabled":
+		return &checkWorkers{
+			AlertCheckCfg: cfg,
+			logger:        logger,
+			eventInput:    newInputChan(),
+		}
+	case "latest":
+		return &sampleWithLatestRecord{
+			logger:        logger,
+			AlertCheckCfg: cfg,
+			prepareToRun:  make(map[string]alert.AlertEvent),
+			eventInput:    newInputChan(),
+		}
+	default:
+		return &sampleWithFirstRecord{
+			logger:        logger,
+			AlertCheckCfg: cfg,
+			checkedAlert:  make(map[string]struct{}),
+			eventInput:    newInputChan(),
+		}
+	}
+}
+
+type checkWorkers struct {
+	*AlertCheckCfg
+	logger *zap.Logger
+
+	eventInput *inputChan
+}
+
+func (c *checkWorkers) Run(ctx context.Context, client *DifyClient) (<-chan model.WorkflowRecord, error) {
+	rChan := make(chan model.WorkflowRecord, MAX_CACHE_SIZE+10)
+	var wg sync.WaitGroup
+	for i := 0; i < c.MaxConcurrency; i++ {
+		wg.Add(1)
+		worker := worker{
+			logger:        c.logger,
+			expiredTS:     -1,
+			AlertCheckCfg: c.AlertCheckCfg,
+		}
+		go worker.run(client, c.eventInput.Ch, rChan, &wg)
+	}
+
+	go waitForShutDown(ctx, c.eventInput, rChan, &wg)
+	return rChan, nil
+}
+
+func (c *checkWorkers) AddEvents(events []alert.AlertEvent) {
+	if c.eventInput.IsShutDown {
+		return
+	}
+	remainSize := len(c.eventInput.Ch)
+	for i := 0; i < len(events); i++ {
+		if remainSize > MAX_CACHE_SIZE {
+			c.logger.Info("too many alerts waiting for check, skip", zap.String("alertId", events[i].AlertID))
+			continue
+		}
+		remainSize++
+		c.eventInput.Ch <- events[i]
+	}
+}
+
+type sampleWithFirstRecord struct {
+	logger *zap.Logger
+	*AlertCheckCfg
+
+	eventInput *inputChan
+
+	checkedAlert map[string]struct{}
+	mutex        sync.Mutex
+
+	workers   []*worker
+	dropCount int // ignore data races.
+}
+
+func (s *sampleWithFirstRecord) Run(
+	ctx context.Context,
+	client *DifyClient,
+) (<-chan model.WorkflowRecord, error) {
+	rChan := make(chan model.WorkflowRecord, MAX_CACHE_SIZE+10)
+
+	var wg sync.WaitGroup
+	now := time.Now()
+	expiredTS := now.Truncate(time.Duration(s.CacheMinutes) * time.Minute).UnixMicro()
+	for i := 0; i < s.MaxConcurrency; i++ {
+		wg.Add(1)
+		worker := worker{
+			logger:        s.logger,
+			expiredTS:     expiredTS,
+			AlertCheckCfg: s.AlertCheckCfg,
+		}
+		s.workers = append(s.workers, &worker)
+		go worker.run(client, s.eventInput.Ch, rChan, &wg)
+	}
+	cronTab := cron.New()
+	_, err := cronTab.AddFunc(fmt.Sprintf("*/%d * * * *", s.CacheMinutes), func() {
+		s.cleanCache()
+	})
+	if err != nil {
+		return nil, err
+	}
+	cronTab.Start()
+	go waitForShutDown(ctx, s.eventInput, rChan, &wg)
+	return rChan, nil
+}
+
+func (s *sampleWithFirstRecord) cleanCache() {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	s.checkedAlert = make(map[string]struct{})
+	now := time.Now()
+	expiredTS := now.Truncate(time.Duration(s.CacheMinutes) * time.Minute).UnixMicro()
+
+	dropCount := 0
+	for _, worker := range s.workers {
+		worker.expiredTS = expiredTS
+		dropCount += worker.dropCount
+		worker.dropCount = 0
+	}
+
+	if dropCount+s.dropCount > 0 {
+		s.logger.Info("check alert failed count", zap.Int("cacheMinutes", s.CacheMinutes), zap.Int("drop count", dropCount+s.dropCount))
+	}
+	s.dropCount++
+}
+
+func (s *sampleWithFirstRecord) AddEvents(events []alert.AlertEvent) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	remainSize := len(s.eventInput.Ch)
+	for i := 0; i < len(events); i++ {
+		if _, find := s.checkedAlert[events[i].AlertID]; find {
+			continue
+		}
+		if remainSize > MAX_CACHE_SIZE {
+			s.dropCount++
+			s.logger.Info("too many alerts waiting for check, skip", zap.String("alertId", events[i].AlertID))
+			continue
+		}
+		remainSize++
+		s.eventInput.Ch <- events[i]
+	}
+}
+
+type sampleWithLatestRecord struct {
+	logger *zap.Logger
+	*AlertCheckCfg
+
+	eventInput *inputChan
+
+	prepareToRun map[string]alert.AlertEvent
+	mutex        sync.Mutex
+
+	workers   []*worker
+	dropCount int // ignore data races.
+}
+
+func (s *sampleWithLatestRecord) Run(
+	ctx context.Context,
+	client *DifyClient,
+) (<-chan model.WorkflowRecord, error) {
+	rChan := make(chan model.WorkflowRecord, MAX_CACHE_SIZE+10)
+
+	var wg sync.WaitGroup
+	for i := 0; i < s.MaxConcurrency; i++ {
+		wg.Add(1)
+		worker := worker{
+			logger:        s.logger,
+			expiredTS:     -1,
+			AlertCheckCfg: s.AlertCheckCfg,
+		}
+		s.workers = append(s.workers, &worker)
+		go worker.run(client, s.eventInput.Ch, rChan, &wg)
+	}
+	cronTab := cron.New()
+	_, err := cronTab.AddFunc(fmt.Sprintf("*/%d * * * *", s.CacheMinutes), func() {
+		s.submit()
+	})
+	if err != nil {
+		return nil, err
+	}
+	cronTab.Start()
+	go waitForShutDown(ctx, s.eventInput, rChan, &wg)
+	return rChan, nil
+}
+
+func (s *sampleWithLatestRecord) AddEvents(events []alert.AlertEvent) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	for _, event := range events {
+		if event.Status == alert.StatusResolved {
+			continue
+		}
+
+		if _, find := s.prepareToRun[event.AlertID]; !find {
+			if len(s.prepareToRun) > MAX_CACHE_SIZE {
+				s.dropCount++
+				continue
+			}
+		}
+		s.prepareToRun[event.AlertID] = event
+	}
+}
+
+func (s *sampleWithLatestRecord) submit() {
+	dropCount := 0
+	for _, worker := range s.workers {
+		dropCount += worker.dropCount
+		worker.dropCount = 0
+	}
+	if dropCount+s.dropCount > 0 {
+		s.logger.Info("check alert failed count", zap.Int("cacheMinutes", s.CacheMinutes), zap.Int("drop count", dropCount+s.dropCount))
+	}
+	s.dropCount = 0
+
+	s.mutex.Lock()
+	var cachedEvents []alert.AlertEvent
+	for _, event := range s.prepareToRun {
+		cachedEvents = append(cachedEvents, event)
+	}
+	s.prepareToRun = make(map[string]alert.AlertEvent)
+	s.mutex.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute*time.Duration(s.CacheMinutes-1))
+	defer cancel()
+	go func() {
+		for i := 0; i < len(cachedEvents); i++ {
+			select {
+			case <-ctx.Done():
+				s.dropCount += len(cachedEvents) - i
+				return
+			case s.eventInput.Ch <- cachedEvents[i]:
+			}
+		}
+	}()
+}
+
+type inputChan struct {
+	Ch         chan alert.AlertEvent
+	IsShutDown bool
+}
+
+func newInputChan() *inputChan {
+	return &inputChan{
+		Ch:         make(chan alert.AlertEvent, MAX_CACHE_SIZE+10),
+		IsShutDown: false,
+	}
+}
+
+type worker struct {
+	logger *zap.Logger
+	*AlertCheckCfg
+
+	expiredTS int64
+	dropCount int // ignore data races.
+}
+
+func (w *worker) run(c *DifyClient, eventInput <-chan alert.AlertEvent, results chan<- model.WorkflowRecord, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for event := range eventInput {
+		endTime := event.ReceivedTime.UnixMicro()
+		if w.expiredTS > 0 && endTime < w.expiredTS {
+			w.dropCount++
+			continue
+		}
+
+		startTime := event.ReceivedTime.Add(-15 * time.Minute).UnixMicro()
+		inputs, _ := json.Marshal(map[string]interface{}{
+			"alert":     event.Name,
+			"params":    event.TagsInStr(),
+			"startTime": startTime,
+			"endTime":   endTime,
+		})
+		resp, err := c.alertCheck(&DifyRequest{Inputs: inputs}, w.Authorization, w.User)
+		if err != nil {
+			w.dropCount++
+			w.logger.Error("failed to to alert check", zap.Error(err))
+			continue
+		}
+
+		tw := time.Duration(w.CacheMinutes) * time.Minute
+		roundedTime := event.ReceivedTime.Truncate(tw).Add(tw)
+
+		record := model.WorkflowRecord{
+			WorkflowRunID: resp.WorkflowRunID(),
+			WorkflowID:    w.FlowId,
+			WorkflowName:  w.FlowName,
+			Ref:           event.AlertID,
+			Input:         "",                             // TODO record input param
+			Output:        resp.IsValidOrDefault("false"), // 'false' means valid alert
+			CreatedAt:     resp.CreatedAt(),
+			RoundedTime:   roundedTime.UnixMicro(),
+		}
+
+		results <- record
+	}
+}
+
+func waitForShutDown(
+	ctx context.Context,
+	eventInput *inputChan,
+	rChan chan model.WorkflowRecord,
+	wg *sync.WaitGroup,
+) {
+	<-ctx.Done()
+	eventInput.IsShutDown = true
+	close(eventInput.Ch)
+	wg.Wait()
+	close(rChan)
+}
+
+func (c *AlertCheckCfg) HasValidAPIKey() bool {
+	if c == nil {
+		return false
+	}
+	// TODO check Destination
+	return len(c.APIKey) > 0
+}

--- a/backend/pkg/services/integration/workflow/alert_check.go
+++ b/backend/pkg/services/integration/workflow/alert_check.go
@@ -173,6 +173,7 @@ func (s *sampleWithFirstRecord) AddEvents(events []alert.AlertEvent) {
 		if _, find := s.checkedAlert[events[i].AlertID]; find {
 			continue
 		}
+		s.checkedAlert[events[i].AlertID] = struct{}{}
 		if remainSize > MAX_CACHE_SIZE {
 			s.dropCount++
 			s.logger.Info("too many alerts waiting for check, skip", zap.String("alertId", events[i].AlertID))

--- a/backend/pkg/services/integration/workflow/alert_check.go
+++ b/backend/pkg/services/integration/workflow/alert_check.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package workflow
 
 import (

--- a/backend/pkg/services/integration/workflow/alert_workflow.go
+++ b/backend/pkg/services/integration/workflow/alert_workflow.go
@@ -26,11 +26,16 @@ type AlertWorkflow struct {
 type Option func(f *AlertWorkflow)
 
 func New(chRepo clickhouse.Repo, client *DifyClient, logger *zap.Logger, opts ...Option) *AlertWorkflow {
-	return &AlertWorkflow{
+	workflow := &AlertWorkflow{
 		chRepo: chRepo,
 		client: client,
 		logger: logger,
 	}
+
+	for _, opt := range opts {
+		opt(workflow)
+	}
+	return workflow
 }
 
 func WithAlertCheckFlow(cfg *AlertCheckCfg) Option {
@@ -52,7 +57,7 @@ func WithAlertCheckFlow(cfg *AlertCheckCfg) Option {
 		}
 		f.logger.Info("start to process alert check",
 			zap.Int("cacheMinutes", cfg.CacheMinutes),
-			zap.Int("MaxConcurrency", cfg.MaxConcurrency),
+			zap.Int("maxConcurrency", cfg.MaxConcurrency),
 		)
 		go f.SaveRecords(context.Background(), records)
 		f.check = check

--- a/backend/pkg/services/integration/workflow/dify.go
+++ b/backend/pkg/services/integration/workflow/dify.go
@@ -113,3 +113,31 @@ func (r *CompletionResponse) _DifyResponse() {}
 type ChunkCompletionResponse struct{}
 
 func (r *ChunkCompletionResponse) _DifyResponse() {}
+
+type AlertCheckResponse struct {
+	resp *CompletionResponse
+}
+
+func (r *AlertCheckResponse) WorkflowRunID() string {
+	return r.resp.WorkflowRunID
+}
+
+// UnixMicro Timestamp
+func (r *AlertCheckResponse) CreatedAt() int64 {
+	return r.resp.Data.CreatedAt * 1e6
+}
+
+func (r *AlertCheckResponse) IsValidOrDefault(defaultV string) string {
+	var res map[string]string
+	err := json.Unmarshal(r.resp.Data.Outputs, &res)
+	if err != nil {
+		return defaultV
+	}
+
+	text, find := res["text"]
+	if !find {
+		return defaultV
+	}
+
+	return text
+}


### PR DESCRIPTION
This PR introduces two optimization configurations for the alert check workflow, 

To reduce costs, when the same alert occurs multiple times, only perform one validity check.

 `sampling` defines how events are selected within the sampling period.
 `cache_minutes` defines the duration of one sampling period.

```yaml
dify:
  # options: "first" "last" "disabled"
  sampling: "first"
  # options: 5, 10, 15, 20, 30
  cache_minutes: 20
  ...
```
