### PR TITLE
chore: Remove alert detail menu.

### DIFF
--- a/backend/pkg/repository/database/init_feature.go
+++ b/backend/pkg/repository/database/init_feature.go
@@ -16,7 +16,7 @@ var validFeatures = []Feature{
 	{FeatureName: "应用基础设施大盘"},
 	{FeatureName: "应用指标大盘"},
 	{FeatureName: "中间件大盘"},
-	{FeatureName: "告警管理"}, {FeatureName: "告警规则"}, {FeatureName: "告警通知"}, {FeatureName: "告警事件"}, {FeatureName: "告警事件详情"},
+	{FeatureName: "告警管理"}, {FeatureName: "告警规则"}, {FeatureName: "告警通知"}, {FeatureName: "告警事件"},
 	{FeatureName: "接入中心"}, {FeatureName: "数据接入"}, {FeatureName: "告警接入"},
 	{FeatureName: "配置中心"},
 	{FeatureName: "系统管理"}, {FeatureName: "用户管理"}, {FeatureName: "菜单管理"}, {FeatureName: "系统配置"},

--- a/backend/pkg/repository/database/init_feature_mapping.go
+++ b/backend/pkg/repository/database/init_feature_mapping.go
@@ -128,10 +128,10 @@ func (repo *daoRepo) initFeatureMenuItems() error {
 
 func (repo *daoRepo) initFeatureRouter() error {
 	featureRoutes := map[string][]string{
-		"服务概览":   {"/service/info", "/service/overview"},
-		"数据接入":   {"/integration/data/settings", "/data/ingestion"},
-		"个人中心":   {"/user", "/profile", "/account"},
-		"告警事件详情": {"/alerts/events/detail/:alertID/:eventID"},
+		"服务概览": {"/service/info", "/service/overview"},
+		"数据接入": {"/integration/data/settings", "/data/ingestion"},
+		"个人中心": {"/user", "/profile", "/account"},
+		"告警事件": {"/alerts/events/detail/:alertID/:eventID"},
 	}
 
 	return repo.db.Transaction(func(tx *gorm.DB) error {

--- a/backend/pkg/repository/database/init_menu_item.go
+++ b/backend/pkg/repository/database/init_menu_item.go
@@ -28,7 +28,6 @@ var validMenuItemMappings = []struct {
 	{MenuItem: MenuItem{Key: "alertsRule", Order: 27}, RouterKey: "/alerts/rule"},
 	{MenuItem: MenuItem{Key: "alertsNotify", Order: 29}, RouterKey: "/alerts/notify"},
 	{MenuItem: MenuItem{Key: "alertEvents", Order: 31}, RouterKey: "/alerts/events"},
-	{MenuItem: MenuItem{Key: "alertEventDetail", Order: 32}, RouterKey: "/alerts/events/detail/:alertID/:eventID"},
 	{MenuItem: MenuItem{Key: "integration", Order: 33}},
 	{MenuItem: MenuItem{Key: "dataIntegration", Order: 35}, RouterKey: "/integration/data"},
 	{MenuItem: MenuItem{Key: "alertsIntegration", Order: 37}, RouterKey: "/integration/alerts"},


### PR DESCRIPTION
## Summary by Sourcery

Remove the alert detail submenu and clean up its related database initialization entries

Chores:
- Delete the "alertEventDetail" menu item and its "/alerts/events/detail/:alertID/:eventID" route mapping
- Remove the "告警事件详情" feature from the initial feature list and rename its router key to "告警事件" in the feature-route mapping