### PR TITLE
fix: optimize the Scan/Value methods for JSON fields

### DIFF
--- a/backend/pkg/model/amconfig/scan.go
+++ b/backend/pkg/model/amconfig/scan.go
@@ -29,14 +29,16 @@ func (e *EmailConfigs) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	val, ok := value.(string)
-	if !ok {
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
-	if len(val) == 0 {
-		return nil
-	}
-	return json.Unmarshal([]byte(val), e)
+	return json.Unmarshal(val, e)
 }
 
 func (e WebhookConfigs) Value() (driver.Value, error) {
@@ -54,14 +56,16 @@ func (e *WebhookConfigs) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	val, ok := value.(string)
-	if !ok {
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
-	if len(val) == 0 {
-		return nil
-	}
-	return json.Unmarshal([]byte(val), e)
+	return json.Unmarshal(val, e)
 }
 
 func (e DingTalkConfigs) Value() (driver.Value, error) {
@@ -79,14 +83,19 @@ func (e *DingTalkConfigs) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	val, ok := value.(string)
-	if !ok {
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
 	if len(val) == 0 {
 		return nil
 	}
-	return json.Unmarshal([]byte(val), e)
+	return json.Unmarshal(val, e)
 }
 
 func (e WechatConfigs) Value() (driver.Value, error) {
@@ -104,12 +113,17 @@ func (e *WechatConfigs) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	val, ok := value.(string)
-	if !ok {
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
 	if len(val) == 0 {
 		return nil
 	}
-	return json.Unmarshal([]byte(val), e)
+	return json.Unmarshal(val, e)
 }

--- a/backend/pkg/model/amconfig/scan.go
+++ b/backend/pkg/model/amconfig/scan.go
@@ -36,7 +36,7 @@ func (e *EmailConfigs) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	return json.Unmarshal(val, e)
 }
@@ -63,7 +63,7 @@ func (e *WebhookConfigs) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	return json.Unmarshal(val, e)
 }
@@ -90,7 +90,7 @@ func (e *DingTalkConfigs) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	if len(val) == 0 {
 		return nil
@@ -120,7 +120,7 @@ func (e *WechatConfigs) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	if len(val) == 0 {
 		return nil

--- a/backend/pkg/model/amconfig/slienceconfig/slience.go
+++ b/backend/pkg/model/amconfig/slienceconfig/slience.go
@@ -43,12 +43,14 @@ func (e *TagsStr) Scan(value interface{}) error {
 	if value == nil {
 		return nil
 	}
-	val, ok := value.(string)
-	if !ok {
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
-	if len(val) == 0 {
-		return nil
-	}
-	return json.Unmarshal([]byte(val), e)
+	return json.Unmarshal(val, e)
 }

--- a/backend/pkg/model/amconfig/slienceconfig/slience.go
+++ b/backend/pkg/model/amconfig/slienceconfig/slience.go
@@ -50,7 +50,7 @@ func (e *TagsStr) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	return json.Unmarshal(val, e)
 }

--- a/backend/pkg/model/integration/config2json.go
+++ b/backend/pkg/model/integration/config2json.go
@@ -32,7 +32,7 @@ func (j *JSONField[T]) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	return json.Unmarshal(val, &j.Obj)
 }
@@ -126,7 +126,7 @@ func (c *APOCollector) Scan(value interface{}) error {
 	case []byte:
 		val = s
 	default:
-		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+		return fmt.Errorf("failed to scan JSONField, expected string or []byte, got %T", value)
 	}
 	return json.Unmarshal(val, c)
 }

--- a/backend/pkg/model/integration/config2json.go
+++ b/backend/pkg/model/integration/config2json.go
@@ -15,26 +15,26 @@ type JSONField[T any] struct {
 }
 
 func (j JSONField[T]) Value() (driver.Value, error) {
-	// 将结构体序列化为 JSON 字符串
 	val, err := json.Marshal(j.Obj)
-	if err != nil {
-		return nil, err
-	}
-	return string(val), nil
+	return string(val), err
 }
 
 func (j *JSONField[T]) Scan(value interface{}) error {
-	// 如果值为 nil，则设置为零值
 	if value == nil {
 		j.Obj = *new(T)
 		return nil
 	}
-	// 将字符串反序列化为结构体
-	val, ok := value.(string)
-	if !ok {
+
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
 		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
 	}
-	return json.Unmarshal([]byte(val), &j.Obj)
+	return json.Unmarshal(val, &j.Obj)
 }
 
 func (j *JSONField[T]) MarshalJSON() ([]byte, error) {
@@ -83,44 +83,50 @@ func acceptSecrets(va, vb reflect.Value) {
 	}
 }
 
-// replaceSecrets 遍历结构体字段，将带有 "secret" 标签的字段值替换为 "<secret>"
+// replace field value with "<secret>" if it has "secret" tag
 func replaceSecrets(v interface{}) {
-	val := reflect.ValueOf(v).Elem() // 获取结构体的值
-	typ := reflect.TypeOf(v).Elem()  // 获取结构体的类型
+	val := reflect.ValueOf(v).Elem()
+	typ := reflect.TypeOf(v).Elem()
 
-	// 遍历结构体的每个字段
 	for i := 0; i < val.NumField(); i++ {
-		field := val.Field(i)     // 获取字段值
-		fieldType := typ.Field(i) // 获取字段类型信息
+		field := val.Field(i)
+		fieldType := typ.Field(i)
 
 		switch field.Kind() {
 		case reflect.String:
-			// 判断字段是否标记了 "secret" 标签
 			if fieldType.Tag.Get("secret") == "true" {
 				if len(field.String()) > 0 {
 					field.SetString(secretFieldValue)
 				}
 			}
 		case reflect.Struct:
-			replaceSecrets(field.Addr().Interface()) // 传递指针类型
+			replaceSecrets(field.Addr().Interface())
 		case reflect.Ptr:
 			if !field.IsNil() {
-				replaceSecrets(field.Interface()) // 递归处理指针指向的内容
+				replaceSecrets(field.Interface())
 			}
 		}
-
 	}
 }
 
 func (c APOCollector) Value() (driver.Value, error) {
-	return json.Marshal(c)
+	val, err := json.Marshal(c)
+	return string(val), err
 }
 
-// 实现 Scanner 接口，将 JSON 字符串扫描回 MapStringString
 func (c *APOCollector) Scan(value interface{}) error {
 	if value == nil {
 		*c = APOCollector{}
 		return nil
 	}
-	return json.Unmarshal(value.([]byte), c)
+	var val []byte
+	switch s := value.(type) {
+	case string:
+		val = []byte(s)
+	case []byte:
+		val = s
+	default:
+		return fmt.Errorf("failed to scan JSONField, expected string, got %T", value)
+	}
+	return json.Unmarshal(val, c)
 }

--- a/backend/pkg/model/integration/integration_config.go
+++ b/backend/pkg/model/integration/integration_config.go
@@ -141,8 +141,8 @@ type LogIntegration struct {
 
 	Mode string `json:"mode" gorm:"type:varchar(255);column:mode"`
 
-	Name   string `json:"name" gorm:"type:json;column:name"`
-	DBType string `json:"dbType" gorm:"type:json;column:db_type"`
+	Name   string `json:"name" gorm:"type:varchar(255);column:name"`
+	DBType string `json:"dbType" gorm:"type:varchar(255);column:db_type"`
 
 	LogAPI               *JSONField[LogAPI]               `json:"logAPI,omitempty" gorm:"type:json;column:log_api"`
 	LogSelfCollectConfig *JSONField[LogSelfCollectConfig] `json:"selfCollectConfig" gorm:"type:json;column:self_collect_config"`

--- a/backend/pkg/repository/database/integration/dao_integration_config.go
+++ b/backend/pkg/repository/database/integration/dao_integration_config.go
@@ -128,21 +128,30 @@ func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.Clust
 	}
 
 	var traceIntegration integration.TraceIntegration
-	err = repo.db.Find(&traceIntegration, "cluster_id = ?", clusterID, "is_deleted = ?", false).Error
+	err = repo.db.
+		Where("cluster_id = ?", clusterID).
+		Where("is_deleted = ?", false).
+		First(&traceIntegration).Error
 	if err != nil {
 		return res, err
 	}
 	res.Trace = traceIntegration
 
 	var metricIntegration integration.MetricIntegration
-	err = repo.db.Find(&metricIntegration, "cluster_id = ?", clusterID, "is_deleted = ?", false).Error
+	err = repo.db.
+		Where("cluster_id = ?", clusterID).
+		Where("is_deleted = ?", false).
+		First(&metricIntegration).Error
 	if err != nil {
 		return res, err
 	}
 	res.Metric = metricIntegration
 
 	var logIntegration integration.LogIntegration
-	err = repo.db.Find(&logIntegration, "cluster_id = ?", clusterID, "is_deleted = ?", false).Error
+	err = repo.db.
+		Where("cluster_id = ?", clusterID).
+		Where("is_deleted = ?", false).
+		First(&logIntegration).Error
 	if err != nil {
 		return res, err
 	}


### PR DESCRIPTION
## Summary by Sourcery

Optimize JSON serialization and scanning across multiple model types and streamline database integrations

Enhancements:
- Simplify JSONField and related Value/Scan methods to handle string and []byte inputs uniformly and reduce boilerplate
- Apply the unified JSON scanning logic to APOCollector, EmailConfigs, WebhookConfigs, DingTalkConfigs, WechatConfigs, and TagsStr
- Refine integration DAO methods to use Where().First() for filtered queries instead of Find() with inline filters
- Change LogIntegration name and dbType columns from JSON type to varchar(255)
- Clean up replaceSecrets function by updating comments and removing redundant code