### PR TITLE
Refactor/Passing context between controller and repository layers - Part2 Passing context to service Layer

### DIFF
--- a/backend/pkg/api/alertinput/func_checkschemaisused.go
+++ b/backend/pkg/api/alertinput/func_checkschemaisused.go
@@ -33,7 +33,7 @@ func (h *handler) CheckSchemaIsUsed() core.HandlerFunc {
 			return
 		}
 
-		alertSources, err := h.inputService.CheckSchemaIsUsed(req.Schema)
+		alertSources, err := h.inputService.CheckSchemaIsUsed(c, req.Schema)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_cleardefaultalertenrichrule.go
+++ b/backend/pkg/api/alertinput/func_cleardefaultalertenrichrule.go
@@ -33,7 +33,7 @@ func (h *handler) ClearDefaultAlertEnrichRule() core.HandlerFunc {
 			return
 		}
 
-		_, err := h.inputService.ClearDefaultAlertEnrichRule(req.SourceType)
+		_, err := h.inputService.ClearDefaultAlertEnrichRule(c, req.SourceType)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_createalertsource.go
+++ b/backend/pkg/api/alertinput/func_createalertsource.go
@@ -34,7 +34,7 @@ func (h *handler) CreateAlertSource() core.HandlerFunc {
 			return
 		}
 
