### PR TITLE
Fix/use updatetime to analyze alert

### DIFF
--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -17,7 +17,7 @@ const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD_COUNT = `WITH lastEvent AS (
   SELECT alert_id,status,%s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY received_time DESC LIMIT 1 BY alert_id
+  ORDER BY update_time DESC LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
   SELECT rounded_time,ref,output,
@@ -49,7 +49,7 @@ const SQL_GET_ALERTEVENT_COUNTS = `WITH lastEvent AS (
   SELECT *, %s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY received_time DESC LIMIT 1 BY alert_id
+  ORDER BY update_time DESC LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
   SELECT *,
@@ -79,7 +79,7 @@ const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD = `WITH lastEvent AS (
   SELECT *, %s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY received_time DESC
+  ORDER BY update_time DESC
   LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
@@ -101,7 +101,7 @@ SELECT
   ae.create_time,
   ae.update_time,
   ae.end_time,
-  ae.received_time,
+  ae.update_time,
   ae.detail,
   ae.status,
   ae.tags,
@@ -137,12 +137,12 @@ func getWorkflowRecordRoundedTime(cacheMinutes int) string {
 }
 
 func getEventRoundedTime(cacheMinutes int) string {
-	return fmt.Sprintf(`toStartOfInterval(ae.received_time, INTERVAL %d MINUTE) + INTERVAL %d MINUTE`, cacheMinutes, cacheMinutes)
+	return fmt.Sprintf(`toStartOfInterval(ae.update_time, INTERVAL %d MINUTE) + INTERVAL %d MINUTE`, cacheMinutes, cacheMinutes)
 }
 
 func sortbyParam(sortBy string) ([]string, []bool) {
 	if len(sortBy) == 0 {
-		return []string{"importance", "received_time"}, []bool{false, true}
+		return []string{"importance", "update_time"}, []bool{false, true}
 	}
 
 	sortBys := strings.Split(sortBy, ",")
@@ -157,14 +157,14 @@ func sortbyParam(sortBy string) ([]string, []bool) {
 		}
 
 		if parts[0] == "receivedTime" {
-			fields = append(fields, "received_time")
+			fields = append(fields, "update_time")
 			ascs = append(ascs, order == "asc")
 		} else if parts[0] == "isValid" {
 			fields = append(fields, "importance")
 			ascs = append(ascs, order == "asc")
 
 			if len(sortBys) == 1 {
-				fields = append(fields, "received_time")
+				fields = append(fields, "update_time")
 				ascs = append(ascs, order == "asc")
 			}
 		}
@@ -175,7 +175,7 @@ func sortbyParam(sortBy string) ([]string, []bool) {
 
 func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error) {
 	alertFilter := NewQueryBuilder().
-		Between("received_time", req.StartTime/1e6, req.EndTime/1e6)
+		Between("update_time", req.StartTime/1e6, req.EndTime/1e6)
 
 	if len(req.Filter.Namespaces) > 0 {
 		alertFilter.InStrings("tags['namespace']", req.Filter.Namespaces)
@@ -220,7 +220,7 @@ func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchR
 
 func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest, cacheMinutes int) (string, []any) {
 	alertFilter := NewQueryBuilder().
-		Between("received_time", req.StartTime/1e6, req.EndTime/1e6)
+		Between("update_time", req.StartTime/1e6, req.EndTime/1e6)
 
 	if len(req.Filter.Namespaces) > 0 {
 		alertFilter.InStrings("tags['namespace']", req.Filter.Namespaces)
@@ -272,7 +272,7 @@ func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest, cac
 
 func (ch *chRepo) GetAlertEventCounts(req *request.AlertEventSearchRequest, cacheMinutes int) (map[string]int64, error) {
 	alertFilter := NewQueryBuilder().
-		Between("received_time", req.StartTime/1e6, req.EndTime/1e6)
+		Between("update_time", req.StartTime/1e6, req.EndTime/1e6)
 
 	var counts []_alertEventCount
 	intervalMicro := int64(5*time.Minute) / 1e3

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -17,7 +17,7 @@ const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD_COUNT = `WITH lastEvent AS (
   SELECT alert_id,status,%s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY update_time DESC LIMIT 1 BY alert_id
+  ORDER BY received_time DESC LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
   SELECT rounded_time,ref,output,
@@ -49,7 +49,7 @@ const SQL_GET_ALERTEVENT_COUNTS = `WITH lastEvent AS (
   SELECT *, %s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY update_time DESC LIMIT 1 BY alert_id
+  ORDER BY received_time DESC LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
   SELECT *,
@@ -79,8 +79,7 @@ const SQL_GET_ALERTEVENT_WITH_WORKFLOW_RECORD = `WITH lastEvent AS (
   SELECT *, %s as rounded_time
   FROM alert_event ae
   %s
-  ORDER BY update_time DESC
-  LIMIT 1 BY alert_id
+  ORDER BY received_time DESC LIMIT 1 BY alert_id
 ),
 filtered_workflows AS (
   SELECT *,

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -101,7 +101,7 @@ SELECT
   ae.create_time,
   ae.update_time,
   ae.end_time,
-  ae.update_time,
+  ae.received_time,
   ae.detail,
   ae.status,
   ae.tags,

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -46,8 +46,14 @@ func (s *service) AlertEventList(req *request.AlertEventSearchRequest) (*respons
 }
 
 func (s *service) fillWorkflowParams(record *alert.AEventWithWRecord) {
-	startTime := record.UpdateTime.Add(-15 * time.Minute)
-	endTime := record.UpdateTime
+	var startTime, endTime time.Time
+	if record.AlertEvent.Status == alert.StatusResolved {
+		startTime = record.EndTime.Add(-15 * time.Minute)
+		endTime = record.EndTime
+	} else {
+		startTime = record.UpdateTime.Add(-15 * time.Minute)
+		endTime = record.UpdateTime
+	}
 
 	record.WorkflowParams = alert.WorkflowParams{
 		StartTime: startTime.UnixMicro(),

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -46,9 +46,8 @@ func (s *service) AlertEventList(req *request.AlertEventSearchRequest) (*respons
 }
 
 func (s *service) fillWorkflowParams(record *alert.AEventWithWRecord) {
-
-	startTime := record.ReceivedTime.Add(-15 * time.Minute)
-	endTime := record.ReceivedTime
+	startTime := record.UpdateTime.Add(-15 * time.Minute)
+	endTime := record.UpdateTime
 
 	record.WorkflowParams = alert.WorkflowParams{
 		StartTime: startTime.UnixMicro(),

--- a/backend/pkg/services/integration/workflow/alert_check.go
+++ b/backend/pkg/services/integration/workflow/alert_check.go
@@ -305,13 +305,13 @@ type worker struct {
 func (w *worker) run(c *DifyClient, eventInput <-chan alert.AlertEvent, results chan<- model.WorkflowRecord, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for event := range eventInput {
-		endTime := event.ReceivedTime.UnixMicro()
+		endTime := event.UpdateTime.UnixMicro()
 		if w.expiredTS > 0 && endTime < w.expiredTS {
 			w.dropCount++
 			continue
 		}
 
-		startTime := event.ReceivedTime.Add(-15 * time.Minute).UnixMicro()
+		startTime := event.UpdateTime.Add(-15 * time.Minute).UnixMicro()
 		inputs, _ := json.Marshal(map[string]interface{}{
 			"alert":     event.Name,
 			"params":    event.TagsInStr(),
@@ -325,7 +325,7 @@ func (w *worker) run(c *DifyClient, eventInput <-chan alert.AlertEvent, results 
 		}
 
 		tw := time.Duration(w.CacheMinutes) * time.Minute
-		roundedTime := event.ReceivedTime.Truncate(tw).Add(tw)
+		roundedTime := event.UpdateTime.Truncate(tw).Add(tw)
 
 		var record model.WorkflowRecord
 		if resp == nil {


### PR DESCRIPTION
## Summary by Sourcery

Replace uses of 'received_time' with 'update_time' in alert event queries and processing

Bug Fixes:
- Modify time-based calculations to use 'update_time' instead of 'received_time' for more accurate alert event tracking

Enhancements:
- Update time-based sorting and filtering logic to use 'update_time' column
- Adjust workflow parameter calculation to use 'update_time' or 'end_time' based on alert status