### PR TITLE
refactor: Use polaris to get container id.

### DIFF
--- a/backend/static/predefined-metrics/default/Originx-Polaris-Metrics-Thread.json
+++ b/backend/static/predefined-metrics/default/Originx-Polaris-Metrics-Thread.json
@@ -295,7 +295,7 @@
                     "variables": [
                         "container_id",
                         "node_name",
-                        "pid",  
+                        "pid",
                         "__interval"
                     ]
                 }
@@ -432,7 +432,7 @@
             "regex": "",
             "query": {
                 "qryType": 1,
-                "query": "label_values(kindling_span_trace_duration_nanoseconds_count{pod=~\"$pod\"},container_id)",
+                "query": "label_values(originx_thread_polaris_nanoseconds_count{pod=~\"$pod\"},container_id)",
                 "refId": "PrometheusVariableQueryEditor-VariableQuery"
             }
         },


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Update Originx-Polaris-Metrics-Thread.json to fetch container ID via Polaris configuration instead of legacy method.