-		alertSource, err := h.inputService.CreateAlertSource(req)
+		alertSource, err := h.inputService.CreateAlertSource(c, req)
 		if err != nil {
 			var vErr alert.ErrAlertSourceAlreadyExist
 			if errors.As(err, &vErr) {

--- a/backend/pkg/api/alertinput/func_createcluster.go
+++ b/backend/pkg/api/alertinput/func_createcluster.go
@@ -33,7 +33,7 @@ func (h *handler) CreateCluster() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.CreateCluster(req)
+		err := h.inputService.CreateCluster(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_createschema.go
+++ b/backend/pkg/api/alertinput/func_createschema.go
@@ -33,7 +33,7 @@ func (h *handler) CreateSchema() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.CreateSchema(req)
+		err := h.inputService.CreateSchema(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_deletealertsource.go
+++ b/backend/pkg/api/alertinput/func_deletealertsource.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteAlertSource() core.HandlerFunc {
 			return
 		}
 
-		alert, err := h.inputService.DeleteAlertSource(*req)
+		alert, err := h.inputService.DeleteAlertSource(c, *req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_deletecluster.go
+++ b/backend/pkg/api/alertinput/func_deletecluster.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteCluster() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.DeleteCluster(req)
+		err := h.inputService.DeleteCluster(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_deleteschema.go
+++ b/backend/pkg/api/alertinput/func_deleteschema.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteSchema() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.DeleteSchema(req.Schema)
+		err := h.inputService.DeleteSchema(c, req.Schema)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_getalertsource.go
+++ b/backend/pkg/api/alertinput/func_getalertsource.go
@@ -33,7 +33,7 @@ func (h *handler) GetAlertSource() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.inputService.GetAlertSource(req)
+		resp, err := h.inputService.GetAlertSource(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_getalertsourceenrichrule.go
+++ b/backend/pkg/api/alertinput/func_getalertsourceenrichrule.go
@@ -33,7 +33,7 @@ func (h *handler) GetAlertSourceEnrichRule() core.HandlerFunc {
 			return
 		}
 
-		rules, err := h.inputService.GetAlertEnrichRule(req.SourceID)
+		rules, err := h.inputService.GetAlertEnrichRule(c, req.SourceID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_getdefaultalertenrichrule.go
+++ b/backend/pkg/api/alertinput/func_getdefaultalertenrichrule.go
@@ -33,7 +33,7 @@ func (h *handler) GetDefaultAlertEnrichRule() core.HandlerFunc {
 			return
 		}
 
-		sourceType, rules := h.inputService.GetDefaultAlertEnrichRule(req.SourceType)
+		sourceType, rules := h.inputService.GetDefaultAlertEnrichRule(c, req.SourceType)
 		c.Payload(alert.DefaultAlertEnrichRuleResponse{
 			SourceType:        sourceType,
 			EnrichRuleConfigs: rules,

--- a/backend/pkg/api/alertinput/func_getschemacolumns.go
+++ b/backend/pkg/api/alertinput/func_getschemacolumns.go
@@ -33,7 +33,7 @@ func (h *handler) GetSchemaColumns() core.HandlerFunc {
 			return
 		}
 
-		columns, err := h.inputService.ListSchemaColumns(req.Schema)
+		columns, err := h.inputService.ListSchemaColumns(c, req.Schema)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_getschemadata.go
+++ b/backend/pkg/api/alertinput/func_getschemadata.go
@@ -33,7 +33,7 @@ func (h *handler) GetSchemaData() core.HandlerFunc {
 			return
 		}
 
-		columns, rows, err := h.inputService.GetSchemaData(req.Schema)
+		columns, rows, err := h.inputService.GetSchemaData(c, req.Schema)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_jsonhandler.go
+++ b/backend/pkg/api/alertinput/func_jsonhandler.go
@@ -52,7 +52,7 @@ func (h *handler) JsonHandler() core.HandlerFunc {
 			)
 			return
 		}
-		err = h.inputService.ProcessAlertEvents(sourceFrom, data)
+		err = h.inputService.ProcessAlertEvents(c, sourceFrom, data)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_listalertsource.go
+++ b/backend/pkg/api/alertinput/func_listalertsource.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/alertinput/source/list [get]
 func (h *handler) ListAlertSource() core.HandlerFunc {
 	return func(c core.Context) {
-		alertSources, err := h.inputService.ListAlertSource()
+		alertSources, err := h.inputService.ListAlertSource(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_listcluster.go
+++ b/backend/pkg/api/alertinput/func_listcluster.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/alertinput/cluster/list [get]
 func (h *handler) ListCluster() core.HandlerFunc {
 	return func(c core.Context) {
-		clusters, err := h.inputService.ListCluster()
+		clusters, err := h.inputService.ListCluster(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_listschema.go
+++ b/backend/pkg/api/alertinput/func_listschema.go
@@ -23,7 +23,7 @@ import (
 func (h *handler) ListSchema() core.HandlerFunc {
 	return func(c core.Context) {
 
-		schemas, err := h.inputService.ListSchema()
+		schemas, err := h.inputService.ListSchema(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_listschemawithcolumns.go
+++ b/backend/pkg/api/alertinput/func_listschemawithcolumns.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/alertinput/schema/listwithcolumns [get]
 func (h *handler) ListSchemaWithColumns() core.HandlerFunc {
 	return func(c core.Context) {
-		schemas, err := h.inputService.ListSchema()
+		schemas, err := h.inputService.ListSchema(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
@@ -36,7 +36,7 @@ func (h *handler) ListSchemaWithColumns() core.HandlerFunc {
 			Schemas: make(map[string][]string, len(schemas)),
 		}
 		for _, schema := range schemas {
-			columns, err := h.inputService.ListSchemaColumns(schema)
+			columns, err := h.inputService.ListSchemaColumns(c, schema)
 			if err != nil {
 				c.AbortWithError(
 					http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_setdefaultalertenrichrule.go
+++ b/backend/pkg/api/alertinput/func_setdefaultalertenrichrule.go
@@ -33,7 +33,7 @@ func (h *handler) SetDefaultAlertEnrichRule() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.SetDefaultAlertEnrichRule(req.SourceType, req.EnrichRuleConfigs)
+		err := h.inputService.SetDefaultAlertEnrichRule(c, req.SourceType, req.EnrichRuleConfigs)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_sourcehandler.go
+++ b/backend/pkg/api/alertinput/func_sourcehandler.go
@@ -43,7 +43,7 @@ func (h *handler) SourceHandler() core.HandlerFunc {
 			)
 			return
 		}
-		err = h.inputService.ProcessAlertEvents(sourceFrom, data)
+		err = h.inputService.ProcessAlertEvents(c, sourceFrom, data)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alertinput/func_updatealertsource.go
+++ b/backend/pkg/api/alertinput/func_updatealertsource.go
@@ -34,7 +34,7 @@ func (h *handler) UpdateAlertSource() core.HandlerFunc {
 			return
 		}
 
-		source, err := h.inputService.UpdateAlertSource(req)
+		source, err := h.inputService.UpdateAlertSource(c, req)
 		if err != nil {
 			var vErr alert.ErrAlertSourceAlreadyExist
 			if errors.As(err, &vErr) {

--- a/backend/pkg/api/alertinput/func_updatealertsourceenrichrule.go
+++ b/backend/pkg/api/alertinput/func_updatealertsourceenrichrule.go
@@ -34,7 +34,7 @@ func (h *handler) UpdateAlertSourceEnrichRule() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.UpdateAlertEnrichRule(req)
+		err := h.inputService.UpdateAlertEnrichRule(c, req)
 		if err != nil {
 			var vErr alert.ErrAlertSourceNotExist
 

--- a/backend/pkg/api/alertinput/func_updatecluster.go
+++ b/backend/pkg/api/alertinput/func_updatecluster.go
@@ -33,7 +33,7 @@ func (h *handler) UpdateCluster() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.UpdateCluster(req)
+		err := h.inputService.UpdateCluster(c, req)
 		if err != nil {
 
 		}

--- a/backend/pkg/api/alertinput/func_updateschemadata.go
+++ b/backend/pkg/api/alertinput/func_updateschemadata.go
@@ -33,7 +33,7 @@ func (h *handler) UpdateSchemaData() core.HandlerFunc {
 			return
 		}
 
-		err := h.inputService.UpdateSchemaData(req)
+		err := h.inputService.UpdateSchemaData(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_addalertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_addalertmanagerconfigreceiver.go
@@ -34,7 +34,7 @@ func (h *handler) AddAlertManagerConfigReceiver() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.AddAMConfigReceiver(req)
+		err := h.alertService.AddAMConfigReceiver(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_addalertrule.go
+++ b/backend/pkg/api/alerts/func_addalertrule.go
@@ -35,7 +35,7 @@ func (h *handler) AddAlertRule() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.AddAlertRule(req)
+		err := h.alertService.AddAlertRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_alerteventclassify.go
+++ b/backend/pkg/api/alerts/func_alerteventclassify.go
@@ -33,7 +33,7 @@ func (h *handler) AlertEventClassify() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.alertService.AlertEventClassify(req)
+		resp, err := h.alertService.AlertEventClassify(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_alerteventdetail.go
+++ b/backend/pkg/api/alerts/func_alerteventdetail.go
@@ -33,7 +33,7 @@ func (h *handler) AlertEventDetail() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.alertService.AlertDetail(req)
+		resp, err := h.alertService.AlertDetail(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_alerteventlist.go
+++ b/backend/pkg/api/alerts/func_alerteventlist.go
@@ -33,7 +33,7 @@ func (h *handler) AlertEventList() core.HandlerFunc {
 			return
 		}
 
-		list, err := h.alertService.AlertEventList(req)
+		list, err := h.alertService.AlertEventList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_checkalertrule.go
+++ b/backend/pkg/api/alerts/func_checkalertrule.go
@@ -37,7 +37,7 @@ func (h *handler) CheckAlertRule() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.alertService.CheckAlertRule(req)
+		resp, err := h.alertService.CheckAlertRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_deletealertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_deletealertmanagerconfigreceiver.go
@@ -34,7 +34,7 @@ func (h *handler) DeleteAlertManagerConfigReceiver() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.DeleteAMConfigReceiver(req)
+		err := h.alertService.DeleteAMConfigReceiver(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_deletealertrule.go
+++ b/backend/pkg/api/alerts/func_deletealertrule.go
@@ -34,7 +34,7 @@ func (h *handler) DeleteAlertRule() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.DeleteAlertRule(req)
+		err := h.alertService.DeleteAlertRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_forwardtodingtalk.go
+++ b/backend/pkg/api/alerts/func_forwardtodingtalk.go
@@ -36,7 +36,7 @@ func (h *handler) ForwardToDingTalk() core.HandlerFunc {
 			return
 		}
 
-		if err := h.alertService.ForwardToDingTalk(req, uuid); err != nil {
+		if err := h.alertService.ForwardToDingTalk(c, req, uuid); err != nil {
 			// TODO Error code
 			c.AbortWithError(http.StatusBadRequest, "", nil)
 		}

--- a/backend/pkg/api/alerts/func_getalertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_getalertmanagerconfigreceiver.go
@@ -34,7 +34,7 @@ func (h *handler) GetAlertManagerConfigReceiver() core.HandlerFunc {
 			return
 		}
 
-		resp := h.alertService.GetAMConfigReceivers(req)
+		resp := h.alertService.GetAMConfigReceivers(c, req)
 		c.Payload(resp)
 	}
 }

--- a/backend/pkg/api/alerts/func_getalertrulefile.go
+++ b/backend/pkg/api/alerts/func_getalertrulefile.go
@@ -35,7 +35,7 @@ func (h *handler) GetAlertRuleFile() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.alertService.GetAlertRuleFile(req)
+		resp, err := h.alertService.GetAlertRuleFile(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_getalertrules.go
+++ b/backend/pkg/api/alerts/func_getalertrules.go
@@ -37,7 +37,7 @@ func (h *handler) GetAlertRules() core.HandlerFunc {
 			req.AlertRuleFilter.Groups = append(req.AlertRuleFilter.Groups, req.AlertRuleFilter.Group)
 		}
 
-		resp := h.alertService.GetAlertRules(req)
+		resp := h.alertService.GetAlertRules(c, req)
 		c.Payload(resp)
 	}
 }

--- a/backend/pkg/api/alerts/func_getalertslientconfig.go
+++ b/backend/pkg/api/alerts/func_getalertslientconfig.go
@@ -33,7 +33,7 @@ func (h *handler) GetAlertSlienceConfig() core.HandlerFunc {
 			)
 			return
 		}
-		config, err := h.alertService.GetSlienceConfigByAlertID(req.AlertID)
+		config, err := h.alertService.GetSlienceConfigByAlertID(c, req.AlertID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_inputalertmanager.go
+++ b/backend/pkg/api/alerts/func_inputalertmanager.go
@@ -36,7 +36,7 @@ func (h *handler) InputAlertManager() core.HandlerFunc {
 
 		// using APO-VM-ALERT as default source
 		sourceFrom := alert.SourceFrom{SourceID: alert.ApoVMAlertSourceID}
-		err = h.inputService.ProcessAlertEvents(sourceFrom, data)
+		err = h.inputService.ProcessAlertEvents(c, sourceFrom, data)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_listalertslientconfig.go
+++ b/backend/pkg/api/alerts/func_listalertslientconfig.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/alerts/slient/list [get]
 func (h *handler) ListAlertSlienceConfig() core.HandlerFunc {
 	return func(c core.Context) {
-		sliences, err := h.alertService.ListSlienceConfig()
+		sliences, err := h.alertService.ListSlienceConfig(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_markalertresolvedmanually.go
+++ b/backend/pkg/api/alerts/func_markalertresolvedmanually.go
@@ -33,7 +33,7 @@ func (h *handler) MarkAlertResolvedManually() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.ManualResolveLatestAlertEventByAlertID(req.AlertID)
+		err := h.alertService.ManualResolveLatestAlertEventByAlertID(c, req.AlertID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_removealertslientconfig.go
+++ b/backend/pkg/api/alerts/func_removealertslientconfig.go
@@ -32,7 +32,7 @@ func (h *handler) RemoveAlertSlienceConfig() core.HandlerFunc {
 			)
 			return
 		}
-		err := h.alertService.RemoveSlienceConfigByAlertID(req.AlertID)
+		err := h.alertService.RemoveSlienceConfigByAlertID(c, req.AlertID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_setalertslientconfig.go
+++ b/backend/pkg/api/alerts/func_setalertslientconfig.go
@@ -33,7 +33,7 @@ func (h *handler) SetAlertSlienceConfig() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.SetSlienceConfigByAlertID(req)
+		err := h.alertService.SetSlienceConfigByAlertID(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_updatealertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_updatealertmanagerconfigreceiver.go
@@ -34,7 +34,7 @@ func (h *handler) UpdateAlertManagerConfigReceiver() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.UpdateAMConfigReceiver(req)
+		err := h.alertService.UpdateAMConfigReceiver(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_updatealertrule.go
+++ b/backend/pkg/api/alerts/func_updatealertrule.go
@@ -34,7 +34,7 @@ func (h *handler) UpdateAlertRule() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.UpdateAlertRule(req)
+		err := h.alertService.UpdateAlertRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/alerts/func_updatealertrulefile.go
+++ b/backend/pkg/api/alerts/func_updatealertrulefile.go
@@ -34,7 +34,7 @@ func (h *handler) UpdateAlertRuleFile() core.HandlerFunc {
 			return
 		}
 
-		err := h.alertService.UpdateAlertRuleFile(req)
+		err := h.alertService.UpdateAlertRuleFile(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/config/func_getttl.go
+++ b/backend/pkg/api/config/func_getttl.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/config/getTTL [get]
 func (h *handler) GetTTL() core.HandlerFunc {
 	return func(c core.Context) {
-		resp, err := h.configService.GetTTL()
+		resp, err := h.configService.GetTTL(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/config/func_setsingletablettl.go
+++ b/backend/pkg/api/config/func_setsingletablettl.go
@@ -33,7 +33,7 @@ func (h *handler) SetSingleTableTTL() core.HandlerFunc {
 			)
 			return
 		}
-		if err := h.configService.SetSingleTableTTL(req); err != nil {
+		if err := h.configService.SetSingleTableTTL(c, req); err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
 				code.SetSingleTableTTLError,

--- a/backend/pkg/api/config/func_setttl.go
+++ b/backend/pkg/api/config/func_setttl.go
@@ -33,7 +33,7 @@ func (h *handler) SetTTL() core.HandlerFunc {
 			)
 			return
 		}
-		if err := h.configService.SetTTL(req); err != nil {
+		if err := h.configService.SetTTL(c, req); err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
 				code.SetTTLError,

--- a/backend/pkg/api/integration/func_createcluster.go
+++ b/backend/pkg/api/integration/func_createcluster.go
@@ -33,7 +33,7 @@ func (h *handler) CreateCluster() core.HandlerFunc {
 			return
 		}
 
-		cluster, err := h.integrationService.CreateCluster(req)
+		cluster, err := h.integrationService.CreateCluster(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_deletecluster.go
+++ b/backend/pkg/api/integration/func_deletecluster.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteCluster() core.HandlerFunc {
 			return
 		}
 
-		err := h.integrationService.DeleteCluster(req)
+		err := h.integrationService.DeleteCluster(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_getcluster.go
+++ b/backend/pkg/api/integration/func_getcluster.go
@@ -33,7 +33,7 @@ func (h *handler) GetCluster() core.HandlerFunc {
 			return
 		}
 
-		clusterIntegration, err := h.integrationService.GetClusterIntegration(req.ID)
+		clusterIntegration, err := h.integrationService.GetClusterIntegration(c, req.ID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_getintegrationinstallconfigfile.go
+++ b/backend/pkg/api/integration/func_getintegrationinstallconfigfile.go
@@ -34,7 +34,7 @@ func (h *handler) GetIntegrationInstallConfigFile() core.HandlerFunc {
 			return
 		}
 
-		configFile, err := h.integrationService.GetIntegrationInstallConfigFile(req)
+		configFile, err := h.integrationService.GetIntegrationInstallConfigFile(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_getintegrationinstalldoc.go
+++ b/backend/pkg/api/integration/func_getintegrationinstalldoc.go
@@ -33,7 +33,7 @@ func (h *handler) GetIntegrationInstallDoc() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.integrationService.GetIntegrationInstallDoc(req)
+		resp, err := h.integrationService.GetIntegrationInstallDoc(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_getstaticintegration.go
+++ b/backend/pkg/api/integration/func_getstaticintegration.go
@@ -17,7 +17,7 @@ import (
 // @Router /api/integration/configuration [get]
 func (h *handler) GetStaticIntegration() core.HandlerFunc {
 	return func(c core.Context) {
-		storeIntegration := h.integrationService.GetStaticIntegration()
+		storeIntegration := h.integrationService.GetStaticIntegration(c)
 		c.Payload(storeIntegration)
 	}
 }

--- a/backend/pkg/api/integration/func_listcluster.go
+++ b/backend/pkg/api/integration/func_listcluster.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/integration/cluster/list [get]
 func (h *handler) ListCluster() core.HandlerFunc {
 	return func(c core.Context) {
-		clusters, err := h.integrationService.ListCluster()
+		clusters, err := h.integrationService.ListCluster(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/integration/func_triggeradapterupdate.go
+++ b/backend/pkg/api/integration/func_triggeradapterupdate.go
@@ -31,7 +31,7 @@ func (h *handler) TriggerAdapterUpdate() core.HandlerFunc {
 			)
 			return
 		}
-		h.integrationService.TriggerAdapterUpdate(req)
+		h.integrationService.TriggerAdapterUpdate(c, req)
 		c.Payload("ok")
 	}
 }

--- a/backend/pkg/api/integration/func_updatecluster.go
+++ b/backend/pkg/api/integration/func_updatecluster.go
@@ -33,7 +33,7 @@ func (h *handler) UpdateCluster() core.HandlerFunc {
 			return
 		}
 
-		err := h.integrationService.UpdateClusterIntegration(req)
+		err := h.integrationService.UpdateClusterIntegration(c, req)
 		if err != nil {
 
 		}

--- a/backend/pkg/api/metric/func_listmetrics.go
+++ b/backend/pkg/api/metric/func_listmetrics.go
@@ -18,7 +18,7 @@ import (
 // @Router /api/metric/list [get]
 func (h *handler) ListMetrics() core.HandlerFunc {
 	return func(c core.Context) {
-		resp := h.metricService.ListPreDefinedMetrics()
+		resp := h.metricService.ListPreDefinedMetrics(c)
 		c.Payload(resp)
 	}
 }

--- a/backend/pkg/api/metric/func_querymetrics.go
+++ b/backend/pkg/api/metric/func_querymetrics.go
@@ -32,7 +32,7 @@ func (h *handler) QueryMetrics() core.HandlerFunc {
 			return
 		}
 
-		resp := h.metricService.QueryMetrics(req)
+		resp := h.metricService.QueryMetrics(c, req)
 		c.Payload(resp)
 	}
 }

--- a/backend/pkg/api/network/func_getpodmap.go
+++ b/backend/pkg/api/network/func_getpodmap.go
@@ -42,7 +42,7 @@ func (h *handler) GetPodMap() core.HandlerFunc {
 			c.AbortWithPermissionError(err, code.AuthError, new(response.PodMapResponse))
 			return
 		}
-		resp, err := h.networkService.GetPodMap(req)
+		resp, err := h.networkService.GetPodMap(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/network/func_getspansegments.go
+++ b/backend/pkg/api/network/func_getspansegments.go
@@ -32,7 +32,7 @@ func (h *handler) GetSpanSegmentsMetrics() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.networkService.GetSpanSegmentsMetrics(req)
+		resp, err := h.networkService.GetSpanSegmentsMetrics(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_checkrouterpermission.go
+++ b/backend/pkg/api/permission/func_checkrouterpermission.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -35,7 +34,7 @@ func (h *handler) CheckRouterPermission() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		resp, err := h.permissionService.CheckRouterPermission(userID, req.Router)
+		resp, err := h.permissionService.CheckRouterPermission(c, userID, req.Router)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_configuremenu.go
+++ b/backend/pkg/api/permission/func_configuremenu.go
@@ -35,7 +35,7 @@ func (h *handler) ConfigureMenu() core.HandlerFunc {
 			return
 		}
 
-		err := h.permissionService.ConfigureMenu(req)
+		err := h.permissionService.ConfigureMenu(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_getfeature.go
+++ b/backend/pkg/api/permission/func_getfeature.go
@@ -40,7 +40,7 @@ func (h *handler) GetFeature() core.HandlerFunc {
 			req.Language = model.TRANSLATION_ZH
 		}
 
-		resp, err := h.permissionService.GetFeature(req)
+		resp, err := h.permissionService.GetFeature(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_getsubjectfeature.go
+++ b/backend/pkg/api/permission/func_getsubjectfeature.go
@@ -36,7 +36,7 @@ func (h *handler) GetSubjectFeature() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.permissionService.GetSubjectFeature(req)
+		resp, err := h.permissionService.GetSubjectFeature(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_getuserconfig.go
+++ b/backend/pkg/api/permission/func_getuserconfig.go
@@ -41,7 +41,7 @@ func (h *handler) GetUserConfig() core.HandlerFunc {
 			req.Language = model.TRANSLATION_ZH
 		}
 
-		resp, err := h.permissionService.GetUserConfig(req)
+		resp, err := h.permissionService.GetUserConfig(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/permission/func_permissionoperation.go
+++ b/backend/pkg/api/permission/func_permissionoperation.go
@@ -37,7 +37,7 @@ func (h *handler) PermissionOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.permissionService.PermissionOperation(req)
+		err := h.permissionService.PermissionOperation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_createrole.go
+++ b/backend/pkg/api/role/func_createrole.go
@@ -38,7 +38,7 @@ func (h *handler) CreateRole() core.HandlerFunc {
 			return
 		}
 
-		err := h.roleService.CreateRole(req)
+		err := h.roleService.CreateRole(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_deleterole.go
+++ b/backend/pkg/api/role/func_deleterole.go
@@ -35,7 +35,7 @@ func (h *handler) DeleteRole() core.HandlerFunc {
 			return
 		}
 
-		err := h.roleService.DeleteRole(req)
+		err := h.roleService.DeleteRole(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_getrole.go
+++ b/backend/pkg/api/role/func_getrole.go
@@ -23,7 +23,7 @@ import (
 func (h *handler) GetRole() core.HandlerFunc {
 	return func(c core.Context) {
 
-		resp, err := h.roleService.GetRoles()
+		resp, err := h.roleService.GetRoles(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_getuserrole.go
+++ b/backend/pkg/api/role/func_getuserrole.go
@@ -34,7 +34,7 @@ func (h *handler) GetUserRole() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.roleService.GetUserRole(req)
+		resp, err := h.roleService.GetUserRole(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_roleoperation.go
+++ b/backend/pkg/api/role/func_roleoperation.go
@@ -36,7 +36,7 @@ func (h *handler) RoleOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.roleService.RoleOperation(req)
+		err := h.roleService.RoleOperation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/role/func_updaterole.go
+++ b/backend/pkg/api/role/func_updaterole.go
@@ -38,7 +38,7 @@ func (h *handler) UpdateRole() core.HandlerFunc {
 			return
 		}
 
-		err := h.roleService.UpdateRole(req)
+		err := h.roleService.UpdateRole(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_createteam.go
+++ b/backend/pkg/api/team/func_createteam.go
@@ -35,7 +35,7 @@ func (h *handler) CreateTeam() core.HandlerFunc {
 			return
 		}
 
-		err := h.teamService.CreateTeam(req)
+		err := h.teamService.CreateTeam(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_deleteteam.go
+++ b/backend/pkg/api/team/func_deleteteam.go
@@ -35,7 +35,7 @@ func (h *handler) DeleteTeam() core.HandlerFunc {
 			return
 		}
 
-		err := h.teamService.DeleteTeam(req)
+		err := h.teamService.DeleteTeam(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_getteam.go
+++ b/backend/pkg/api/team/func_getteam.go
@@ -46,7 +46,7 @@ func (h *handler) GetTeam() core.HandlerFunc {
 			}
 		}
 
-		resp, err := h.teamService.GetTeamList(req)
+		resp, err := h.teamService.GetTeamList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_getteamuser.go
+++ b/backend/pkg/api/team/func_getteamuser.go
@@ -35,7 +35,7 @@ func (h *handler) GetTeamUser() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.teamService.GetTeamUser(req)
+		resp, err := h.teamService.GetTeamUser(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_teamoperation.go
+++ b/backend/pkg/api/team/func_teamoperation.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -36,7 +35,7 @@ func (h *handler) TeamOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.teamService.TeamOperation(req)
+		err := h.teamService.TeamOperation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_teamuseroperation.go
+++ b/backend/pkg/api/team/func_teamuseroperation.go
@@ -36,7 +36,7 @@ func (h *handler) TeamUserOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.teamService.TeamUserOperation(req)
+		err := h.teamService.TeamUserOperation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/team/func_updateteam.go
+++ b/backend/pkg/api/team/func_updateteam.go
@@ -35,7 +35,7 @@ func (h *handler) UpdateTeam() core.HandlerFunc {
 			return
 		}
 
-		err := h.teamService.UpdateTeam(req)
+		err := h.teamService.UpdateTeam(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_getflamegraphdata.go
+++ b/backend/pkg/api/trace/func_getflamegraphdata.go
@@ -40,7 +40,7 @@ func (h *handler) GetFlameGraphData() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.traceService.GetFlameGraphData(req)
+		resp, err := h.traceService.GetFlameGraphData(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_getonoffcpu.go
+++ b/backend/pkg/api/trace/func_getonoffcpu.go
@@ -37,7 +37,7 @@ func (h *handler) GetOnOffCPU() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.traceService.GetOnOffCPU(req)
+		resp, err := h.traceService.GetOnOffCPU(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_getprocessflamegraph.go
+++ b/backend/pkg/api/trace/func_getprocessflamegraph.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -39,7 +38,7 @@ func (h *handler) GetProcessFlameGraph() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.traceService.GetProcessFlameGraphData(req)
+		resp, err := h.traceService.GetProcessFlameGraphData(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_getsingletraceinfo.go
+++ b/backend/pkg/api/trace/func_getsingletraceinfo.go
@@ -35,7 +35,7 @@ func (h *handler) GetSingleTraceInfo() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.traceService.GetSingleTraceID(req)
+		resp, err := h.traceService.GetSingleTraceID(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_gettracefilters.go
+++ b/backend/pkg/api/trace/func_gettracefilters.go
@@ -40,7 +40,7 @@ func (h *handler) GetTraceFilters() core.HandlerFunc {
 
 		startTime := time.UnixMicro(req.StartTime)
 		endTime := time.UnixMicro(req.EndTime)
-		resp, err := h.traceService.GetTraceFilters(startTime, endTime, req.NeedUpdate)
+		resp, err := h.traceService.GetTraceFilters(c, startTime, endTime, req.NeedUpdate)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_gettracefiltervalue.go
+++ b/backend/pkg/api/trace/func_gettracefiltervalue.go
@@ -38,7 +38,7 @@ func (h *handler) GetTraceFilterValue() core.HandlerFunc {
 
 		startTime := time.UnixMicro(req.StartTime)
 		endTime := time.UnixMicro(req.EndTime)
-		resp, err := h.traceService.GetTraceFilterValues(startTime, endTime, req.SearchText, req.Filter)
+		resp, err := h.traceService.GetTraceFilterValues(c, startTime, endTime, req.SearchText, req.Filter)
 
 		if err != nil {
 			c.AbortWithError(

--- a/backend/pkg/api/trace/func_gettracepagelist.go
+++ b/backend/pkg/api/trace/func_gettracepagelist.go
@@ -57,7 +57,7 @@ func (h *handler) GetTracePageList() core.HandlerFunc {
 			req.PageSize = 10
 		}
 
-		resp, err := h.traceService.GetTracePageList(req)
+		resp, err := h.traceService.GetTracePageList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_createuser.go
+++ b/backend/pkg/api/user/func_createuser.go
@@ -58,7 +58,7 @@ func (h *handler) CreateUser() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.CreateUser(req)
+		err := h.userService.CreateUser(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_getuserinfo.go
+++ b/backend/pkg/api/user/func_getuserinfo.go
@@ -37,7 +37,7 @@ func (h *handler) GetUserInfo() core.HandlerFunc {
 		if req.UserID == 0 {
 			req.UserID = c.UserID()
 		}
-		resp, err := h.userService.GetUserInfo(req.UserID)
+		resp, err := h.userService.GetUserInfo(c, req.UserID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_getuserlist.go
+++ b/backend/pkg/api/user/func_getuserlist.go
@@ -47,7 +47,7 @@ func (h *handler) GetUserList() core.HandlerFunc {
 			}
 		}
 
-		resp, err := h.userService.GetUserList(req)
+		resp, err := h.userService.GetUserList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_getuserteam.go
+++ b/backend/pkg/api/user/func_getuserteam.go
@@ -35,7 +35,7 @@ func (h *handler) GetUserTeam() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.userService.GetUserTeam(req)
+		resp, err := h.userService.GetUserTeam(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_login.go
+++ b/backend/pkg/api/user/func_login.go
@@ -35,7 +35,7 @@ func (h *handler) Login() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.userService.Login(req)
+		resp, err := h.userService.Login(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_logout.go
+++ b/backend/pkg/api/user/func_logout.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -35,7 +34,7 @@ func (h *handler) Logout() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.Logout(req)
+		err := h.userService.Logout(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_refreshtoken.go
+++ b/backend/pkg/api/user/func_refreshtoken.go
@@ -24,7 +24,7 @@ func (h *handler) RefreshToken() core.HandlerFunc {
 	return func(c core.Context) {
 		token := c.GetHeader("Authorization")
 
-		resp, err := h.userService.RefreshToken(token)
+		resp, err := h.userService.RefreshToken(c, token)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_removeuser.go
+++ b/backend/pkg/api/user/func_removeuser.go
@@ -35,7 +35,7 @@ func (h *handler) RemoveUser() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.RemoveUser(req.UserID)
+		err := h.userService.RemoveUser(c, req.UserID)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_resetpassword.go
+++ b/backend/pkg/api/user/func_resetpassword.go
@@ -46,7 +46,7 @@ func (h *handler) ResetPassword() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.RestPassword(req)
+		err := h.userService.RestPassword(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_updateselfinfo.go
+++ b/backend/pkg/api/user/func_updateselfinfo.go
@@ -38,7 +38,7 @@ func (h *handler) UpdateSelfInfo() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.UpdateSelfInfo(req)
+		err := h.userService.UpdateSelfInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_updateuseremail.go
+++ b/backend/pkg/api/user/func_updateuseremail.go
@@ -36,7 +36,7 @@ func (h *handler) UpdateUserEmail() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.UpdateUserEmail(req)
+		err := h.userService.UpdateUserEmail(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_updateuserinfo.go
+++ b/backend/pkg/api/user/func_updateuserinfo.go
@@ -39,7 +39,7 @@ func (h *handler) UpdateUserInfo() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.UpdateUserInfo(req)
+		err := h.userService.UpdateUserInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_updateuserpassword.go
+++ b/backend/pkg/api/user/func_updateuserpassword.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -47,7 +46,7 @@ func (h *handler) UpdateUserPassword() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.UpdateUserPassword(req)
+		err := h.userService.UpdateUserPassword(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/user/func_updateuserphone.go
+++ b/backend/pkg/api/user/func_updateuserphone.go
@@ -46,7 +46,7 @@ func (h *handler) UpdateUserPhone() core.HandlerFunc {
 			return
 		}
 
-		err := h.userService.UpdateUserPhone(req)
+		err := h.userService.UpdateUserPhone(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/middleware/auth_middleware.go
+++ b/backend/pkg/middleware/auth_middleware.go
@@ -23,7 +23,7 @@ func (m *middleware) AuthMiddleware() core.HandlerFunc {
 				return
 			}
 
-			anonymousUser, err := m.userService.GetUserInfo(0)
+			anonymousUser, err := m.userService.GetUserInfo(c, 0)
 			if err != nil {
 				c.AbortWithError(http.StatusBadRequest, code.AuthError, nil)
 				return
@@ -34,7 +34,7 @@ func (m *middleware) AuthMiddleware() core.HandlerFunc {
 			return
 		}
 
-		if ok, _ := m.userService.IsInBlacklist(token); ok {
+		if ok, _ := m.userService.IsInBlacklist(c, token); ok {
 			c.AbortWithError(http.StatusBadRequest, code.InValidToken, nil)
 			return
 		}

--- a/backend/pkg/middleware/permission_middleware.go
+++ b/backend/pkg/middleware/permission_middleware.go
@@ -19,7 +19,7 @@ func (m *middleware) PermissionMiddleware() core.HandlerFunc {
 		}
 		method, path := c.GetMethodPath()
 
-		can, err := m.permissionService.CheckApiPermission(userID, method, path)
+		can, err := m.permissionService.CheckApiPermission(c, userID, method, path)
 		if err != nil {
 			c.AbortWithError(http.StatusForbidden, code.AuthError, err)
 			return

--- a/backend/pkg/receiver/handle_record.go
+++ b/backend/pkg/receiver/handle_record.go
@@ -44,17 +44,19 @@ func (r *InnerReceivers) HandleAlertCheckRecord(ctx context.Context, record *mod
 	var success []string
 	var errs error
 
-	ctx = notify.WithGroupKey(ctx, "alertName")
-	ctx = notify.WithGroupLabels(ctx, pmodel.LabelSet{"alertName": pmodel.LabelValue(alert.Name)})
+	gCtx := context.Background()
+
+	gCtx = notify.WithGroupKey(gCtx, "alertName")
+	gCtx = notify.WithGroupLabels(gCtx, pmodel.LabelSet{"alertName": pmodel.LabelValue(alert.Name)})
 	for name, integrations := range r.receivers {
-		ctx = notify.WithReceiverName(ctx, name)
+		gCtx = notify.WithReceiverName(gCtx, name)
 
 		for _, integration := range integrations {
 			alerts := alert.ToAMAlert(r.externalURL.String(), false)
 			var err error
 			var shouldRetry bool
 			for retry := 3; retry > 0; retry-- {
-				shouldRetry, err = integration.Notify(ctx, alerts)
+				shouldRetry, err = integration.Notify(gCtx, alerts)
 				if !shouldRetry {
 					break
 				}

--- a/backend/pkg/receiver/receiver.go
+++ b/backend/pkg/receiver/receiver.go
@@ -16,6 +16,7 @@ import (
 	"go.uber.org/zap"
 	"gopkg.in/yaml.v3"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
@@ -36,15 +37,15 @@ import (
 type Receivers interface {
 	HandleAlertCheckRecord(ctx context.Context, record *model.WorkflowRecord) error
 
-	GetAMConfigReceiver(filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int)
-	AddAMConfigReceiver(receiver amconfig.Receiver) error
-	UpdateAMConfigReceiver(receiver amconfig.Receiver, oldName string) error
-	DeleteAMConfigReceiver(name string) error
+	GetAMConfigReceiver(ctx core.Context, filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int)
+	AddAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver) error
+	UpdateAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver, oldName string) error
+	DeleteAMConfigReceiver(ctx core.Context, name string) error
 
-	ListSlienceConfig() ([]slienceconfig.AlertSlienceConfig, error)
-	GetSlienceConfigByAlertID(alertID string) (*slienceconfig.AlertSlienceConfig, error)
-	SetSlienceConfigByAlertID(alertID string, forDuration string) error
-	RemoveSlienceConfigByAlertID(alertID string) error
+	ListSlienceConfig(ctx core.Context) ([]slienceconfig.AlertSlienceConfig, error)
+	GetSlienceConfigByAlertID(ctx core.Context, alertID string) (*slienceconfig.AlertSlienceConfig, error)
+	SetSlienceConfigByAlertID(ctx core.Context, alertID string, forDuration string) error
+	RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error
 }
 
 type InnerReceivers struct {

--- a/backend/pkg/receiver/receiver_config.go
+++ b/backend/pkg/receiver/receiver_config.go
@@ -4,6 +4,7 @@
 package receiver
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/prometheus/alertmanager/template"
@@ -24,7 +25,7 @@ func (r *InnerReceivers) updateReceiversInMemory(receivers []amconfig.Receiver) 
 	return nil
 }
 
-func (r *InnerReceivers) GetAMConfigReceiver(filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int) {
+func (r *InnerReceivers) GetAMConfigReceiver(ctx core.Context, filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int) {
 	receivers, count, err := r.database.GetAMConfigReceiver(filter, pageParam)
 	if err != nil {
 		r.logger.Error("failed to list amconfigReceiver", "err", err)
@@ -33,7 +34,7 @@ func (r *InnerReceivers) GetAMConfigReceiver(filter *request.AMConfigReceiverFil
 	return receivers, count
 }
 
-func (r *InnerReceivers) AddAMConfigReceiver(receiver amconfig.Receiver) error {
+func (r *InnerReceivers) AddAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver) error {
 	err := r.database.AddAMConfigReceiver(receiver)
 	if err != nil {
 		return err
@@ -46,7 +47,7 @@ func (r *InnerReceivers) AddAMConfigReceiver(receiver amconfig.Receiver) error {
 	return r.updateReceiversInMemory(receivers)
 }
 
-func (r *InnerReceivers) UpdateAMConfigReceiver(receiver amconfig.Receiver, oldName string) error {
+func (r *InnerReceivers) UpdateAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver, oldName string) error {
 	err := r.database.UpdateAMConfigReceiver(receiver, oldName)
 	if err != nil {
 		return err
@@ -58,7 +59,7 @@ func (r *InnerReceivers) UpdateAMConfigReceiver(receiver amconfig.Receiver, oldN
 	return r.updateReceiversInMemory(receivers)
 }
 
-func (r *InnerReceivers) DeleteAMConfigReceiver(name string) error {
+func (r *InnerReceivers) DeleteAMConfigReceiver(ctx core.Context, name string) error {
 	err := r.database.DeleteAMConfigReceiver(name)
 	if err != nil {
 		return err

--- a/backend/pkg/receiver/slient_config.go
+++ b/backend/pkg/receiver/slient_config.go
@@ -7,21 +7,22 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 )
 
-func (r *InnerReceivers) GetSlienceConfigByAlertID(alertID string) (*sc.AlertSlienceConfig, error) {
+func (r *InnerReceivers) GetSlienceConfigByAlertID(ctx core.Context, alertID string) (*sc.AlertSlienceConfig, error) {
 	if cfgPtr, find := r.slientCFGMap.Load(alertID); find {
 		return cfgPtr.(*sc.AlertSlienceConfig), nil
 	}
 	return nil, nil
 }
 
-func (r *InnerReceivers) ListSlienceConfig() ([]sc.AlertSlienceConfig, error) {
+func (r *InnerReceivers) ListSlienceConfig(ctx core.Context) ([]sc.AlertSlienceConfig, error) {
 	return r.database.GetAlertSlience()
 }
 
-func (r *InnerReceivers) SetSlienceConfigByAlertID(alertID string, forDuration string) error {
+func (r *InnerReceivers) SetSlienceConfigByAlertID(ctx core.Context, alertID string, forDuration string) error {
 	duration, err := time.ParseDuration(forDuration)
 	if err != nil {
 		return fmt.Errorf("duration is not valid: %w", err)
@@ -53,7 +54,7 @@ func (r *InnerReceivers) SetSlienceConfigByAlertID(alertID string, forDuration s
 	}
 }
 
-func (r *InnerReceivers) RemoveSlienceConfigByAlertID(alertID string) error {
+func (r *InnerReceivers) RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error {
 	if cfgPtr, loaded := r.slientCFGMap.LoadAndDelete(alertID); loaded {
 		cfg := cfgPtr.(*sc.AlertSlienceConfig)
 		return r.database.DeleteAlertSlience(cfg.ID)

--- a/backend/pkg/services/alerts/inputs_alertmanager.go
+++ b/backend/pkg/services/alerts/inputs_alertmanager.go
@@ -9,6 +9,7 @@ import (
 	"log"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
@@ -73,7 +74,7 @@ func convertStatus(status string) model.Status {
 	}
 }
 
-func (s *service) InputAlertManager(req *request.InputAlertManagerRequest) error {
+func (s *service) InputAlertManager(ctx core.Context, req *request.InputAlertManagerRequest) error {
 	events := transferAlertManager(req)
 	err := s.chRepo.InsertBatchAlertEvents(context.Background(), events)
 	if err != nil {

--- a/backend/pkg/services/alerts/service.go
+++ b/backend/pkg/services/alerts/service.go
@@ -5,7 +5,7 @@ package alerts
 
 import (
 	"github.com/CloudDetail/apo/backend/config"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -21,46 +21,46 @@ var _ Service = (*service)(nil)
 
 type Service interface {
 	// ========================告警检索========================
-	AlertEventList(req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error)
-	AlertDetail(req *request.GetAlertDetailRequest) (*response.GetAlertDetailResponse, error)
+	AlertEventList(ctx core.Context, req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error)
+	AlertDetail(ctx core.Context, req *request.GetAlertDetailRequest) (*response.GetAlertDetailResponse, error)
 
-	AlertEventClassify(req *request.AlertEventClassifyRequest) (*response.AlertEventClassifyResponse, error)
+	AlertEventClassify(ctx core.Context, req *request.AlertEventClassifyRequest) (*response.AlertEventClassifyResponse, error)
 
 	// ========================告警配置========================
 
 	// InputAlertManager receive AlertManager alarm events
 	// Deprecated: use alertinput.ProcessAlertEvents instead
-	InputAlertManager(req *request.InputAlertManagerRequest) error
-	ForwardToDingTalk(req *request.ForwardToDingTalkRequest, uuid string) error
+	InputAlertManager(ctx core.Context, req *request.InputAlertManagerRequest) error
+	ForwardToDingTalk(ctx core.Context, req *request.ForwardToDingTalkRequest, uuid string) error
 
 	// GetAlertRuleFile get basic alarm rules
-	GetAlertRuleFile(req *request.GetAlertRuleConfigRequest) (*response.GetAlertRuleFileResponse, error)
+	GetAlertRuleFile(ctx core.Context, req *request.GetAlertRuleConfigRequest) (*response.GetAlertRuleFileResponse, error)
 	// UpdateAlertRuleFile update basic alarm rules
-	UpdateAlertRuleFile(req *request.UpdateAlertRuleConfigRequest) error
+	UpdateAlertRuleFile(ctx core.Context, req *request.UpdateAlertRuleConfigRequest) error
 
 	// AlertRule Options
 	GetGroupList(ctx core.Context) response.GetGroupListResponse
 	GetMetricPQL(ctx core.Context) (*response.GetMetricPQLResponse, error)
 
 	// AlertRule CRUD
-	GetAlertRules(req *request.GetAlertRuleRequest) response.GetAlertRulesResponse
-	UpdateAlertRule(req *request.UpdateAlertRuleRequest) error
-	DeleteAlertRule(req *request.DeleteAlertRuleRequest) error
-	AddAlertRule(req *request.AddAlertRuleRequest) error
-	CheckAlertRule(req *request.CheckAlertRuleRequest) (response.CheckAlertRuleResponse, error)
+	GetAlertRules(ctx core.Context, req *request.GetAlertRuleRequest) response.GetAlertRulesResponse
+	UpdateAlertRule(ctx core.Context, req *request.UpdateAlertRuleRequest) error
+	DeleteAlertRule(ctx core.Context, req *request.DeleteAlertRuleRequest) error
+	AddAlertRule(ctx core.Context, req *request.AddAlertRuleRequest) error
+	CheckAlertRule(ctx core.Context, req *request.CheckAlertRuleRequest) (response.CheckAlertRuleResponse, error)
 
 	// AlertManager Receiver CRUD
-	GetAMConfigReceivers(req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse
-	AddAMConfigReceiver(req *request.AddAlertManagerConfigReceiver) error
-	UpdateAMConfigReceiver(req *request.UpdateAlertManagerConfigReceiver) error
-	DeleteAMConfigReceiver(req *request.DeleteAlertManagerConfigReceiverRequest) error
+	GetAMConfigReceivers(ctx core.Context, req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse
+	AddAMConfigReceiver(ctx core.Context, req *request.AddAlertManagerConfigReceiver) error
+	UpdateAMConfigReceiver(ctx core.Context, req *request.UpdateAlertManagerConfigReceiver) error
+	DeleteAMConfigReceiver(ctx core.Context, req *request.DeleteAlertManagerConfigReceiverRequest) error
 
-	GetSlienceConfigByAlertID(alertID string) (*slienceconfig.AlertSlienceConfig, error)
-	ListSlienceConfig() ([]slienceconfig.AlertSlienceConfig, error)
-	SetSlienceConfigByAlertID(req *request.SetAlertSlienceConfigRequest) error
-	RemoveSlienceConfigByAlertID(alertID string) error
+	GetSlienceConfigByAlertID(ctx core.Context, alertID string) (*slienceconfig.AlertSlienceConfig, error)
+	ListSlienceConfig(ctx core.Context) ([]slienceconfig.AlertSlienceConfig, error)
+	SetSlienceConfigByAlertID(ctx core.Context, req *request.SetAlertSlienceConfigRequest) error
+	RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error
 
-	ManualResolveLatestAlertEventByAlertID(alertID string) error
+	ManualResolveLatestAlertEventByAlertID(ctx core.Context, alertID string) error
 }
 
 type service struct {

--- a/backend/pkg/services/alerts/service_add_alert_rule.go
+++ b/backend/pkg/services/alerts/service_add_alert_rule.go
@@ -5,11 +5,11 @@ package alerts
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) AddAlertRule(req *request.AddAlertRuleRequest) error {
+func (s *service) AddAlertRule(ctx core.Context, req *request.AddAlertRuleRequest) error {
 	if !checkOrFillGroupsLabel(req.AlertRule.Group, req.AlertRule.Labels) {
 		return core.Error(code.AlertGroupAndLabelMismatchError, "gourp and group label mismatch")
 	}

--- a/backend/pkg/services/alerts/service_alert_event_classify.go
+++ b/backend/pkg/services/alerts/service_alert_event_classify.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/dify"
@@ -17,7 +18,7 @@ import (
 
 var cache = expirable.NewLRU[string, string](10, nil, time.Hour)
 
-func (s *service) AlertEventClassify(req *request.AlertEventClassifyRequest) (*response.AlertEventClassifyResponse, error) {
+func (s *service) AlertEventClassify(ctx core.Context, req *request.AlertEventClassifyRequest) (*response.AlertEventClassifyResponse, error) {
 	inputs, _ := json.Marshal(map[string]interface{}{
 		"alertGroup": req.AlertGroup,
 		"alertName":  req.AlertName,

--- a/backend/pkg/services/alerts/service_alert_event_detail.go
+++ b/backend/pkg/services/alerts/service_alert_event_detail.go
@@ -7,12 +7,13 @@ import (
 	"encoding/json"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) AlertDetail(req *request.GetAlertDetailRequest) (*response.GetAlertDetailResponse, error) {
+func (s *service) AlertDetail(ctx core.Context, req *request.GetAlertDetailRequest) (*response.GetAlertDetailResponse, error) {
 	eventDetail, err := s.chRepo.GetAlertDetail(req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err
@@ -120,7 +121,7 @@ func (s *service) fillSimilarEventWorkflowParams(records []alert.AEventWithWReco
 	}
 }
 
-func (s *service) ManualResolveLatestAlertEventByAlertID(alertID string) error {
+func (s *service) ManualResolveLatestAlertEventByAlertID(ctx core.Context, alertID string) error {
 	// TODO valid alertID
 	return s.chRepo.ManualResolveLatestAlertEventByAlertID(alertID)
 }

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -15,7 +16,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
-func (s *service) AlertEventList(req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
+func (s *service) AlertEventList(ctx core.Context, req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
 	events, count, err := s.chRepo.GetAlertEventWithWorkflowRecord(req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/alerts/service_alert_slient_config.go
+++ b/backend/pkg/services/alerts/service_alert_slient_config.go
@@ -6,34 +6,35 @@ package alerts
 import (
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) GetSlienceConfigByAlertID(alertID string) (*slienceconfig.AlertSlienceConfig, error) {
+func (s *service) GetSlienceConfigByAlertID(ctx core.Context, alertID string) (*slienceconfig.AlertSlienceConfig, error) {
 	if !s.enableInnerReceiver {
 		return nil, errors.New("inner alert is not open")
 	}
-	return s.receivers.GetSlienceConfigByAlertID(alertID)
+	return s.receivers.GetSlienceConfigByAlertID(ctx, alertID)
 }
 
-func (s *service) ListSlienceConfig() ([]slienceconfig.AlertSlienceConfig, error) {
+func (s *service) ListSlienceConfig(ctx core.Context) ([]slienceconfig.AlertSlienceConfig, error) {
 	if !s.enableInnerReceiver {
 		return nil, errors.New("inner alert is not open")
 	}
-	return s.receivers.ListSlienceConfig()
+	return s.receivers.ListSlienceConfig(ctx)
 }
 
-func (s *service) SetSlienceConfigByAlertID(req *request.SetAlertSlienceConfigRequest) error {
+func (s *service) SetSlienceConfigByAlertID(ctx core.Context, req *request.SetAlertSlienceConfigRequest) error {
 	if !s.enableInnerReceiver {
 		return errors.New("inner alert is not open")
 	}
-	return s.receivers.SetSlienceConfigByAlertID(req.AlertID, req.ForDuration)
+	return s.receivers.SetSlienceConfigByAlertID(ctx, req.AlertID, req.ForDuration)
 }
 
-func (s *service) RemoveSlienceConfigByAlertID(alertID string) error {
+func (s *service) RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error {
 	if !s.enableInnerReceiver {
 		return errors.New("inner alert is not open")
 	}
-	return s.receivers.RemoveSlienceConfigByAlertID(alertID)
+	return s.receivers.RemoveSlienceConfigByAlertID(ctx, alertID)
 }

--- a/backend/pkg/services/alerts/service_amconfig_receiver.go
+++ b/backend/pkg/services/alerts/service_amconfig_receiver.go
@@ -8,7 +8,7 @@ import (
 	"net/url"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
@@ -16,12 +16,12 @@ import (
 	uuid2 "github.com/google/uuid"
 )
 
-func (s *service) GetAMConfigReceivers(req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse {
+func (s *service) GetAMConfigReceivers(ctx core.Context, req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse {
 	if !s.enableInnerReceiver {
-		s.GetAMReceiversFromExternalAM(req)
+		s.GetAMReceiversFromExternalAM(ctx, req)
 	}
 
-	receivers, total := s.receivers.GetAMConfigReceiver(req.AMConfigReceiverFilter, req.PageParam)
+	receivers, total := s.receivers.GetAMConfigReceiver(ctx, req.AMConfigReceiverFilter, req.PageParam)
 	if receivers == nil {
 		receivers = make([]amconfig.Receiver, 0)
 	}
@@ -35,7 +35,7 @@ func (s *service) GetAMConfigReceivers(req *request.GetAlertManagerConfigRecever
 	}
 }
 
-func (s *service) GetAMReceiversFromExternalAM(req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse {
+func (s *service) GetAMReceiversFromExternalAM(ctx core.Context, req *request.GetAlertManagerConfigReceverRequest) response.GetAlertManagerConfigReceiverResponse {
 	if req.PageParam == nil {
 		req.PageParam = &request.PageParam{
 			CurrentPage: 1,
@@ -79,15 +79,15 @@ func (s *service) GetAMReceiversFromExternalAM(req *request.GetAlertManagerConfi
 	return resp
 }
 
-func (s *service) AddAMConfigReceiver(req *request.AddAlertManagerConfigReceiver) error {
+func (s *service) AddAMConfigReceiver(ctx core.Context, req *request.AddAlertManagerConfigReceiver) error {
 	if !s.enableInnerReceiver {
-		return s.AddAMReceiversForExternalAM(req)
+		return s.AddAMReceiversForExternalAM(ctx, req)
 	}
 
-	return s.receivers.AddAMConfigReceiver(req.AMConfigReceiver)
+	return s.receivers.AddAMConfigReceiver(ctx, req.AMConfigReceiver)
 }
 
-func (s *service) AddAMReceiversForExternalAM(req *request.AddAlertManagerConfigReceiver) error {
+func (s *service) AddAMReceiversForExternalAM(ctx core.Context, req *request.AddAlertManagerConfigReceiver) error {
 	if req.Type != "dingtalk" {
 		return s.k8sApi.AddAMConfigReceiver(req.AMConfigFile, req.AMConfigReceiver)
 	}
@@ -113,15 +113,15 @@ func (s *service) AddAMReceiversForExternalAM(req *request.AddAlertManagerConfig
 	return nil
 }
 
-func (s *service) UpdateAMConfigReceiver(req *request.UpdateAlertManagerConfigReceiver) error {
+func (s *service) UpdateAMConfigReceiver(ctx core.Context, req *request.UpdateAlertManagerConfigReceiver) error {
 	if !s.enableInnerReceiver {
-		return s.UpdateAMReceiverForExternalAM(req)
+		return s.UpdateAMReceiverForExternalAM(ctx, req)
 	}
 
-	return s.receivers.UpdateAMConfigReceiver(req.AMConfigReceiver, req.OldName)
+	return s.receivers.UpdateAMConfigReceiver(ctx, req.AMConfigReceiver, req.OldName)
 }
 
-func (s *service) UpdateAMReceiverForExternalAM(req *request.UpdateAlertManagerConfigReceiver) error {
+func (s *service) UpdateAMReceiverForExternalAM(ctx core.Context, req *request.UpdateAlertManagerConfigReceiver) error {
 	if req.Type != "dingtalk" {
 		return s.k8sApi.UpdateAMConfigReceiver(req.AMConfigFile, req.AMConfigReceiver, req.OldName)
 	}
@@ -149,15 +149,15 @@ func (s *service) UpdateAMReceiverForExternalAM(req *request.UpdateAlertManagerC
 	return nil
 }
 
-func (s *service) DeleteAMConfigReceiver(req *request.DeleteAlertManagerConfigReceiverRequest) error {
+func (s *service) DeleteAMConfigReceiver(ctx core.Context, req *request.DeleteAlertManagerConfigReceiverRequest) error {
 	if !s.enableInnerReceiver {
-		return s.DeleteAMReceiverForExternalAM(req)
+		return s.DeleteAMReceiverForExternalAM(ctx, req)
 	}
 
-	return s.receivers.DeleteAMConfigReceiver(req.Name)
+	return s.receivers.DeleteAMConfigReceiver(ctx, req.Name)
 }
 
-func (s *service) DeleteAMReceiverForExternalAM(req *request.DeleteAlertManagerConfigReceiverRequest) error {
+func (s *service) DeleteAMReceiverForExternalAM(ctx core.Context, req *request.DeleteAlertManagerConfigReceiverRequest) error {
 	err := s.k8sApi.DeleteAMConfigReceiver(req.AMConfigFile, req.Name)
 	if err != nil {
 		return err

--- a/backend/pkg/services/alerts/service_check_alert_rule.go
+++ b/backend/pkg/services/alerts/service_check_alert_rule.go
@@ -4,11 +4,12 @@
 package alerts
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) CheckAlertRule(req *request.CheckAlertRuleRequest) (response.CheckAlertRuleResponse, error) {
+func (s *service) CheckAlertRule(ctx core.Context, req *request.CheckAlertRuleRequest) (response.CheckAlertRuleResponse, error) {
 	var resp response.CheckAlertRuleResponse
 	find, err := s.k8sApi.CheckAlertRule(req.AlertRuleFile, req.Group, req.Alert)
 	if err != nil {

--- a/backend/pkg/services/alerts/service_forward_to_dingtalk.go
+++ b/backend/pkg/services/alerts/service_forward_to_dingtalk.go
@@ -4,12 +4,14 @@
 package alerts
 
 import (
+	"log"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/services/alerts/notification"
-	"log"
 )
 
-func (s *service) ForwardToDingTalk(req *request.ForwardToDingTalkRequest, uuid string) error {
+func (s *service) ForwardToDingTalk(ctx core.Context, req *request.ForwardToDingTalkRequest, uuid string) error {
 	config, err := s.dbRepo.GetDingTalkReceiver(uuid)
 	if err != nil {
 		log.Println("get dingtalk receiver err:", err)

--- a/backend/pkg/services/alerts/service_get_alert_rule.go
+++ b/backend/pkg/services/alerts/service_get_alert_rule.go
@@ -4,12 +4,13 @@
 package alerts
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetAlertRules(req *request.GetAlertRuleRequest) response.GetAlertRulesResponse {
+func (s *service) GetAlertRules(ctx core.Context, req *request.GetAlertRuleRequest) response.GetAlertRulesResponse {
 	if req.PageParam == nil {
 		req.PageParam = &request.PageParam{
 			CurrentPage: 1,
@@ -29,7 +30,7 @@ func (s *service) GetAlertRules(req *request.GetAlertRuleRequest) response.GetAl
 }
 
 // GetAlertRuleFile get alarm rules
-func (s *service) GetAlertRuleFile(req *request.GetAlertRuleConfigRequest) (*response.GetAlertRuleFileResponse, error) {
+func (s *service) GetAlertRuleFile(ctx core.Context, req *request.GetAlertRuleConfigRequest) (*response.GetAlertRuleFileResponse, error) {
 	rules, err := s.k8sApi.GetAlertRuleConfigFile(req.AlertRuleFile)
 	if err != nil {
 		return &response.GetAlertRuleFileResponse{AlertRules: map[string]string{}}, err

--- a/backend/pkg/services/alerts/service_update_alert_rule.go
+++ b/backend/pkg/services/alerts/service_update_alert_rule.go
@@ -5,12 +5,12 @@ package alerts
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/kubernetes"
 )
 
-func (s *service) UpdateAlertRule(req *request.UpdateAlertRuleRequest) error {
+func (s *service) UpdateAlertRule(ctx core.Context, req *request.UpdateAlertRuleRequest) error {
 	if !checkOrFillGroupsLabel(req.AlertRule.Group, req.AlertRule.Labels) {
 		return core.Error(
 			code.AlertGroupAndLabelMismatchError,
@@ -21,11 +21,11 @@ func (s *service) UpdateAlertRule(req *request.UpdateAlertRuleRequest) error {
 	return s.k8sApi.UpdateAlertRule(req.AlertRuleFile, req.AlertRule, req.OldGroup, req.OldAlert)
 }
 
-func (s *service) DeleteAlertRule(req *request.DeleteAlertRuleRequest) error {
+func (s *service) DeleteAlertRule(ctx core.Context, req *request.DeleteAlertRuleRequest) error {
 	return s.k8sApi.DeleteAlertRule(req.AlertRuleFile, req.Group, req.Alert)
 }
 
-func (s *service) UpdateAlertRuleFile(req *request.UpdateAlertRuleConfigRequest) error {
+func (s *service) UpdateAlertRuleFile(ctx core.Context, req *request.UpdateAlertRuleConfigRequest) error {
 	return s.k8sApi.UpdateAlertRuleConfigFile(req.AlertRuleFile, []byte(req.Content))
 }
 

--- a/backend/pkg/services/config/service.go
+++ b/backend/pkg/services/config/service.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -12,9 +13,9 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	SetTTL(req *request.SetTTLRequest) error
-	SetSingleTableTTL(req *request.SetSingleTTLRequest) error
-	GetTTL() (*response.GetTTLResponse, error)
+	SetTTL(ctx core.Context, req *request.SetTTLRequest) error
+	SetSingleTableTTL(ctx core.Context, req *request.SetSingleTTLRequest) error
+	GetTTL(ctx core.Context) (*response.GetTTLResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/config/service_getttl.go
+++ b/backend/pkg/services/config/service_getttl.go
@@ -6,11 +6,12 @@ package config
 import (
 	"log"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTTL() (*response.GetTTLResponse, error) {
+func (s *service) GetTTL(ctx core.Context) (*response.GetTTLResponse, error) {
 	tables, err := s.chRepo.GetTables(model.GetAllTables())
 	if err != nil {
 		log.Println("[GetTTL] Error getting tables: ", err)

--- a/backend/pkg/services/config/service_setttl.go
+++ b/backend/pkg/services/config/service_setttl.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
@@ -47,7 +48,7 @@ func prepareTTLInfo(tables []model.TablesQuery) []model.ModifyTableTTLMap {
 	return mapResult
 }
 
-func (s *service) SetTableTTL(tableNames []model.Table, day int) error {
+func (s *service) SetTableTTL(ctx core.Context, tableNames []model.Table, day int) error {
 	tables, err := s.chRepo.GetTables(tableNames)
 	if err != nil {
 		log.Println("[SetSingleTableTTL] Error getting tables: ", err)
@@ -76,7 +77,7 @@ func convertModifyTableTTLMap(tables []model.TablesQuery, day int) ([]model.Modi
 	return mapResult, nil
 }
 
-func (s *service) SetTTL(req *request.SetTTLRequest) error {
+func (s *service) SetTTL(ctx core.Context, req *request.SetTTLRequest) error {
 	if req.Day <= 0 {
 		return errors.New("[SetTTL] Error : day should > 0  ")
 	}
@@ -85,11 +86,11 @@ func (s *service) SetTTL(req *request.SetTTLRequest) error {
 	if len(tables) == 0 {
 		return fmt.Errorf("type: %s does not have tables", req.DataType)
 	}
-	err := s.SetTableTTL(tables, req.Day)
+	err := s.SetTableTTL(ctx, tables, req.Day)
 	return err
 }
 
-func (s *service) SetSingleTableTTL(req *request.SetSingleTTLRequest) error {
+func (s *service) SetSingleTableTTL(ctx core.Context, req *request.SetSingleTTLRequest) error {
 	if req.Day <= 0 {
 		return errors.New("[SetSingleTableTTL] Error: day should > 0  ")
 	}
@@ -100,6 +101,6 @@ func (s *service) SetSingleTableTTL(req *request.SetSingleTTLRequest) error {
 	tables := []model.Table{
 		{Name: req.Name},
 	}
-	err := s.SetTableTTL(tables, req.Day)
+	err := s.SetTableTTL(ctx, tables, req.Day)
 	return err
 }

--- a/backend/pkg/services/integration/alert/dispatch.go
+++ b/backend/pkg/services/integration/alert/dispatch.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"sync"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/decoder"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/enrich"
@@ -77,7 +78,7 @@ func (d *Dispatcher) AddAlertSource(
 	}
 }
 
-func (d *Dispatcher) DeleteAlertSource(
+func (d *Dispatcher) DeleteAlertSource(ctx core.Context,
 	source *alert.AlertSource,
 ) {
 	enricher, loaded := d.EnricherMap.LoadAndDelete(source.SourceID)

--- a/backend/pkg/services/integration/alert/service.go
+++ b/backend/pkg/services/integration/alert/service.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	input "github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -20,35 +20,35 @@ import (
 var _ Service = &service{}
 
 type Service interface {
-	CreateAlertSource(source *alert.AlertSource) (*alert.AlertSource, error)
-	GetAlertSource(source *alert.SourceFrom) (*alert.AlertSource, error)
-	UpdateAlertSource(source *alert.AlertSource) (*alert.AlertSource, error)
-	DeleteAlertSource(source alert.SourceFrom) (*alert.AlertSource, error)
-	ListAlertSource() ([]alert.AlertSource, error)
+	CreateAlertSource(ctx core.Context, source *alert.AlertSource) (*alert.AlertSource, error)
+	GetAlertSource(ctx core.Context, source *alert.SourceFrom) (*alert.AlertSource, error)
+	UpdateAlertSource(ctx core.Context, source *alert.AlertSource) (*alert.AlertSource, error)
+	DeleteAlertSource(ctx core.Context, source alert.SourceFrom) (*alert.AlertSource, error)
+	ListAlertSource(ctx core.Context) ([]alert.AlertSource, error)
 
-	UpdateAlertEnrichRule(*alert.AlertEnrichRuleConfigRequest) error
-	GetAlertEnrichRule(sourceID string) ([]alert.AlertEnrichRuleVO, error)
+	UpdateAlertEnrichRule(ctx core.Context, req *alert.AlertEnrichRuleConfigRequest) error
+	GetAlertEnrichRule(ctx core.Context, sourceID string) ([]alert.AlertEnrichRuleVO, error)
 
-	ProcessAlertEvents(source alert.SourceFrom, data []byte) error
+	ProcessAlertEvents(ctx core.Context, source alert.SourceFrom, data []byte) error
 
 	GetAlertEnrichRuleTags(ctx core.Context) ([]alert.TargetTag, error)
 
-	CreateSchema(req *alert.CreateSchemaRequest) error
-	DeleteSchema(schema string) error
-	ListSchema() ([]string, error)
-	ListSchemaColumns(schema string) ([]string, error)
-	UpdateSchemaData(req *alert.UpdateSchemaDataRequest) error
-	CheckSchemaIsUsed(schema string) ([]string, error)
-	GetSchemaData(schema string) ([]string, map[int64][]string, error)
+	CreateSchema(ctx core.Context, req *alert.CreateSchemaRequest) error
+	DeleteSchema(ctx core.Context, schema string) error
+	ListSchema(ctx core.Context) ([]string, error)
+	ListSchemaColumns(ctx core.Context, schema string) ([]string, error)
+	UpdateSchemaData(ctx core.Context, req *alert.UpdateSchemaDataRequest) error
+	CheckSchemaIsUsed(ctx core.Context, schema string) ([]string, error)
+	GetSchemaData(ctx core.Context, schema string) ([]string, map[int64][]string, error)
 
-	CreateCluster(cluster *input.Cluster) error
-	ListCluster() ([]input.Cluster, error)
-	UpdateCluster(cluster *input.Cluster) error
-	DeleteCluster(cluster *input.Cluster) error
+	CreateCluster(ctx core.Context, cluster *input.Cluster) error
+	ListCluster(ctx core.Context) ([]input.Cluster, error)
+	UpdateCluster(ctx core.Context, cluster *input.Cluster) error
+	DeleteCluster(ctx core.Context, cluster *input.Cluster) error
 
-	GetDefaultAlertEnrichRule(sourceType string) (string, []alert.AlertEnrichRuleVO)
-	ClearDefaultAlertEnrichRule(sourceType string) (bool, error)
-	SetDefaultAlertEnrichRule(sourceType string, tagEnrichRules []alert.AlertEnrichRuleVO) error
+	GetDefaultAlertEnrichRule(ctx core.Context, sourceType string) (string, []alert.AlertEnrichRuleVO)
+	ClearDefaultAlertEnrichRule(ctx core.Context, sourceType string) (bool, error)
+	SetDefaultAlertEnrichRule(ctx core.Context, sourceType string, tagEnrichRules []alert.AlertEnrichRuleVO) error
 }
 
 type service struct {

--- a/backend/pkg/services/integration/alert/service_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_alert_source.go
@@ -7,13 +7,14 @@ import (
 	"errors"
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/enrich"
 	"go.uber.org/multierr"
 	"gorm.io/gorm"
 )
 
-func (s *service) GetAlertSource(source *alert.SourceFrom) (*alert.AlertSource, error) {
+func (s *service) GetAlertSource(ctx core.Context, source *alert.SourceFrom) (*alert.AlertSource, error) {
 	// TODO support search by sourceName
 	alertSource, err := s.dbRepo.GetAlertSource(source.SourceID)
 
@@ -23,7 +24,7 @@ func (s *service) GetAlertSource(source *alert.SourceFrom) (*alert.AlertSource, 
 	return alertSource, err
 }
 
-func (s *service) UpdateAlertSource(source *alert.AlertSource) (*alert.AlertSource, error) {
+func (s *service) UpdateAlertSource(ctx core.Context, source *alert.AlertSource) (*alert.AlertSource, error) {
 	if len(source.SourceID) <= 0 {
 		return nil, fmt.Errorf("must use sourceId to specify the data source")
 	}
@@ -42,17 +43,17 @@ func (s *service) UpdateAlertSource(source *alert.AlertSource) (*alert.AlertSour
 	return source, err
 }
 
-func (s *service) ListAlertSource() ([]alert.AlertSource, error) {
+func (s *service) ListAlertSource(ctx core.Context) ([]alert.AlertSource, error) {
 	return s.dbRepo.ListAlertSource()
 }
 
-func (s *service) DeleteAlertSource(source alert.SourceFrom) (*alert.AlertSource, error) {
+func (s *service) DeleteAlertSource(ctx core.Context, source alert.SourceFrom) (*alert.AlertSource, error) {
 	deletedSource, err := s.dbRepo.DeleteAlertSource(source)
 	if err != nil {
 		return nil, err
 	}
 
-	s.dispatcher.DeleteAlertSource(deletedSource)
+	s.dispatcher.DeleteAlertSource(ctx, deletedSource)
 
 	var storeError error
 	err = s.dbRepo.DeleteAlertEnrichRuleBySourceId(source.SourceID)

--- a/backend/pkg/services/integration/alert/service_clusters.go
+++ b/backend/pkg/services/integration/alert/service_clusters.go
@@ -4,23 +4,24 @@
 package alert
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	input "github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/google/uuid"
 )
 
-func (s *service) CreateCluster(cluster *input.Cluster) error {
+func (s *service) CreateCluster(ctx core.Context, cluster *input.Cluster) error {
 	cluster.ID = uuid.NewString()
 	return s.dbRepo.CreateCluster(cluster)
 }
 
-func (s *service) ListCluster() ([]input.Cluster, error) {
+func (s *service) ListCluster(ctx core.Context) ([]input.Cluster, error) {
 	return s.dbRepo.ListCluster()
 }
 
-func (s *service) UpdateCluster(cluster *input.Cluster) error {
+func (s *service) UpdateCluster(ctx core.Context, cluster *input.Cluster) error {
 	return s.dbRepo.UpdateCluster(cluster)
 }
 
-func (s *service) DeleteCluster(cluster *input.Cluster) error {
+func (s *service) DeleteCluster(ctx core.Context, cluster *input.Cluster) error {
 	return s.dbRepo.DeleteCluster(cluster)
 }

--- a/backend/pkg/services/integration/alert/service_create_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_create_alert_source.go
@@ -6,6 +6,7 @@ package alert
 import (
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	alertin "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/enrich"
@@ -13,7 +14,7 @@ import (
 	"go.uber.org/multierr"
 )
 
-func (s *service) CreateAlertSource(source *alertin.AlertSource) (*alertin.AlertSource, error) {
+func (s *service) CreateAlertSource(ctx core.Context, source *alertin.AlertSource) (*alertin.AlertSource, error) {
 	_, find := s.dispatcher.SourceName2EnricherMap.Load(source.SourceName)
 	if find {
 		return nil, alertin.ErrAlertSourceAlreadyExist{
@@ -59,7 +60,7 @@ func (s *service) initDefaultAlertSource(source *alertin.SourceFrom) (*enrich.Al
 		return enricher.(*enrich.AlertEnricher), alertin.ErrAlertSourceAlreadyExist{}
 	}
 
-	_, defaultRules := s.GetDefaultAlertEnrichRule(source.SourceType)
+	_, defaultRules := s.GetDefaultAlertEnrichRule(nil, source.SourceType)
 	storedRules, newR, newC, newS := s.prepareAlertEnrichRule(source, defaultRules)
 
 	enricher, err := s.createAlertSource(source, storedRules)

--- a/backend/pkg/services/integration/alert/service_default_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_default_alert_source.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/google/uuid"
 	"go.uber.org/multierr"
@@ -18,7 +19,7 @@ var (
 	commonSourceType  = "json"
 )
 
-func (s *service) ClearDefaultAlertEnrichRule(sourceType string) (bool, error) {
+func (s *service) ClearDefaultAlertEnrichRule(ctx core.Context, sourceType string) (bool, error) {
 	_, find := s.defaultEnrichRules.LoadAndDelete(sourceType)
 
 	sourceUUID := uuid.NewMD5(uuidZero, []byte(sourceType)).String()
@@ -33,7 +34,7 @@ func (s *service) ClearDefaultAlertEnrichRule(sourceType string) (bool, error) {
 	return find, storeError
 }
 
-func (s *service) GetDefaultAlertEnrichRule(sourceType string) (string, []alert.AlertEnrichRuleVO) {
+func (s *service) GetDefaultAlertEnrichRule(ctx core.Context, sourceType string) (string, []alert.AlertEnrichRuleVO) {
 	rules, find := s.defaultEnrichRules.Load(sourceType)
 	if find {
 		return sourceType, rules.([]alert.AlertEnrichRuleVO)
@@ -47,8 +48,8 @@ func (s *service) GetDefaultAlertEnrichRule(sourceType string) (string, []alert.
 	return "", []alert.AlertEnrichRuleVO{}
 }
 
-func (s *service) SetDefaultAlertEnrichRule(sourceType string, tagEnrichRules []alert.AlertEnrichRuleVO) error {
-	existed, err := s.ClearDefaultAlertEnrichRule(sourceType)
+func (s *service) SetDefaultAlertEnrichRule(ctx core.Context, sourceType string, tagEnrichRules []alert.AlertEnrichRuleVO) error {
+	existed, err := s.ClearDefaultAlertEnrichRule(ctx, sourceType)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/services/integration/alert/service_get_alert_enrich_rule.go
+++ b/backend/pkg/services/integration/alert/service_get_alert_enrich_rule.go
@@ -3,9 +3,12 @@
 
 package alert
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
 
-func (s *service) GetAlertEnrichRule(
+func (s *service) GetAlertEnrichRule(ctx core.Context,
 	sourceID string,
 ) ([]alert.AlertEnrichRuleVO, error) {
 	enrichRules, err := s.dbRepo.GetAlertEnrichRule(sourceID)

--- a/backend/pkg/services/integration/alert/service_process_alert_events.go
+++ b/backend/pkg/services/integration/alert/service_process_alert_events.go
@@ -9,10 +9,11 @@ import (
 	"fmt"
 	"log"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
-func (s *service) ProcessAlertEvents(source alert.SourceFrom, data []byte) error {
+func (s *service) ProcessAlertEvents(ctx core.Context, source alert.SourceFrom, data []byte) error {
 	events, err := s.dispatcher.DispatchEvents(&source, data)
 	if err != nil {
 		var errSourceNotExist alert.ErrAlertSourceNotExist

--- a/backend/pkg/services/integration/alert/service_schema.go
+++ b/backend/pkg/services/integration/alert/service_schema.go
@@ -4,11 +4,12 @@
 package alert
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/enrich"
 )
 
-func (s *service) CreateSchema(req *alert.CreateSchemaRequest) error {
+func (s *service) CreateSchema(ctx core.Context, req *alert.CreateSchemaRequest) error {
 	err := s.dbRepo.CreateSchema(req.Schema, req.Columns)
 	if err != nil {
 		return err
@@ -19,19 +20,19 @@ func (s *service) CreateSchema(req *alert.CreateSchemaRequest) error {
 	return nil
 }
 
-func (s *service) ListSchema() ([]string, error) {
+func (s *service) ListSchema(ctx core.Context) ([]string, error) {
 	return s.dbRepo.ListSchema()
 }
 
-func (s *service) GetSchemaData(schema string) ([]string, map[int64][]string, error) {
+func (s *service) GetSchemaData(ctx core.Context, schema string) ([]string, map[int64][]string, error) {
 	return s.dbRepo.GetSchemaData(schema)
 }
 
-func (s *service) CheckSchemaIsUsed(schema string) ([]string, error) {
+func (s *service) CheckSchemaIsUsed(ctx core.Context, schema string) ([]string, error) {
 	return s.dbRepo.CheckSchemaIsUsed(schema)
 }
 
-func (s *service) DeleteSchema(schema string) error {
+func (s *service) DeleteSchema(ctx core.Context, schema string) error {
 	s.dispatcher.EnricherMap.Range(func(key, value any) bool {
 		enricher := value.(*enrich.AlertEnricher)
 		enricher.RemoveRuleByDeletedSchema(schema)
@@ -41,11 +42,11 @@ func (s *service) DeleteSchema(schema string) error {
 	return s.dbRepo.DeleteSchema(schema)
 }
 
-func (s *service) ListSchemaColumns(schema string) ([]string, error) {
+func (s *service) ListSchemaColumns(ctx core.Context, schema string) ([]string, error) {
 	return s.dbRepo.ListSchemaColumns(schema)
 }
 
-func (s *service) UpdateSchemaData(req *alert.UpdateSchemaDataRequest) error {
+func (s *service) UpdateSchemaData(ctx core.Context, req *alert.UpdateSchemaDataRequest) error {
 	if req.ClearAll {
 		err := s.dbRepo.ClearSchemaData(req.Schema)
 		if err != nil {

--- a/backend/pkg/services/integration/alert/service_update_alert_enrich_rule.go
+++ b/backend/pkg/services/integration/alert/service_update_alert_enrich_rule.go
@@ -6,13 +6,14 @@ package alert
 import (
 	"sort"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/enrich"
 	"github.com/google/uuid"
 	"go.uber.org/multierr"
 )
 
-func (s *service) UpdateAlertEnrichRule(req *alert.AlertEnrichRuleConfigRequest) error {
+func (s *service) UpdateAlertEnrichRule(ctx core.Context, req *alert.AlertEnrichRuleConfigRequest) error {
 	oldEnricherPtr, find := s.dispatcher.EnricherMap.Load(req.SourceId)
 	if !find {
 		return alert.ErrAlertSourceNotExist{}
@@ -103,7 +104,7 @@ func (s *service) UpdateAlertEnrichRule(req *alert.AlertEnrichRuleConfigRequest)
 		enricher, loaded := s.dispatcher.EnricherMap.Load(req.SourceId)
 		if loaded {
 			sourceType := enricher.(*enrich.AlertEnricher).SourceType
-			s.SetDefaultAlertEnrichRule(sourceType, req.EnrichRuleConfigs)
+			s.SetDefaultAlertEnrichRule(ctx, sourceType, req.EnrichRuleConfigs)
 		}
 	}
 

--- a/backend/pkg/services/integration/service.go
+++ b/backend/pkg/services/integration/service.go
@@ -4,25 +4,26 @@
 package integration
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
 type Service interface {
-	GetStaticIntegration() map[string]any
+	GetStaticIntegration(ctx core.Context) map[string]any
 
-	CreateCluster(cluster *integration.ClusterIntegration) (*integration.Cluster, error)
-	GetClusterIntegration(clusterID string) (*integration.ClusterIntegrationVO, error)
-	UpdateClusterIntegration(cluster *integration.ClusterIntegration) error
+	CreateCluster(ctx core.Context, cluster *integration.ClusterIntegration) (*integration.Cluster, error)
+	GetClusterIntegration(ctx core.Context, clusterID string) (*integration.ClusterIntegrationVO, error)
+	UpdateClusterIntegration(ctx core.Context, cluster *integration.ClusterIntegration) error
 
-	ListCluster() ([]integration.Cluster, error)
-	DeleteCluster(cluster *integration.Cluster) error
+	ListCluster(ctx core.Context) ([]integration.Cluster, error)
+	DeleteCluster(ctx core.Context, cluster *integration.Cluster) error
 
-	GetIntegrationInstallConfigFile(req *integration.GetCInstallRequest) (*integration.GetCInstallConfigResponse, error)
+	GetIntegrationInstallConfigFile(ctx core.Context, req *integration.GetCInstallRequest) (*integration.GetCInstallConfigResponse, error)
 	// Deprecated
-	GetIntegrationInstallDoc(req *integration.GetCInstallRequest) ([]byte, error)
+	GetIntegrationInstallDoc(ctx core.Context, req *integration.GetCInstallRequest) ([]byte, error)
 
-	TriggerAdapterUpdate(req *integration.TriggerAdapterUpdateRequest)
+	TriggerAdapterUpdate(ctx core.Context, req *integration.TriggerAdapterUpdateRequest)
 }
 
 var _ Service = &service{}

--- a/backend/pkg/services/integration/service_clusters.go
+++ b/backend/pkg/services/integration/service_clusters.go
@@ -4,14 +4,15 @@
 package integration
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 )
 
-func (s *service) ListCluster() ([]integration.Cluster, error) {
+func (s *service) ListCluster(ctx core.Context) ([]integration.Cluster, error) {
 	return s.dbRepo.ListCluster()
 }
 
-func (s *service) DeleteCluster(cluster *integration.Cluster) error {
+func (s *service) DeleteCluster(ctx core.Context, cluster *integration.Cluster) error {
 	err := s.dbRepo.DeleteCluster(cluster)
 	if err != nil {
 		return err

--- a/backend/pkg/services/integration/service_create_cluster.go
+++ b/backend/pkg/services/integration/service_create_cluster.go
@@ -7,11 +7,12 @@ import (
 	"errors"
 
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/google/uuid"
 )
 
-func (s *service) CreateCluster(cluster *integration.ClusterIntegration) (*integration.Cluster, error) {
+func (s *service) CreateCluster(ctx core.Context, cluster *integration.ClusterIntegration) (*integration.Cluster, error) {
 	isExist, err := s.dbRepo.CheckClusterNameExisted(cluster.Name)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/integration/service_get_cluster_integration.go
+++ b/backend/pkg/services/integration/service_get_cluster_integration.go
@@ -3,9 +3,12 @@
 
 package integration
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration"
+)
 
-func (s *service) GetClusterIntegration(clusterID string) (*integration.ClusterIntegrationVO, error) {
+func (s *service) GetClusterIntegration(ctx core.Context, clusterID string) (*integration.ClusterIntegrationVO, error) {
 	config, err := s.dbRepo.GetIntegrationConfig(clusterID)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/integration/service_integration_config.go
+++ b/backend/pkg/services/integration/service_integration_config.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"text/template"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 )
 
@@ -77,7 +78,7 @@ func defaultValue(v any, def any) string {
 	}
 }
 
-func (s *service) GetIntegrationInstallConfigFile(req *integration.GetCInstallRequest) (*integration.GetCInstallConfigResponse, error) {
+func (s *service) GetIntegrationInstallConfigFile(ctx core.Context, req *integration.GetCInstallRequest) (*integration.GetCInstallConfigResponse, error) {
 	clusterConfig, err := s.dbRepo.GetIntegrationConfig(req.ClusterID)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/integration/service_integration_doc.go
+++ b/backend/pkg/services/integration/service_integration_doc.go
@@ -7,11 +7,12 @@ import (
 	"bytes"
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 )
 
 // Deprecated
-func (s *service) GetIntegrationInstallDoc(req *integration.GetCInstallRequest) ([]byte, error) {
+func (s *service) GetIntegrationInstallDoc(ctx core.Context, req *integration.GetCInstallRequest) ([]byte, error) {
 	cluster, err := s.dbRepo.GetCluster(req.ClusterID)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/integration/service_static_integration.go
+++ b/backend/pkg/services/integration/service_static_integration.go
@@ -5,12 +5,13 @@ package integration
 
 import (
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/mitchellh/mapstructure"
 )
 
 // HACK use static config in configFile now
-func (s *service) GetStaticIntegration() map[string]any {
+func (s *service) GetStaticIntegration(ctx core.Context) map[string]any {
 	resp := make(map[string]any)
 
 	chCfg := config.Get().ClickHouse

--- a/backend/pkg/services/integration/service_trigger_adapter_update.go
+++ b/backend/pkg/services/integration/service_trigger_adapter_update.go
@@ -6,12 +6,14 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/CloudDetail/apo/backend/pkg/util"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 
+	"github.com/CloudDetail/apo/backend/pkg/util"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 )
 
@@ -28,7 +30,7 @@ const adapterUpdateAPI = "/trace/api/update"
 
 var adapterServiceAddress = "http://apo-apm-adapter-svc:8079"
 
-func (s *service) TriggerAdapterUpdate(req *integration.TriggerAdapterUpdateRequest) {
+func (s *service) TriggerAdapterUpdate(ctx core.Context, req *integration.TriggerAdapterUpdateRequest) {
 	traceAPI, err := s.dbRepo.GetLatestTraceAPIs(req.LastUpdateTS)
 	if err != nil {
 		log.Println("get latest trace api error: ", err)

--- a/backend/pkg/services/integration/service_update_cluster_integration.go
+++ b/backend/pkg/services/integration/service_update_cluster_integration.go
@@ -5,10 +5,11 @@ package integration
 
 import (
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 )
 
-func (s *service) UpdateClusterIntegration(cluster *integration.ClusterIntegration) error {
+func (s *service) UpdateClusterIntegration(ctx core.Context, cluster *integration.ClusterIntegration) error {
 	// TODO 当前强制指定VM和CK配置
 	vmCfg := config.Get().Promethues
 	cluster.Metric.MetricAPI = &integration.JSONField[integration.MetricAPI]{

--- a/backend/pkg/services/metric/query_dict.go
+++ b/backend/pkg/services/metric/query_dict.go
@@ -3,7 +3,11 @@
 
 package metric
 
-import "fmt"
+import (
+	"fmt"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+)
 
 type QueryDict struct {
 	querys   []Query
@@ -31,7 +35,7 @@ func (q *QueryDict) ListMetrics() []QueryInfo {
 	return q.listQuerys
 }
 
-func (q *QueryDict) ListQuerys() []Query {
+func (q *QueryDict) ListQuerys(ctx core.Context) []Query {
 	return q.querys
 }
 

--- a/backend/pkg/services/metric/service.go
+++ b/backend/pkg/services/metric/service.go
@@ -3,14 +3,17 @@
 
 package metric
 
-import "github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
+)
 
 var _ Service = (*service)(nil)
 
 type Service interface {
-	ListPreDefinedMetrics() []QueryInfo
-	ListQuerys() []Query
-	QueryMetrics(req *QueryMetricsRequest) *QueryMetricsResult
+	ListPreDefinedMetrics(ctx core.Context) []QueryInfo
+	ListQuerys(ctx core.Context) []Query
+	QueryMetrics(ctx core.Context, req *QueryMetricsRequest) *QueryMetricsResult
 }
 
 type service struct {

--- a/backend/pkg/services/metric/service_predefined_metrics.go
+++ b/backend/pkg/services/metric/service_predefined_metrics.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
@@ -58,15 +59,15 @@ func init() {
 	}
 }
 
-func (s *service) ListPreDefinedMetrics() []QueryInfo {
+func (s *service) ListPreDefinedMetrics(ctx core.Context) []QueryInfo {
 	return queryDict.ListMetrics()
 }
 
-func (s *service) ListQuerys() []Query {
-	return queryDict.ListQuerys()
+func (s *service) ListQuerys(ctx core.Context) []Query {
+	return queryDict.ListQuerys(ctx)
 }
 
-func (s *service) QueryMetrics(req *QueryMetricsRequest) *QueryMetricsResult {
+func (s *service) QueryMetrics(ctx core.Context, req *QueryMetricsRequest) *QueryMetricsResult {
 	// auto params
 
 	interval := prometheus.VecFromDuration(time.Duration(req.Step) * time.Microsecond)

--- a/backend/pkg/services/network/service.go
+++ b/backend/pkg/services/network/service.go
@@ -4,6 +4,7 @@
 package network
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -12,8 +13,8 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	GetPodMap(req *request.PodMapRequest) (*response.PodMapResponse, error)
-	GetSpanSegmentsMetrics(req *request.SpanSegmentMetricsRequest) (response.SpanSegmentMetricsResponse, error)
+	GetPodMap(ctx core.Context, req *request.PodMapRequest) (*response.PodMapResponse, error)
+	GetSpanSegmentsMetrics(ctx core.Context, req *request.SpanSegmentMetricsRequest) (response.SpanSegmentMetricsResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/network/service_get_pod_map.go
+++ b/backend/pkg/services/network/service_get_pod_map.go
@@ -6,12 +6,14 @@ package network
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/CloudDetail/apo/backend/pkg/util"
 	"io"
 	"net/http"
 	"net/url"
 
+	"github.com/CloudDetail/apo/backend/pkg/util"
+
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -28,7 +30,7 @@ const (
 	sqlTemplate = "SELECT %s FROM vtap_app_edge_port %s %s"
 )
 
-func (s *service) GetPodMap(req *request.PodMapRequest) (*response.PodMapResponse, error) {
+func (s *service) GetPodMap(ctx core.Context, req *request.PodMapRequest) (*response.PodMapResponse, error) {
 	deepflowServer := config.Get().DeepFlow.ServerAddress
 	sql := buildPodMapQuery(req)
 	db := "flow_metrics"

--- a/backend/pkg/services/network/service_get_segments_network.go
+++ b/backend/pkg/services/network/service_get_segments_network.go
@@ -4,11 +4,12 @@
 package network
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetSpanSegmentsMetrics(req *request.SpanSegmentMetricsRequest) (response.SpanSegmentMetricsResponse, error) {
+func (s *service) GetSpanSegmentsMetrics(ctx core.Context, req *request.SpanSegmentMetricsRequest) (response.SpanSegmentMetricsResponse, error) {
 	netSegments, err := s.chRepo.GetNetworkSpanSegments(req.TraceId, req.SpanId)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/permission/service.go
+++ b/backend/pkg/services/permission/service.go
@@ -4,19 +4,20 @@
 package permission
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
 type Service interface {
-	GetFeature(req *request.GetFeatureRequest) (response.GetFeatureResponse, error)
-	PermissionOperation(req *request.PermissionOperationRequest) error
-	ConfigureMenu(req *request.ConfigureMenuRequest) error
-	GetUserConfig(req *request.GetUserConfigRequest) (response.GetUserConfigResponse, error)
-	GetSubjectFeature(req *request.GetSubjectFeatureRequest) (resp response.GetSubjectFeatureResponse, err error)
-	CheckApiPermission(userID int64, method string, path string) (ok bool, err error)
-	CheckRouterPermission(userID int64, router string) (bool, error)
+	GetFeature(ctx core.Context, req *request.GetFeatureRequest) (response.GetFeatureResponse, error)
+	PermissionOperation(ctx core.Context, req *request.PermissionOperationRequest) error
+	ConfigureMenu(ctx core.Context, req *request.ConfigureMenuRequest) error
+	GetUserConfig(ctx core.Context, req *request.GetUserConfigRequest) (response.GetUserConfigResponse, error)
+	GetSubjectFeature(ctx core.Context, req *request.GetSubjectFeatureRequest) (resp response.GetSubjectFeatureResponse, err error)
+	CheckApiPermission(ctx core.Context, userID int64, method string, path string) (ok bool, err error)
+	CheckRouterPermission(ctx core.Context, userID int64, router string) (bool, error)
 }
 
 type service struct {

--- a/backend/pkg/services/permission/service_check_api_permission.go
+++ b/backend/pkg/services/permission/service_check_api_permission.go
@@ -5,11 +5,11 @@ package permission
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (s *service) CheckApiPermission(userID int64, method string, path string) (ok bool, err error) {
+func (s *service) CheckApiPermission(ctx core.Context, userID int64, method string, path string) (ok bool, err error) {
 	exists, err := s.dbRepo.UserExists(userID)
 	if err != nil {
 		return false, err
@@ -19,7 +19,7 @@ func (s *service) CheckApiPermission(userID int64, method string, path string) (
 		return false, core.Error(code.UserNotExistsError, "user does not exist")
 	}
 
-	featureIDs, err := s.getUserFeatureIDs(userID)
+	featureIDs, err := s.getUserFeatureIDs(ctx, userID)
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/services/permission/service_check_router.go
+++ b/backend/pkg/services/permission/service_check_router.go
@@ -6,11 +6,12 @@ package permission
 import (
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (s *service) CheckRouterPermission(userID int64, routerTo string) (bool, error) {
-	features, err := s.getUserFeatureIDs(userID)
+func (s *service) CheckRouterPermission(ctx core.Context, userID int64, routerTo string) (bool, error) {
+	features, err := s.getUserFeatureIDs(ctx, userID)
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/services/permission/service_configure_menu.go
+++ b/backend/pkg/services/permission/service_configure_menu.go
@@ -5,11 +5,13 @@ package permission
 
 import (
 	"context"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) ConfigureMenu(req *request.ConfigureMenuRequest) error {
+func (s *service) ConfigureMenu(ctx core.Context, req *request.ConfigureMenuRequest) error {
 	filter := model.RoleFilter{
 		Names: []string{model.ROLE_ADMIN, model.ROLE_VIEWER, model.ROLE_MANAGER},
 	}

--- a/backend/pkg/services/permission/service_get_user_permission.go
+++ b/backend/pkg/services/permission/service_get_user_permission.go
@@ -4,10 +4,11 @@
 package permission
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (s *service) getUserFeatureIDs(userID int64) ([]int, error) {
+func (s *service) getUserFeatureIDs(ctx core.Context, userID int64) ([]int, error) {
 	// 1. Get user's role
 	roles, err := s.dbRepo.GetUserRole(userID)
 	if err != nil {

--- a/backend/pkg/services/permission/service_permission.go
+++ b/backend/pkg/services/permission/service_permission.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) GetFeature(req *request.GetFeatureRequest) (response.GetFeatureResponse, error) {
+func (s *service) GetFeature(ctx core.Context, req *request.GetFeatureRequest) (response.GetFeatureResponse, error) {
 	features, err := s.dbRepo.GetFeature(nil)
 	if err != nil {
 		return nil, err
@@ -46,9 +46,9 @@ func (s *service) GetFeature(req *request.GetFeatureRequest) (response.GetFeatur
 	return rootFeatures, nil
 }
 
-func (s *service) GetSubjectFeature(req *request.GetSubjectFeatureRequest) (response.GetSubjectFeatureResponse, error) {
+func (s *service) GetSubjectFeature(ctx core.Context, req *request.GetSubjectFeatureRequest) (response.GetSubjectFeatureResponse, error) {
 	if req.SubjectType == model.PERMISSION_SUB_TYP_USER {
-		return s.getUserFeatureWithSource(req.SubjectID, req.Language)
+		return s.getUserFeatureWithSource(ctx, req.SubjectID, req.Language)
 	}
 
 	featureIDs, err := s.dbRepo.GetSubjectPermission(req.SubjectID, req.SubjectType, model.PERMISSION_TYP_FEATURE)
@@ -64,7 +64,7 @@ func (s *service) GetSubjectFeature(req *request.GetSubjectFeatureRequest) (resp
 	return featureList, nil
 }
 
-func (s *service) getUserFeatureWithSource(userID int64, language string) (response.GetSubjectFeatureResponse, error) {
+func (s *service) getUserFeatureWithSource(ctx core.Context, userID int64, language string) (response.GetSubjectFeatureResponse, error) {
 	// Get user's roles and teams
 	roles, err := s.dbRepo.GetUserRole(userID)
 	if err != nil {
@@ -129,7 +129,7 @@ func (s *service) getUserFeatureWithSource(userID int64, language string) (respo
 	return resp, err
 }
 
-func (s *service) PermissionOperation(req *request.PermissionOperationRequest) error {
+func (s *service) PermissionOperation(ctx core.Context, req *request.PermissionOperationRequest) error {
 	var exists bool
 	var err error
 	switch req.SubjectType {

--- a/backend/pkg/services/permission/service_user_configs.go
+++ b/backend/pkg/services/permission/service_user_configs.go
@@ -4,17 +4,19 @@
 package permission
 
 import (
+	"sort"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
-	"sort"
 )
 
 // GetUserConfig Gets menus and routes that users can view.
-func (s *service) GetUserConfig(req *request.GetUserConfigRequest) (response.GetUserConfigResponse, error) {
+func (s *service) GetUserConfig(ctx core.Context, req *request.GetUserConfigRequest) (response.GetUserConfigResponse, error) {
 	var resp response.GetUserConfigResponse
-	featureIDs, err := s.getUserFeatureIDs(req.UserID)
+	featureIDs, err := s.getUserFeatureIDs(ctx, req.UserID)
 	if err != nil {
 		return resp, err
 	}

--- a/backend/pkg/services/role/service.go
+++ b/backend/pkg/services/role/service.go
@@ -4,6 +4,7 @@
 package role
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -12,12 +13,12 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	RoleOperation(req *request.RoleOperationRequest) error
-	GetRoles() (response.GetRoleResponse, error)
-	GetUserRole(req *request.GetUserRoleRequest) (response.GetUserRoleResponse, error)
-	CreateRole(req *request.CreateRoleRequest) error
-	UpdateRole(req *request.UpdateRoleRequest) error
-	DeleteRole(req *request.DeleteRoleRequest) error
+	RoleOperation(ctx core.Context, req *request.RoleOperationRequest) error
+	GetRoles(ctx core.Context) (response.GetRoleResponse, error)
+	GetUserRole(ctx core.Context, req *request.GetUserRoleRequest) (response.GetUserRoleResponse, error)
+	CreateRole(ctx core.Context, req *request.CreateRoleRequest) error
+	UpdateRole(ctx core.Context, req *request.UpdateRoleRequest) error
+	DeleteRole(ctx core.Context, req *request.DeleteRoleRequest) error
 }
 
 type service struct {

--- a/backend/pkg/services/role/service_create_role.go
+++ b/backend/pkg/services/role/service_create_role.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) CreateRole(req *request.CreateRoleRequest) error {
+func (s *service) CreateRole(ctx core.Context, req *request.CreateRoleRequest) error {
 	filter := model.RoleFilter{
 		Name: req.RoleName,
 	}

--- a/backend/pkg/services/role/service_delete_role.go
+++ b/backend/pkg/services/role/service_delete_role.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) DeleteRole(req *request.DeleteRoleRequest) error {
+func (s *service) DeleteRole(ctx core.Context, req *request.DeleteRoleRequest) error {
 	exists, err := s.dbRepo.RoleExists(req.RoleID)
 	if err != nil {
 		return err

--- a/backend/pkg/services/role/service_update_role.go
+++ b/backend/pkg/services/role/service_update_role.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) UpdateRole(req *request.UpdateRoleRequest) error {
+func (s *service) UpdateRole(ctx core.Context, req *request.UpdateRoleRequest) error {
 	idFilter := model.RoleFilter{
 		ID: req.RoleID,
 	}

--- a/backend/pkg/services/role/service_user_role.go
+++ b/backend/pkg/services/role/service_user_role.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) GetRoles() (response.GetRoleResponse, error) {
+func (s *service) GetRoles(ctx core.Context) (response.GetRoleResponse, error) {
 	roles, err := s.dbRepo.GetRoles(model.RoleFilter{})
 	var resp response.GetRoleResponse
 	if err != nil {
@@ -25,7 +25,7 @@ func (s *service) GetRoles() (response.GetRoleResponse, error) {
 	return resp, nil
 }
 
-func (s *service) GetUserRole(req *request.GetUserRoleRequest) (response.GetUserRoleResponse, error) {
+func (s *service) GetUserRole(ctx core.Context, req *request.GetUserRoleRequest) (response.GetUserRoleResponse, error) {
 	userRole, err := s.dbRepo.GetUserRole(req.UserID)
 	if err != nil {
 		return nil, err
@@ -43,7 +43,7 @@ func (s *service) GetUserRole(req *request.GetUserRoleRequest) (response.GetUser
 	return roles, nil
 }
 
-func (s *service) RoleOperation(req *request.RoleOperationRequest) error {
+func (s *service) RoleOperation(ctx core.Context, req *request.RoleOperationRequest) error {
 	// 1. get user's role
 	userRole, err := s.dbRepo.GetUserRole(req.UserID)
 	if err != nil {

--- a/backend/pkg/services/team/service.go
+++ b/backend/pkg/services/team/service.go
@@ -4,19 +4,20 @@
 package team
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
 type Service interface {
-	CreateTeam(req *request.CreateTeamRequest) error
-	UpdateTeam(req *request.UpdateTeamRequest) error
-	GetTeamList(req *request.GetTeamRequest) (resp response.GetTeamResponse, err error)
-	DeleteTeam(req *request.DeleteTeamRequest) error
-	TeamOperation(req *request.TeamOperationRequest) error
-	TeamUserOperation(req *request.AssignToTeamRequest) error
-	GetTeamUser(req *request.GetTeamUserRequest) (response.GetTeamUserResponse, error)
+	CreateTeam(ctx core.Context, req *request.CreateTeamRequest) error
+	UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) error
+	GetTeamList(ctx core.Context, req *request.GetTeamRequest) (resp response.GetTeamResponse, err error)
+	DeleteTeam(ctx core.Context, req *request.DeleteTeamRequest) error
+	TeamOperation(ctx core.Context, req *request.TeamOperationRequest) error
+	TeamUserOperation(ctx core.Context, req *request.AssignToTeamRequest) error
+	GetTeamUser(ctx core.Context, req *request.GetTeamUserRequest) (response.GetTeamUserResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/team/service_create_team.go
+++ b/backend/pkg/services/team/service_create_team.go
@@ -7,14 +7,14 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 	"github.com/CloudDetail/apo/backend/pkg/util"
 )
 
-func (s *service) CreateTeam(req *request.CreateTeamRequest) error {
+func (s *service) CreateTeam(ctx core.Context, req *request.CreateTeamRequest) error {
 	team := database.Team{
 		TeamID:      util.Generator.GenerateID(),
 		TeamName:    req.TeamName,

--- a/backend/pkg/services/team/service_delete_team.go
+++ b/backend/pkg/services/team/service_delete_team.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) DeleteTeam(req *request.DeleteTeamRequest) error {
+func (s *service) DeleteTeam(ctx core.Context, req *request.DeleteTeamRequest) error {
 	filter := model.TeamFilter{
 		ID: req.TeamID,
 	}

--- a/backend/pkg/services/team/service_get_team.go
+++ b/backend/pkg/services/team/service_get_team.go
@@ -4,12 +4,13 @@
 package team
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTeamList(req *request.GetTeamRequest) (resp response.GetTeamResponse, err error) {
+func (s *service) GetTeamList(ctx core.Context, req *request.GetTeamRequest) (resp response.GetTeamResponse, err error) {
 	teams, count, err := s.dbRepo.GetTeamList(req)
 	if err != nil {
 		return

--- a/backend/pkg/services/team/service_get_team_user.go
+++ b/backend/pkg/services/team/service_get_team_user.go
@@ -5,13 +5,13 @@ package team
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTeamUser(req *request.GetTeamUserRequest) (resp response.GetTeamUserResponse, err error) {
+func (s *service) GetTeamUser(ctx core.Context, req *request.GetTeamUserRequest) (resp response.GetTeamUserResponse, err error) {
 	filter := model.TeamFilter{
 		ID: req.TeamID,
 	}

--- a/backend/pkg/services/team/service_team_opreation.go
+++ b/backend/pkg/services/team/service_team_opreation.go
@@ -7,11 +7,11 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) TeamOperation(req *request.TeamOperationRequest) error {
+func (s *service) TeamOperation(ctx core.Context, req *request.TeamOperationRequest) error {
 	teamIDs, err := s.dbRepo.GetUserTeams(req.UserID)
 	if err != nil {
 		return err

--- a/backend/pkg/services/team/service_team_user_operation.go
+++ b/backend/pkg/services/team/service_team_user_operation.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) TeamUserOperation(req *request.AssignToTeamRequest) error {
+func (s *service) TeamUserOperation(ctx core.Context, req *request.AssignToTeamRequest) error {
 	filter := model.TeamFilter{
 		ID: req.TeamID,
 	}

--- a/backend/pkg/services/team/service_update_team.go
+++ b/backend/pkg/services/team/service_update_team.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) UpdateTeam(req *request.UpdateTeamRequest) error {
+func (s *service) UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) error {
 	team, err := s.dbRepo.GetTeam(req.TeamID)
 	if err != nil {
 		return err

--- a/backend/pkg/services/trace/service.go
+++ b/backend/pkg/services/trace/service.go
@@ -4,10 +4,12 @@
 package trace
 
 import (
-	"github.com/CloudDetail/apo/backend/pkg/repository/jaeger"
-	"go.uber.org/zap"
 	"time"
 
+	"github.com/CloudDetail/apo/backend/pkg/repository/jaeger"
+	"go.uber.org/zap"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -16,13 +18,13 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	GetTraceFilters(startTime, endTime time.Time, needUpdate bool) (*response.GetTraceFiltersResponse, error)
-	GetTraceFilterValues(startTime, endTime time.Time, searchText string, filter request.SpanTraceFilter) (*response.GetTraceFilterValueResponse, error)
-	GetTracePageList(req *request.GetTracePageListRequest) (*response.GetTracePageListResponse, error)
-	GetOnOffCPU(req *request.GetOnOffCPURequest) (*response.GetOnOffCPUResponse, error)
-	GetSingleTraceID(req *request.GetSingleTraceInfoRequest) (string, error)
-	GetFlameGraphData(req *request.GetFlameDataRequest) (response.GetFlameDataResponse, error)
-	GetProcessFlameGraphData(req *request.GetProcessFlameGraphRequest) (response.GetProcessFlameGraphResponse, error)
+	GetTraceFilters(ctx core.Context, startTime, endTime time.Time, needUpdate bool) (*response.GetTraceFiltersResponse, error)
+	GetTraceFilterValues(ctx core.Context, startTime, endTime time.Time, searchText string, filter request.SpanTraceFilter) (*response.GetTraceFilterValueResponse, error)
+	GetTracePageList(ctx core.Context, req *request.GetTracePageListRequest) (*response.GetTracePageListResponse, error)
+	GetOnOffCPU(ctx core.Context, req *request.GetOnOffCPURequest) (*response.GetOnOffCPUResponse, error)
+	GetSingleTraceID(ctx core.Context, req *request.GetSingleTraceInfoRequest) (string, error)
+	GetFlameGraphData(ctx core.Context, req *request.GetFlameDataRequest) (response.GetFlameDataResponse, error)
+	GetProcessFlameGraphData(ctx core.Context, req *request.GetProcessFlameGraphRequest) (response.GetProcessFlameGraphResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/trace/service_get_flame_data.go
+++ b/backend/pkg/services/trace/service_get_flame_data.go
@@ -4,12 +4,13 @@
 package trace
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"go.uber.org/zap"
 )
 
-func (s *service) GetFlameGraphData(req *request.GetFlameDataRequest) (resp response.GetFlameDataResponse, err error) {
+func (s *service) GetFlameGraphData(ctx core.Context, req *request.GetFlameDataRequest) (resp response.GetFlameDataResponse, err error) {
 	flameData, err := s.chRepo.GetFlameGraphData(req.StartTime, req.EndTime, req.NodeName,
 		req.PID, req.TID, req.SampleType, req.SpanID, req.TraceID)
 	if err != nil {

--- a/backend/pkg/services/trace/service_get_on_off_cpu.go
+++ b/backend/pkg/services/trace/service_get_on_off_cpu.go
@@ -4,11 +4,12 @@
 package trace
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetOnOffCPU(req *request.GetOnOffCPURequest) (*response.GetOnOffCPUResponse, error) {
+func (s *service) GetOnOffCPU(ctx core.Context, req *request.GetOnOffCPURequest) (*response.GetOnOffCPUResponse, error) {
 	result, err := s.chRepo.GetOnOffCPU(req.PID, req.NodeName, req.StartTime, req.EndTime)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/trace/service_get_process_flame_data.go
+++ b/backend/pkg/services/trace/service_get_process_flame_data.go
@@ -5,14 +5,16 @@ package trace
 
 import (
 	"encoding/json"
+	"math"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"go.uber.org/zap"
-	"math"
 )
 
-func (s *service) GetProcessFlameGraphData(req *request.GetProcessFlameGraphRequest) (response.GetProcessFlameGraphResponse, error) {
+func (s *service) GetProcessFlameGraphData(ctx core.Context, req *request.GetProcessFlameGraphRequest) (response.GetProcessFlameGraphResponse, error) {
 	data, err := s.chRepo.GetFlameGraphData(req.StartTime, req.EndTime, req.NodeName,
 		req.PID, -1, req.SampleType, "", "")
 	if err != nil {

--- a/backend/pkg/services/trace/service_get_single_trace_info.go
+++ b/backend/pkg/services/trace/service_get_single_trace_info.go
@@ -4,10 +4,11 @@
 package trace
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) GetSingleTraceID(req *request.GetSingleTraceInfoRequest) (string, error) {
+func (s *service) GetSingleTraceID(ctx core.Context, req *request.GetSingleTraceInfoRequest) (string, error) {
 	result, err := s.jaegerRepo.GetSingleTrace(req.TraceID)
 	if err != nil {
 		return "", err

--- a/backend/pkg/services/trace/service_get_trace_filter_values.go
+++ b/backend/pkg/services/trace/service_get_trace_filter_values.go
@@ -6,12 +6,13 @@ package trace
 import (
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetTraceFilterValues(startTime, endTime time.Time, searchText string, filter request.SpanTraceFilter) (*response.GetTraceFilterValueResponse, error) {
+func (s *service) GetTraceFilterValues(ctx core.Context, startTime, endTime time.Time, searchText string, filter request.SpanTraceFilter) (*response.GetTraceFilterValueResponse, error) {
 	option, err := s.chRepo.GetFieldValues(searchText, &filter, startTime, endTime)
 	if err != nil {
 		return &response.GetTraceFilterValueResponse{

--- a/backend/pkg/services/trace/service_get_trace_filters.go
+++ b/backend/pkg/services/trace/service_get_trace_filters.go
@@ -6,11 +6,12 @@ package trace
 import (
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTraceFilters(startTime, endTime time.Time, needUpdate bool) (*response.GetTraceFiltersResponse, error) {
+func (s *service) GetTraceFilters(ctx core.Context, startTime, endTime time.Time, needUpdate bool) (*response.GetTraceFiltersResponse, error) {
 	filters, err := s.chRepo.GetAvailableFilterKey(startTime, endTime, needUpdate)
 	if err != nil {
 		return &response.GetTraceFiltersResponse{

--- a/backend/pkg/services/trace/service_get_trace_page_list.go
+++ b/backend/pkg/services/trace/service_get_trace_page_list.go
@@ -4,12 +4,13 @@
 package trace
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTracePageList(req *request.GetTracePageListRequest) (*response.GetTracePageListResponse, error) {
+func (s *service) GetTracePageList(ctx core.Context, req *request.GetTracePageListRequest) (*response.GetTracePageListResponse, error) {
 	list, total, err := s.chRepo.GetTracePageList(req)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/user/service.go
+++ b/backend/pkg/services/user/service.go
@@ -4,6 +4,7 @@
 package user
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/cache"
@@ -14,23 +15,23 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	Login(req *request.LoginRequest) (response.LoginResponse, error)
-	Logout(req *request.LogoutRequest) error
-	CreateUser(req *request.CreateUserRequest) error
-	RefreshToken(token string) (response.RefreshTokenResponse, error)
-	UpdateUserInfo(req *request.UpdateUserInfoRequest) error
-	UpdateSelfInfo(req *request.UpdateSelfInfoRequest) error
-	UpdateUserPhone(req *request.UpdateUserPhoneRequest) error
-	UpdateUserEmail(req *request.UpdateUserEmailRequest) error
-	UpdateUserPassword(req *request.UpdateUserPasswordRequest) error
-	GetUserInfo(userID int64) (response.GetUserInfoResponse, error)
-	GetUserList(req *request.GetUserListRequest) (response.GetUserListResponse, error)
-	RemoveUser(userID int64) error
-	RestPassword(req *request.ResetPasswordRequest) error
+	Login(ctx core.Context, req *request.LoginRequest) (response.LoginResponse, error)
+	Logout(ctx core.Context, req *request.LogoutRequest) error
+	CreateUser(ctx core.Context, req *request.CreateUserRequest) error
+	RefreshToken(ctx core.Context, token string) (response.RefreshTokenResponse, error)
+	UpdateUserInfo(ctx core.Context, req *request.UpdateUserInfoRequest) error
+	UpdateSelfInfo(ctx core.Context, req *request.UpdateSelfInfoRequest) error
+	UpdateUserPhone(ctx core.Context, req *request.UpdateUserPhoneRequest) error
+	UpdateUserEmail(ctx core.Context, req *request.UpdateUserEmailRequest) error
+	UpdateUserPassword(ctx core.Context, req *request.UpdateUserPasswordRequest) error
+	GetUserInfo(ctx core.Context, userID int64) (response.GetUserInfoResponse, error)
+	GetUserList(ctx core.Context, req *request.GetUserListRequest) (response.GetUserListResponse, error)
+	RemoveUser(ctx core.Context, userID int64) error
+	RestPassword(ctx core.Context, req *request.ResetPasswordRequest) error
 
-	GetUserTeam(req *request.GetUserTeamRequest) (response.GetUserTeamResponse, error)
+	GetUserTeam(ctx core.Context, req *request.GetUserTeamRequest) (response.GetUserTeamResponse, error)
 
-	IsInBlacklist(token string) (bool, error)
+	IsInBlacklist(ctx core.Context, token string) (bool, error)
 }
 
 type service struct {

--- a/backend/pkg/services/user/service_create_user.go
+++ b/backend/pkg/services/user/service_create_user.go
@@ -9,7 +9,7 @@ import (
 	"net/mail"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -24,7 +24,7 @@ func checkUserName(username string) error {
 	return nil
 }
 
-func (s *service) CreateUser(req *request.CreateUserRequest) error {
+func (s *service) CreateUser(ctx core.Context, req *request.CreateUserRequest) error {
 	if err := checkUserName(req.Username); err != nil {
 		return err
 	}

--- a/backend/pkg/services/user/service_get_user_info.go
+++ b/backend/pkg/services/user/service_get_user_info.go
@@ -5,13 +5,13 @@ package user
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) GetUserInfo(userID int64) (response.GetUserInfoResponse, error) {
+func (s *service) GetUserInfo(ctx core.Context, userID int64) (response.GetUserInfoResponse, error) {
 	var (
 		user database.User
 		err  error
@@ -42,7 +42,7 @@ func (s *service) GetUserInfo(userID int64) (response.GetUserInfoResponse, error
 	return resp, nil
 }
 
-func (s *service) GetUserList(req *request.GetUserListRequest) (resp response.GetUserListResponse, err error) {
+func (s *service) GetUserList(ctx core.Context, req *request.GetUserListRequest) (resp response.GetUserListResponse, err error) {
 	users, count, err := s.dbRepo.GetUserList(req)
 	resp.Users = users
 	resp.PageSize = req.PageSize

--- a/backend/pkg/services/user/service_get_user_team.go
+++ b/backend/pkg/services/user/service_get_user_team.go
@@ -5,12 +5,12 @@ package user
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetUserTeam(req *request.GetUserTeamRequest) (response.GetUserTeamResponse, error) {
+func (s *service) GetUserTeam(ctx core.Context, req *request.GetUserTeamRequest) (response.GetUserTeamResponse, error) {
 	exists, err := s.dbRepo.UserExists(req.UserID)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/user/service_login.go
+++ b/backend/pkg/services/user/service_login.go
@@ -4,12 +4,13 @@
 package user
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/util/jwt"
 )
 
-func (s *service) Login(req *request.LoginRequest) (response.LoginResponse, error) {
+func (s *service) Login(ctx core.Context, req *request.LoginRequest) (response.LoginResponse, error) {
 	user, err := s.dbRepo.Login(req.Username, req.Password)
 	if err != nil {
 		return response.LoginResponse{}, err

--- a/backend/pkg/services/user/service_logout.go
+++ b/backend/pkg/services/user/service_logout.go
@@ -4,10 +4,11 @@
 package user
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) Logout(req *request.LogoutRequest) error {
+func (s *service) Logout(ctx core.Context, req *request.LogoutRequest) error {
 	err := s.cacheRepo.AddToken(req.AccessToken)
 	if err != nil {
 		return err

--- a/backend/pkg/services/user/service_refresh_token.go
+++ b/backend/pkg/services/user/service_refresh_token.go
@@ -4,11 +4,12 @@
 package user
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/util/jwt"
 )
 
-func (s *service) RefreshToken(token string) (response.RefreshTokenResponse, error) {
+func (s *service) RefreshToken(ctx core.Context, token string) (response.RefreshTokenResponse, error) {
 	accessToken, err := jwt.RefreshToken(token)
 	var resp response.RefreshTokenResponse
 	if err != nil {
@@ -18,6 +19,6 @@ func (s *service) RefreshToken(token string) (response.RefreshTokenResponse, err
 	return resp, nil
 }
 
-func (s *service) IsInBlacklist(token string) (bool, error) {
+func (s *service) IsInBlacklist(ctx core.Context, token string) (bool, error) {
 	return s.cacheRepo.IsInBlacklist(token)
 }

--- a/backend/pkg/services/user/service_remove_user.go
+++ b/backend/pkg/services/user/service_remove_user.go
@@ -8,11 +8,11 @@ import (
 	"errors"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (s *service) RemoveUser(userID int64) error {
+func (s *service) RemoveUser(ctx core.Context, userID int64) error {
 	exists, err := s.dbRepo.UserExists(userID)
 	if err != nil {
 		return err

--- a/backend/pkg/services/user/service_update_info.go
+++ b/backend/pkg/services/user/service_update_info.go
@@ -9,11 +9,11 @@ import (
 	"unicode"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) UpdateUserInfo(req *request.UpdateUserInfoRequest) error {
+func (s *service) UpdateUserInfo(ctx core.Context, req *request.UpdateUserInfoRequest) error {
 	//userRoles, err := s.dbRepo.GetUserRole(req.UserID)
 	//if err != nil {
 	//	return err
@@ -44,15 +44,15 @@ func (s *service) UpdateUserInfo(req *request.UpdateUserInfoRequest) error {
 	return s.dbRepo.Transaction(context.Background(), updateInfoFunc)
 }
 
-func (s *service) UpdateUserPhone(req *request.UpdateUserPhoneRequest) error {
+func (s *service) UpdateUserPhone(ctx core.Context, req *request.UpdateUserPhoneRequest) error {
 	return s.dbRepo.UpdateUserPhone(req.UserID, req.Phone)
 }
 
-func (s *service) UpdateUserEmail(req *request.UpdateUserEmailRequest) error {
+func (s *service) UpdateUserEmail(ctx core.Context, req *request.UpdateUserEmailRequest) error {
 	return s.dbRepo.UpdateUserEmail(req.UserID, req.Email)
 }
 
-func (s *service) UpdateUserPassword(req *request.UpdateUserPasswordRequest) error {
+func (s *service) UpdateUserPassword(ctx core.Context, req *request.UpdateUserPasswordRequest) error {
 	if err := checkPasswordComplexity(req.NewPassword); err != nil {
 		return err
 	}
@@ -126,7 +126,7 @@ func containsRune(set string, char rune) bool {
 	return false
 }
 
-func (s *service) RestPassword(req *request.ResetPasswordRequest) error {
+func (s *service) RestPassword(ctx core.Context, req *request.ResetPasswordRequest) error {
 	if err := checkPasswordComplexity(req.NewPassword); err != nil {
 		return err
 	}
@@ -150,6 +150,6 @@ func (s *service) RestPassword(req *request.ResetPasswordRequest) error {
 	return s.dbRepo.Transaction(context.Background(), resetPasswordFunc, resetDifyPasswordFunc)
 }
 
-func (s *service) UpdateSelfInfo(req *request.UpdateSelfInfoRequest) error {
+func (s *service) UpdateSelfInfo(ctx core.Context, req *request.UpdateSelfInfoRequest) error {
 	return s.dbRepo.UpdateUserInfo(context.Background(), req.UserID, req.Phone, req.Email, req.Corporation)
 }


### PR DESCRIPTION
## Summary by Sourcery

Propagate a common core.Context throughout the application by adding context parameters to service, handler, receiver, and repository method signatures and updating call sites accordingly.

Enhancements:
- Propagate core.Context parameter through controller, service, receiver, and repository layers
- Update handler and middleware functions to pass context through to service calls
- Standardize import and usage of the core.Context type across the codebase