### PR TITLE
Refactor/Passing context between controller and repository layers - Part3 Passing context to service Layer 

### DIFF
--- a/backend/pkg/api/data/func_createdatagroup.go
+++ b/backend/pkg/api/data/func_createdatagroup.go
@@ -35,7 +35,7 @@ func (h *handler) CreateDataGroup() core.HandlerFunc {
 			return
 		}
 
-		err := h.dataService.CreateDataGroup(req)
+		err := h.dataService.CreateDataGroup(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_datagroupoperation.go
+++ b/backend/pkg/api/data/func_datagroupoperation.go
@@ -35,7 +35,7 @@ func (h *handler) DataGroupOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.dataService.DataGroupOperation(req)
+		err := h.dataService.DataGroupOperation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_deletedatagroup.go
+++ b/backend/pkg/api/data/func_deletedatagroup.go
@@ -35,7 +35,7 @@ func (h *handler) DeleteDataGroup() core.HandlerFunc {
 			return
 		}
 
-		err := h.dataService.DeleteDataGroup(req)
+		err := h.dataService.DeleteDataGroup(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_getdatagroup.go
+++ b/backend/pkg/api/data/func_getdatagroup.go
@@ -42,7 +42,7 @@ func (h *handler) GetDataGroup() core.HandlerFunc {
 			}
 		}
 
-		resp, err := h.dataService.GetDataGroup(req)
+		resp, err := h.dataService.GetDataGroup(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_getdatasource.go
+++ b/backend/pkg/api/data/func_getdatasource.go
@@ -22,7 +22,7 @@ import (
 // @Router /api/data/datasource [get]
 func (h *handler) GetDatasource() core.HandlerFunc {
 	return func(c core.Context) {
-		resp, err := h.dataService.GetDataSource()
+		resp, err := h.dataService.GetDataSource(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_getgroupdatasource.go
+++ b/backend/pkg/api/data/func_getgroupdatasource.go
@@ -36,7 +36,7 @@ func (h *handler) GetGroupDatasource() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		resp, err := h.dataService.GetGroupDatasource(req, userID)
+		resp, err := h.dataService.GetGroupDatasource(c, req, userID)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.GetGroupDatasourceError, nil)
 			return

--- a/backend/pkg/api/data/func_getgroupsubs.go
+++ b/backend/pkg/api/data/func_getgroupsubs.go
@@ -36,7 +36,7 @@ func (h *handler) GetGroupSubs() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.dataService.GetGroupSubs(req)
+		resp, err := h.dataService.GetGroupSubs(c, req)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.GetGroupSubsError, nil)
 			return

--- a/backend/pkg/api/data/func_getsubjectdatagroup.go
+++ b/backend/pkg/api/data/func_getsubjectdatagroup.go
@@ -37,7 +37,7 @@ func (h *handler) GetSubjectDataGroup() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.dataService.GetSubjectDataGroup(req)
+		resp, err := h.dataService.GetSubjectDataGroup(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_getuserdatagroup.go
+++ b/backend/pkg/api/data/func_getuserdatagroup.go
@@ -40,7 +40,7 @@ func (h *handler) GetUserDataGroup() core.HandlerFunc {
 		subReq.SubjectID = req.UserID
 		subReq.SubjectType = model.DATA_GROUP_SUB_TYP_USER
 		subReq.Category = req.Category
-		groups, err := h.dataService.GetSubjectDataGroup(subReq)
+		groups, err := h.dataService.GetSubjectDataGroup(c, subReq)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/data/func_groupsubsoperation.go
+++ b/backend/pkg/api/data/func_groupsubsoperation.go
@@ -35,7 +35,7 @@ func (h *handler) GroupSubsOperation() core.HandlerFunc {
 			return
 		}
 
-		err := h.dataService.GroupSubsOperation(req)
+		err := h.dataService.GroupSubsOperation(c, req)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AssignDataGroupError, nil)
 			return

--- a/backend/pkg/api/data/func_updatedatagroup.go
+++ b/backend/pkg/api/data/func_updatedatagroup.go
@@ -35,7 +35,7 @@ func (h *handler) UpdateDataGroup() core.HandlerFunc {
 			return
 		}
 
-		err := h.dataService.UpdateDataGroup(req)
+		err := h.dataService.UpdateDataGroup(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/k8s/func_getnamespaceinfo.go
+++ b/backend/pkg/api/k8s/func_getnamespaceinfo.go
@@ -34,7 +34,7 @@ func (h *handler) GetNamespaceInfo() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.k8sService.GetNamespaceInfo(req)
+		resp, err := h.k8sService.GetNamespaceInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/k8s/func_getnamespacelist.go
+++ b/backend/pkg/api/k8s/func_getnamespacelist.go
@@ -22,7 +22,7 @@ import (
 func (h *handler) GetNamespaceList() core.HandlerFunc {
 	return func(c core.Context) {
 
-		resp, err := h.k8sService.GetNamespaceList()
+		resp, err := h.k8sService.GetNamespaceList(c)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/k8s/func_getpodinfo.go
+++ b/backend/pkg/api/k8s/func_getpodinfo.go
@@ -35,7 +35,7 @@ func (h *handler) GetPodInfo() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.k8sService.GetPodInfo(req)
+		resp, err := h.k8sService.GetPodInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/k8s/func_getpodlist.go
+++ b/backend/pkg/api/k8s/func_getpodlist.go
@@ -32,7 +32,7 @@ func (h *handler) GetPodList() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.k8sService.GetPodList(req)
+		resp, err := h.k8sService.GetPodList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_addothertable.go
+++ b/backend/pkg/api/log/func_addothertable.go
@@ -34,7 +34,7 @@ func (h *handler) AddOtherTable() core.HandlerFunc {
 			return
 		}
 		req.FillerValue()
-		resp, err := h.logService.AddOtherTable(req)
+		resp, err := h.logService.AddOtherTable(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_addparserule.go
+++ b/backend/pkg/api/log/func_addparserule.go
@@ -33,7 +33,7 @@ func (h *handler) AddLogParseRule() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.AddLogParseRule(req)
+		resp, err := h.logService.AddLogParseRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_deleteothertable.go
+++ b/backend/pkg/api/log/func_deleteothertable.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteOtherTable() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.DeleteOtherTable(req)
+		resp, err := h.logService.DeleteOtherTable(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_deleteparserule.go
+++ b/backend/pkg/api/log/func_deleteparserule.go
@@ -33,7 +33,7 @@ func (h *handler) DeleteLogParseRule() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.DeleteLogParseRule(req)
+		resp, err := h.logService.DeleteLogParseRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getfaultlogcontent.go
+++ b/backend/pkg/api/log/func_getfaultlogcontent.go
@@ -35,13 +35,13 @@ func (h *handler) GetFaultLogContent() core.HandlerFunc {
 
 		// TODO GetFaultLogContentRequest's service is unused, won't check data permission
 		//userID := c.UserID()
-		//err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, "")
+		//err := h.dataService.CheckDatasourcePermission(c,userID, 0, nil, &req.ServiceName, "")
 		//if err != nil {
 		//	c.AbortWithPermissionError(err, code.AuthError)
 		//	return
 		//}
 
-		resp, err := h.logService.GetFaultLogContent(req)
+		resp, err := h.logService.GetFaultLogContent(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getfaultloglist.go
+++ b/backend/pkg/api/log/func_getfaultloglist.go
@@ -44,7 +44,7 @@ func (h *handler) GetFaultLogPageList() core.HandlerFunc {
 			req.PageSize = 10
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, req.GroupID, &req.Namespaces, &req.Service, "")
+		err := h.dataService.CheckDatasourcePermission(c, userID, req.GroupID, &req.Namespaces, &req.Service, "")
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetFaultLogPageListResponse{
 				Pagination: &model.Pagination{
@@ -56,7 +56,7 @@ func (h *handler) GetFaultLogPageList() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.logService.GetFaultLogPageList(req)
+		resp, err := h.logService.GetFaultLogPageList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getlogchart.go
+++ b/backend/pkg/api/log/func_getlogchart.go
@@ -42,7 +42,7 @@ func (h *handler) GetLogChart() core.HandlerFunc {
 		if req.LogField == "" {
 			req.LogField = "content"
 		}
-		resp, err := h.logService.GetLogChart(req)
+		resp, err := h.logService.GetLogChart(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getlogindex.go
+++ b/backend/pkg/api/log/func_getlogindex.go
@@ -42,7 +42,7 @@ func (h *handler) GetLogIndex() core.HandlerFunc {
 		if req.LogField == "" {
 			req.LogField = "content"
 		}
-		resp, err := h.logService.GetLogIndex(req)
+		resp, err := h.logService.GetLogIndex(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getlogparserule.go
+++ b/backend/pkg/api/log/func_getlogparserule.go
@@ -34,7 +34,7 @@ func (h *handler) GetLogParseRule() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.GetLogParseRule(req)
+		resp, err := h.logService.GetLogParseRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getlogtableinfo.go
+++ b/backend/pkg/api/log/func_getlogtableinfo.go
@@ -33,7 +33,7 @@ func (h *handler) GetLogTableInfo() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.GetLogTableInfo(req)
+		resp, err := h.logService.GetLogTableInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_getserviceroute.go
+++ b/backend/pkg/api/log/func_getserviceroute.go
@@ -35,14 +35,14 @@ func (h *handler) GetServiceRoute() core.HandlerFunc {
 			return
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, "")
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, "")
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetServiceRouteResponse{
 				RouteRule: map[string]string{},
 			})
 			return
 		}
-		resp, err := h.logService.GetServiceRoute(req)
+		resp, err := h.logService.GetServiceRoute(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_othertable.go
+++ b/backend/pkg/api/log/func_othertable.go
@@ -33,7 +33,7 @@ func (h *handler) OtherTable() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.OtherTable(req)
+		resp, err := h.logService.OtherTable(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_othertableinfo.go
+++ b/backend/pkg/api/log/func_othertableinfo.go
@@ -33,7 +33,7 @@ func (h *handler) OtherTableInfo() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.OtherTableInfo(req)
+		resp, err := h.logService.OtherTableInfo(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_querylog.go
+++ b/backend/pkg/api/log/func_querylog.go
@@ -48,7 +48,7 @@ func (h *handler) QueryLog() core.HandlerFunc {
 		if req.LogField == "" {
 			req.LogField = "content"
 		}
-		resp, err := h.logService.QueryLog(req)
+		resp, err := h.logService.QueryLog(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_querylogcontext.go
+++ b/backend/pkg/api/log/func_querylogcontext.go
@@ -33,7 +33,7 @@ func (h *handler) QueryLogContext() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.QueryLogContext(req)
+		resp, err := h.logService.QueryLogContext(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/func_updatelogparserule.go
+++ b/backend/pkg/api/log/func_updatelogparserule.go
@@ -33,7 +33,7 @@ func (h *handler) UpdateLogParseRule() core.HandlerFunc {
 			)
 			return
 		}
-		resp, err := h.logService.UpdateLogParseRule(req)
+		resp, err := h.logService.UpdateLogParseRule(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/log/handler.go
+++ b/backend/pkg/api/log/handler.go
@@ -107,7 +107,8 @@ func New(logger *zap.Logger, chRepo clickhouse.Repo, dbRepo database.Repo, k8sAp
 	logservice := log.New(chRepo, dbRepo, k8sApi, promRepo)
 	req := &request.LogTableRequest{}
 	req.FillerValue()
-	_, err := logservice.InitParseLogTable(req)
+
+	_, err := logservice.InitParseLogTable(nil, req)
 	if err != nil {
 		logger.Error("create default log table failed", zap.Error(err))
 	}

--- a/backend/pkg/api/network/func_getpodmap.go
+++ b/backend/pkg/api/network/func_getpodmap.go
@@ -37,7 +37,7 @@ func (h *handler) GetPodMap() core.HandlerFunc {
 			return
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, &req.Namespace, nil, "")
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, &req.Namespace, nil, "")
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, new(response.PodMapResponse))
 			return

--- a/backend/pkg/api/service/func_countk8sevents.go
+++ b/backend/pkg/api/service/func_countk8sevents.go
@@ -40,7 +40,7 @@ func (h *handler) CountK8sEvents() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetK8sEventsResponse{
 				Status:  model.STATUS_NORMAL,
@@ -49,7 +49,7 @@ func (h *handler) CountK8sEvents() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.CountK8sEvents(req)
+		resp, err := h.serviceInfoService.CountK8sEvents(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getalertevents.go
+++ b/backend/pkg/api/service/func_getalertevents.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -53,7 +52,7 @@ func (h *handler) GetAlertEvents() core.HandlerFunc {
 			req.Services = append(req.Services, req.Service)
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Services, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Services, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetAlertEventsResponse{
 				TotalCount: 0,
@@ -61,7 +60,7 @@ func (h *handler) GetAlertEvents() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetAlertEvents(req)
+		resp, err := h.serviceInfoService.GetAlertEvents(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getalerteventssample.go
+++ b/backend/pkg/api/service/func_getalerteventssample.go
@@ -49,7 +49,7 @@ func (h *handler) GetAlertEventsSample() core.HandlerFunc {
 			req.Services = append(req.Services, req.Service)
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Services, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Services, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetAlertEventsSampleResponse{
 				EventMap: map[string]map[string][]clickhouse.AlertEventSample{},
@@ -57,7 +57,7 @@ func (h *handler) GetAlertEventsSample() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetAlertEventsSample(req)
+		resp, err := h.serviceInfoService.GetAlertEventsSample(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getdescendantmetrics.go
+++ b/backend/pkg/api/service/func_getdescendantmetrics.go
@@ -43,12 +43,12 @@ func (h *handler) GetDescendantMetrics() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, nil)
 			return
 		}
-		resp, err := h.serviceInfoService.GetDescendantMetrics(req)
+		resp, err := h.serviceInfoService.GetDescendantMetrics(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getdescendantrelevance.go
+++ b/backend/pkg/api/service/func_getdescendantrelevance.go
@@ -44,12 +44,12 @@ func (h *handler) GetDescendantRelevance() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []response.GetDescendantRelevanceResponse{})
 			return
 		}
-		res, err := h.serviceInfoService.GetDescendantRelevance(req)
+		res, err := h.serviceInfoService.GetDescendantRelevance(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_geterrorinstance.go
+++ b/backend/pkg/api/service/func_geterrorinstance.go
@@ -44,7 +44,7 @@ func (h *handler) GetErrorInstance() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetErrorInstanceResponse{
 				Status:    model.STATUS_NORMAL,
@@ -52,7 +52,7 @@ func (h *handler) GetErrorInstance() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetErrorInstance(req)
+		resp, err := h.serviceInfoService.GetErrorInstance(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_geterrorinstancelogs.go
+++ b/backend/pkg/api/service/func_geterrorinstancelogs.go
@@ -45,12 +45,12 @@ func (h *handler) GetErrorInstanceLogs() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []clickhouse.FaultLogResult{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetErrorInstanceLogs(req)
+		resp, err := h.serviceInfoService.GetErrorInstanceLogs(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getloglogs.go
+++ b/backend/pkg/api/service/func_getloglogs.go
@@ -45,12 +45,12 @@ func (h *handler) GetLogLogs() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []clickhouse.FaultLogResult{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetLogLogs(req)
+		resp, err := h.serviceInfoService.GetLogLogs(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getlogmetrics.go
+++ b/backend/pkg/api/service/func_getlogmetrics.go
@@ -44,12 +44,12 @@ func (h *handler) GetLogMetrics() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []*response.GetLogMetricsResponse{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetLogMetrics(req)
+		resp, err := h.serviceInfoService.GetLogMetrics(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getnamespacelist.go
+++ b/backend/pkg/api/service/func_getnamespacelist.go
@@ -35,7 +35,7 @@ func (h *handler) GetNamespaceList() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.serviceInfoService.GetServiceNamespaceList(req)
+		resp, err := h.serviceInfoService.GetServiceNamespaceList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getpolarisinfer.go
+++ b/backend/pkg/api/service/func_getpolarisinfer.go
@@ -41,12 +41,12 @@ func (h *handler) GetPolarisInfer() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, nil)
 			return
 		}
-		res, err := h.serviceInfoService.GetPolarisInfer(req)
+		res, err := h.serviceInfoService.GetPolarisInfer(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceendpointlist.go
+++ b/backend/pkg/api/service/func_getserviceendpointlist.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -40,12 +39,12 @@ func (h *handler) GetServiceEndPointList() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []string{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetServiceEndPointList(req)
+		resp, err := h.serviceInfoService.GetServiceEndPointList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceendpointrelation.go
+++ b/backend/pkg/api/service/func_getserviceendpointrelation.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
@@ -44,7 +43,7 @@ func (h *handler) GetServiceEndpointRelation() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetServiceEndpointRelationResponse{
 				Parents:       []*model.TopologyNode{},
@@ -53,7 +52,7 @@ func (h *handler) GetServiceEndpointRelation() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetServiceEndpointRelation(req)
+		resp, err := h.serviceInfoService.GetServiceEndpointRelation(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceendpointtopology.go
+++ b/backend/pkg/api/service/func_getserviceendpointtopology.go
@@ -43,7 +43,7 @@ func (h *handler) GetServiceEndpointTopology() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetServiceEndpointTopologyResponse{
 				Parents:  []*model.TopologyNode{},
@@ -52,7 +52,7 @@ func (h *handler) GetServiceEndpointTopology() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetServiceEndpointTopology(req)
+		resp, err := h.serviceInfoService.GetServiceEndpointTopology(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceentryendpoints.go
+++ b/backend/pkg/api/service/func_getserviceentryendpoints.go
@@ -52,7 +52,7 @@ func (h *handler) GetServiceEntryEndpoints() core.HandlerFunc {
 		)
 
 		userID := c.UserID()
-		err = h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err = h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetServiceEntryEndpointsResponse{
 				Status: model.STATUS_NORMAL,
@@ -66,10 +66,10 @@ func (h *handler) GetServiceEntryEndpoints() core.HandlerFunc {
 			Status: model.STATUS_NORMAL,
 			Data:   make([]*response.EntryInstanceData, 0),
 		}
-		entryNodes, err := h.serviceInfoService.GetServiceEntryEndpoints(req)
+		entryNodes, err := h.serviceInfoService.GetServiceEntryEndpoints(c, req)
 		if err == nil {
 			// TODO defaults to global Threshold first, and then adjusts to the Threshold of specific services.
-			threshold, err = h.serviceoverviewService.GetThreshold(database.GLOBAL, "", "")
+			threshold, err = h.serviceoverviewService.GetThreshold(c, database.GLOBAL, "", "")
 		}
 		if err == nil {
 			startTime := time.UnixMicro(req.StartTime)
@@ -82,7 +82,7 @@ func (h *handler) GetServiceEntryEndpoints() core.HandlerFunc {
 					ContainsEndpointName: entryNode.Endpoint,
 					Namespace:            "",
 				}
-				endpointResps, err = h.serviceoverviewService.GetServicesEndpointDataWithChart(startTime, endTime, step, filter, request.DODThreshold)
+				endpointResps, err = h.serviceoverviewService.GetServicesEndpointDataWithChart(c, startTime, endTime, step, filter, request.DODThreshold)
 				if err == nil {
 					for _, endpointResp := range endpointResps {
 						if serviceResp, found := result[endpointResp.ServiceName]; found {
@@ -127,7 +127,7 @@ func (h *handler) GetServiceEntryEndpoints() core.HandlerFunc {
 			for serviceName := range result {
 				serviceNames = append(serviceNames, serviceName)
 			}
-			alertResps, err = h.serviceoverviewService.GetServicesAlert(startTime, endTime, step, serviceNames, nil)
+			alertResps, err = h.serviceoverviewService.GetServicesAlert(c, startTime, endTime, step, serviceNames, nil)
 			if err == nil {
 				for _, alertResp := range alertResps {
 					if serviceResp, found := result[alertResp.ServiceName]; found {

--- a/backend/pkg/api/service/func_getserviceinstance.go
+++ b/backend/pkg/api/service/func_getserviceinstance.go
@@ -43,7 +43,7 @@ func (h *handler) GetServiceInstance() core.HandlerFunc {
 			return
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.InstancesRes{
 				Status: model.STATUS_NORMAL,
@@ -60,7 +60,7 @@ func (h *handler) GetServiceInstance() core.HandlerFunc {
 		step := time.Duration(req.Step * 1000)
 		serviceName := req.ServiceName
 		endpoint := req.Endpoint
-		data, err := h.serviceInfoService.GetInstancesNew(startTime, endTime, step, serviceName, endpoint)
+		data, err := h.serviceInfoService.GetInstancesNew(c, startTime, endTime, step, serviceName, endpoint)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceinstanceinfolist.go
+++ b/backend/pkg/api/service/func_getserviceinstanceinfolist.go
@@ -41,12 +41,12 @@ func (h *handler) GetServiceInstanceInfoList() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []prometheus.InstanceKey{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetServiceInstanceInfoList(req)
+		resp, err := h.serviceInfoService.GetServiceInstanceInfoList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceinstancelist.go
+++ b/backend/pkg/api/service/func_getserviceinstancelist.go
@@ -38,7 +38,7 @@ func (h *handler) GetServiceInstanceList() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.serviceInfoService.GetServiceInstanceList(req)
+		resp, err := h.serviceInfoService.GetServiceInstanceList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceinstanceoptions.go
+++ b/backend/pkg/api/service/func_getserviceinstanceoptions.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -40,12 +39,12 @@ func (h *handler) GetServiceInstanceOptions() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, make(map[string]*model.ServiceInstance))
 			return
 		}
-		resp, err := h.serviceInfoService.GetServiceInstanceOptions(req)
+		resp, err := h.serviceInfoService.GetServiceInstanceOptions(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getservicelist.go
+++ b/backend/pkg/api/service/func_getservicelist.go
@@ -36,7 +36,7 @@ func (h *handler) GetServiceList() core.HandlerFunc {
 			return
 		}
 
-		resp, err := h.serviceInfoService.GetServiceList(req)
+		resp, err := h.serviceInfoService.GetServiceList(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getserviceredcharts.go
+++ b/backend/pkg/api/service/func_getserviceredcharts.go
@@ -37,11 +37,11 @@ func (h *handler) GetServiceREDCharts() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceList, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceList, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, response.GetServiceREDChartsResponse{})
 		}
-		resp, err := h.serviceInfoService.GetServiceREDCharts(req)
+		resp, err := h.serviceInfoService.GetServiceREDCharts(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_getsqlmetrics.go
+++ b/backend/pkg/api/service/func_getsqlmetrics.go
@@ -43,7 +43,7 @@ func (h *handler) GetSQLMetrics() core.HandlerFunc {
 			return
 		}
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, &response.GetSQLMetricsResponse{
 				Pagination: model.Pagination{
@@ -55,7 +55,7 @@ func (h *handler) GetSQLMetrics() core.HandlerFunc {
 			})
 			return
 		}
-		resp, err := h.serviceInfoService.GetSQLMetrics(req)
+		resp, err := h.serviceInfoService.GetSQLMetrics(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_gettracelogs.go
+++ b/backend/pkg/api/service/func_gettracelogs.go
@@ -45,12 +45,12 @@ func (h *handler) GetTraceLogs() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []clickhouse.FaultLogResult{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetTraceLogs(req)
+		resp, err := h.serviceInfoService.GetTraceLogs(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/service/func_gettracemetrics.go
+++ b/backend/pkg/api/service/func_gettracemetrics.go
@@ -44,12 +44,12 @@ func (h *handler) GetTraceMetrics() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.Service, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []response.GetTraceMetricsResponse{})
 			return
 		}
-		resp, err := h.serviceInfoService.GetTraceMetrics(req)
+		resp, err := h.serviceInfoService.GetTraceMetrics(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getendpointsdata.go
+++ b/backend/pkg/api/serviceoverview/func_getendpointsdata.go
@@ -54,7 +54,7 @@ func (h *handler) GetEndPointsData() core.HandlerFunc {
 		step := time.Duration(req.Step * 1000)
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, req.GroupID, &req.Namespace, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, req.GroupID, &req.Namespace, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []response.ServiceEndPointsRes{})
 			return
@@ -65,7 +65,7 @@ func (h *handler) GetEndPointsData() core.HandlerFunc {
 			MultiEndpoint:  req.EndpointName,
 			MultiNamespace: req.Namespace,
 		}
-		data, err = h.serviceoverview.GetServicesEndPointData(startTime, endTime, step, filter, req.SortRule)
+		data, err = h.serviceoverview.GetServicesEndPointData(c, startTime, endTime, step, filter, req.SortRule)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getmonitorstatus.go
+++ b/backend/pkg/api/serviceoverview/func_getmonitorstatus.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -39,7 +38,7 @@ func (h *handler) GetMonitorStatus() core.HandlerFunc {
 		startTime := time.UnixMicro(req.StartTime)
 		endTime := time.UnixMicro(req.EndTime)
 
-		resp, err := h.serviceoverview.GetMonitorStatus(startTime, endTime)
+		resp, err := h.serviceoverview.GetMonitorStatus(c, startTime, endTime)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getryglight.go
+++ b/backend/pkg/api/serviceoverview/func_getryglight.go
@@ -44,7 +44,7 @@ func (h *handler) GetRYGLight() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, &req.Namespace, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, &req.Namespace, &req.ServiceName, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, response.ServiceRYGLightRes{
 				ServiceList: []*response.ServiceRYGResult{},
@@ -59,7 +59,7 @@ func (h *handler) GetRYGLight() core.HandlerFunc {
 			Namespace:            req.Namespace,
 		}
 
-		resp, err := h.serviceoverview.GetServicesRYGLightStatus(startTime, endTime, filter)
+		resp, err := h.serviceoverview.GetServicesRYGLightStatus(c, startTime, endTime, filter)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getservicemoreurllist.go
+++ b/backend/pkg/api/serviceoverview/func_getservicemoreurllist.go
@@ -50,7 +50,7 @@ func (h *handler) GetServiceMoreUrlList() core.HandlerFunc {
 		//step := time.Minute
 		serviceName := req.ServiceName
 		var res []response.ServiceDetail
-		data, err := h.serviceoverview.GetServiceMoreUrl(startTime, endTime, step, serviceName, req.SortRule)
+		data, err := h.serviceoverview.GetServiceMoreUrl(c, startTime, endTime, step, serviceName, req.SortRule)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getservicesalert.go
+++ b/backend/pkg/api/serviceoverview/func_getservicesalert.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	"github.com/CloudDetail/apo/backend/pkg/core"
-
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -46,7 +45,7 @@ func (h *handler) GetServicesAlert() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, 0, nil, &req.ServiceNames, model.DATASOURCE_CATEGORY_APM)
+		err := h.dataService.CheckDatasourcePermission(c, userID, 0, nil, &req.ServiceNames, model.DATASOURCE_CATEGORY_APM)
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, []response.ServiceAlertRes{})
 			return
@@ -61,7 +60,7 @@ func (h *handler) GetServicesAlert() core.HandlerFunc {
 		serviceNames := req.ServiceNames
 		returnData := req.ReturnData
 		var resp []response.ServiceAlertRes
-		data, err := h.serviceoverview.GetServicesAlert(startTime, endTime, step, serviceNames, returnData)
+		data, err := h.serviceoverview.GetServicesAlert(c, startTime, endTime, step, serviceNames, returnData)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_getthreshold.go
+++ b/backend/pkg/api/serviceoverview/func_getthreshold.go
@@ -39,7 +39,7 @@ func (h *handler) GetThreshold() core.HandlerFunc {
 		serviceName := req.ServiceName
 		endPoint := req.Endpoint
 		level := req.Level
-		resp, err := h.serviceoverview.GetThreshold(level, serviceName, endPoint)
+		resp, err := h.serviceoverview.GetThreshold(c, level, serviceName, endPoint)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/serviceoverview/func_setthreshold.go
+++ b/backend/pkg/api/serviceoverview/func_setthreshold.go
@@ -47,7 +47,7 @@ func (h *handler) SetThreshold() core.HandlerFunc {
 		errorRate := req.ErrorRate
 		tps := req.Tps
 		log := req.Log
-		resp, err := h.serviceoverview.SetThreshold(level, serviceName, endpoint, latency, errorRate, tps, log)
+		resp, err := h.serviceoverview.SetThreshold(c, level, serviceName, endpoint, latency, errorRate, tps, log)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/api/trace/func_gettracepagelist.go
+++ b/backend/pkg/api/trace/func_gettracepagelist.go
@@ -38,7 +38,7 @@ func (h *handler) GetTracePageList() core.HandlerFunc {
 		}
 
 		userID := c.UserID()
-		err := h.dataService.CheckDatasourcePermission(userID, req.GroupID, &req.Namespace, &req.Service, "")
+		err := h.dataService.CheckDatasourcePermission(c, userID, req.GroupID, &req.Namespace, &req.Service, "")
 		if err != nil {
 			c.AbortWithPermissionError(err, code.AuthError, response.GetTracePageListResponse{
 				List: []clickhouse.QueryTraceResult{},

--- a/backend/pkg/services/data/datasource_permission_test.go
+++ b/backend/pkg/services/data/datasource_permission_test.go
@@ -64,7 +64,7 @@ func TestDataSourcePermission(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = s.CheckDatasourcePermission(anonymousUser.UserID, 0, &namespaceList, nil, model.DATASOURCE_CATEGORY_APM)
+	err = s.CheckDatasourcePermission(nil, anonymousUser.UserID, 0, &namespaceList, nil, model.DATASOURCE_CATEGORY_APM)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/pkg/services/data/service.go
+++ b/backend/pkg/services/data/service.go
@@ -4,6 +4,7 @@
 package data
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -12,18 +13,18 @@ import (
 )
 
 type Service interface {
-	GetDataSource() (response.GetDatasourceResponse, error)
-	CreateDataGroup(req *request.CreateDataGroupRequest) error
-	DeleteDataGroup(req *request.DeleteDataGroupRequest) error
-	GetDataGroup(req *request.GetDataGroupRequest) (response.GetDataGroupResponse, error)
-	UpdateDataGroup(req *request.UpdateDataGroupRequest) error
-	GetGroupDatasource(req *request.GetGroupDatasourceRequest, userID int64) (response.GetGroupDatasourceResponse, error)
-	DataGroupOperation(req *request.DataGroupOperationRequest) error
-	GetSubjectDataGroup(req *request.GetSubjectDataGroupRequest) (response.GetSubjectDataGroupResponse, error)
+	GetDataSource(ctx core.Context) (response.GetDatasourceResponse, error)
+	CreateDataGroup(ctx core.Context, req *request.CreateDataGroupRequest) error
+	DeleteDataGroup(ctx core.Context, req *request.DeleteDataGroupRequest) error
+	GetDataGroup(ctx core.Context, req *request.GetDataGroupRequest) (response.GetDataGroupResponse, error)
+	UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroupRequest) error
+	GetGroupDatasource(ctx core.Context, req *request.GetGroupDatasourceRequest, userID int64) (response.GetGroupDatasourceResponse, error)
+	DataGroupOperation(ctx core.Context, req *request.DataGroupOperationRequest) error
+	GetSubjectDataGroup(ctx core.Context, req *request.GetSubjectDataGroupRequest) (response.GetSubjectDataGroupResponse, error)
 	// CheckDatasourcePermission Filtering and filling data sources that users are not authorised to view. Expected *string or *[]string.
-	CheckDatasourcePermission(userID, groupID int64, namespaces, services interface{}, fillCategory string) (err error)
-	GroupSubsOperation(req *request.GroupSubsOperationRequest) error
-	GetGroupSubs(req *request.GetGroupSubsRequest) (response.GetGroupSubsResponse, error)
+	CheckDatasourcePermission(ctx core.Context, userID, groupID int64, namespaces, services interface{}, fillCategory string) (err error)
+	GroupSubsOperation(ctx core.Context, req *request.GroupSubsOperationRequest) error
+	GetGroupSubs(ctx core.Context, req *request.GetGroupSubsRequest) (response.GetGroupSubsResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/data/service_check_datasource_permission.go
+++ b/backend/pkg/services/data/service_check_datasource_permission.go
@@ -8,12 +8,12 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) CheckDatasourcePermission(userID, groupID int64, namespaces, services interface{}, fillCategory string) (err error) {
+func (s *service) CheckDatasourcePermission(ctx core.Context, userID, groupID int64, namespaces, services interface{}, fillCategory string) (err error) {
 	var (
 		namespaceMap    = map[string]bool{}     // mapped all namespaces user can view
 		serviceMap      = map[string]struct{}{} // mapped all services user can view
@@ -47,14 +47,14 @@ func (s *service) CheckDatasourcePermission(userID, groupID int64, namespaces, s
 			return err
 		}
 	} else {
-		groups, err = s.getUserDataGroup(userID, fillCategory)
+		groups, err = s.getUserDataGroup(ctx, userID, fillCategory)
 		if err != nil {
 			return err
 		}
 	}
 
 	if len(groups) == 0 {
-		defaultGroup, err := s.getDefaultDataGroup(fillCategory)
+		defaultGroup, err := s.getDefaultDataGroup(ctx, fillCategory)
 		if err != nil {
 			return err
 		}

--- a/backend/pkg/services/data/service_data_group.go
+++ b/backend/pkg/services/data/service_data_group.go
@@ -7,7 +7,7 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -15,7 +15,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/util"
 )
 
-func (s *service) CreateDataGroup(req *request.CreateDataGroupRequest) error {
+func (s *service) CreateDataGroup(ctx core.Context, req *request.CreateDataGroupRequest) error {
 	filter := model.DataGroupFilter{
 		Name: req.GroupName,
 	}
@@ -44,7 +44,7 @@ func (s *service) CreateDataGroup(req *request.CreateDataGroupRequest) error {
 	return s.dbRepo.Transaction(context.Background(), createGroupFunc, createDSGroupFunc)
 }
 
-func (s *service) DeleteDataGroup(req *request.DeleteDataGroupRequest) error {
+func (s *service) DeleteDataGroup(ctx core.Context, req *request.DeleteDataGroupRequest) error {
 	filter := model.DataGroupFilter{
 		ID: req.GroupID,
 	}
@@ -68,7 +68,7 @@ func (s *service) DeleteDataGroup(req *request.DeleteDataGroupRequest) error {
 	return s.dbRepo.Transaction(context.Background(), deleteDSGroupFunc, deleteGroupFunc)
 }
 
-func (s *service) UpdateDataGroup(req *request.UpdateDataGroupRequest) error {
+func (s *service) UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroupRequest) error {
 	idFilter := model.DataGroupFilter{
 		ID: req.GroupID,
 	}
@@ -104,7 +104,7 @@ func (s *service) UpdateDataGroup(req *request.UpdateDataGroupRequest) error {
 	}
 
 	// 2. Get all datasource
-	datasource, err := s.GetDataSource()
+	datasource, err := s.GetDataSource(ctx)
 	if err != nil {
 		return err
 	}
@@ -156,7 +156,7 @@ func (s *service) UpdateDataGroup(req *request.UpdateDataGroupRequest) error {
 	return s.dbRepo.Transaction(context.Background(), updateNameFunc, assignFunc, retrieveFunc)
 }
 
-func (s *service) GetDataGroup(req *request.GetDataGroupRequest) (resp response.GetDataGroupResponse, err error) {
+func (s *service) GetDataGroup(ctx core.Context, req *request.GetDataGroupRequest) (resp response.GetDataGroupResponse, err error) {
 	filter := model.DataGroupFilter{
 		Name:           req.GroupName,
 		PageSize:       &req.PageSize,

--- a/backend/pkg/services/data/service_data_group_operation.go
+++ b/backend/pkg/services/data/service_data_group_operation.go
@@ -7,12 +7,12 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) DataGroupOperation(req *request.DataGroupOperationRequest) error {
+func (s *service) DataGroupOperation(ctx core.Context, req *request.DataGroupOperationRequest) error {
 	var exists bool
 	var err error
 	switch req.SubjectType {

--- a/backend/pkg/services/data/service_datasource.go
+++ b/backend/pkg/services/data/service_datasource.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -18,7 +18,7 @@ import (
 
 var subTime = -time.Hour * 24 * 15
 
-func (s *service) GetDataSource() (resp response.GetDatasourceResponse, err error) {
+func (s *service) GetDataSource(ctx core.Context) (resp response.GetDatasourceResponse, err error) {
 	var (
 		endTime        = time.Now()
 		startTime      = endTime.Add(subTime)
@@ -96,7 +96,7 @@ func (s *service) GetDataSource() (resp response.GetDatasourceResponse, err erro
 	return resp, nil
 }
 
-func (s *service) GetGroupDatasource(req *request.GetGroupDatasourceRequest, userID int64) (response.GetGroupDatasourceResponse, error) {
+func (s *service) GetGroupDatasource(ctx core.Context, req *request.GetGroupDatasourceRequest, userID int64) (response.GetGroupDatasourceResponse, error) {
 	var (
 		groups       []database.DataGroup
 		err          error
@@ -108,13 +108,13 @@ func (s *service) GetGroupDatasource(req *request.GetGroupDatasourceRequest, use
 		startTime    = endTime.Add(subTime)
 	)
 	if req.GroupID != 0 {
-		groups, err = s.getDataGroup(req.GroupID, req.Category)
+		groups, err = s.getDataGroup(ctx, req.GroupID, req.Category)
 	} else {
-		groups, err = s.getUserDataGroup(userID, req.Category)
+		groups, err = s.getUserDataGroup(ctx, userID, req.Category)
 	}
 
 	if len(groups) == 0 {
-		defaultGroup, err := s.getDefaultDataGroup(req.Category)
+		defaultGroup, err := s.getDefaultDataGroup(ctx, req.Category)
 		if err != nil {
 			return resp, err
 		}
@@ -194,7 +194,7 @@ func (s *service) getNested(datasource string, typ string) ([]string, error) {
 	return nested, err
 }
 
-func (s *service) getDataGroup(groupID int64, category string) ([]database.DataGroup, error) {
+func (s *service) getDataGroup(ctx core.Context, groupID int64, category string) ([]database.DataGroup, error) {
 	filter := model.DataGroupFilter{
 		ID: groupID,
 	}

--- a/backend/pkg/services/data/service_get_group_subs.go
+++ b/backend/pkg/services/data/service_get_group_subs.go
@@ -4,12 +4,13 @@
 package data
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetGroupSubs(req *request.GetGroupSubsRequest) (response.GetGroupSubsResponse, error) {
+func (s *service) GetGroupSubs(ctx core.Context, req *request.GetGroupSubsRequest) (response.GetGroupSubsResponse, error) {
 	var (
 		resp response.GetGroupSubsResponse
 		err  error

--- a/backend/pkg/services/data/service_get_subject_data_group.go
+++ b/backend/pkg/services/data/service_get_subject_data_group.go
@@ -4,22 +4,23 @@
 package data
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) GetSubjectDataGroup(req *request.GetSubjectDataGroupRequest) (response.GetSubjectDataGroupResponse, error) {
+func (s *service) GetSubjectDataGroup(ctx core.Context, req *request.GetSubjectDataGroupRequest) (response.GetSubjectDataGroupResponse, error) {
 	if req.SubjectType == model.DATA_GROUP_SUB_TYP_TEAM {
 		return s.dbRepo.GetSubjectDataGroupList(req.SubjectID, req.SubjectType, req.Category)
 	}
 
-	return s.getUserDataGroup(req.SubjectID, req.Category)
+	return s.getUserDataGroup(ctx, req.SubjectID, req.Category)
 }
 
 // getUserDataGroup Get user's data group or default data group.
-func (s *service) getUserDataGroup(userID int64, category string) ([]database.DataGroup, error) {
+func (s *service) getUserDataGroup(ctx core.Context, userID int64, category string) ([]database.DataGroup, error) {
 	teamIDs, err := s.dbRepo.GetUserTeams(userID)
 	if err != nil {
 		return nil, err
@@ -62,13 +63,13 @@ func (s *service) getUserDataGroup(userID int64, category string) ([]database.Da
 	return groups, nil
 }
 
-func (s *service) getDefaultDataGroup(category string) (database.DataGroup, error) {
+func (s *service) getDefaultDataGroup(ctx core.Context, category string) (database.DataGroup, error) {
 	defaultGroup := database.DataGroup{
 		GroupName: "default",
 		Source:    model.DATA_GROUP_SOURCE_DEFAULT,
 	}
 
-	datasource, err := s.GetDataSource()
+	datasource, err := s.GetDataSource(ctx)
 	if err != nil {
 		return defaultGroup, err
 	}

--- a/backend/pkg/services/data/service_group_subs_operation.go
+++ b/backend/pkg/services/data/service_group_subs_operation.go
@@ -7,13 +7,13 @@ import (
 	"context"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) GroupSubsOperation(req *request.GroupSubsOperationRequest) error {
+func (s *service) GroupSubsOperation(ctx core.Context, req *request.GroupSubsOperationRequest) error {
 	var (
 		toDelete []int64
 		toAdd    []database.AuthDataGroup

--- a/backend/pkg/services/k8s/service.go
+++ b/backend/pkg/services/k8s/service.go
@@ -4,16 +4,17 @@
 package k8s
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/kubernetes"
 )
 
 type Service interface {
-	GetNamespaceList() (*response.GetNamespaceListResponse, error)
-	GetNamespaceInfo(req *request.GetNamespaceInfoRequest) (*response.GetNamespaceInfoResponse, error)
-	GetPodList(req *request.GetPodListRequest) (*response.GetPodListResponse, error)
-	GetPodInfo(req *request.GetPodInfoRequest) (*response.GetPodInfoResponse, error)
+	GetNamespaceList(ctx core.Context) (*response.GetNamespaceListResponse, error)
+	GetNamespaceInfo(ctx core.Context, req *request.GetNamespaceInfoRequest) (*response.GetNamespaceInfoResponse, error)
+	GetPodList(ctx core.Context, req *request.GetPodListRequest) (*response.GetPodListResponse, error)
+	GetPodInfo(ctx core.Context, req *request.GetPodInfoRequest) (*response.GetPodInfoResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/k8s/service_get_namespace.go
+++ b/backend/pkg/services/k8s/service_get_namespace.go
@@ -4,11 +4,12 @@
 package k8s
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s service) GetNamespaceList() (*response.GetNamespaceListResponse, error) {
+func (s service) GetNamespaceList(ctx core.Context) (*response.GetNamespaceListResponse, error) {
 	list, err := s.k8sRepo.GetNamespaceList()
 	if err != nil {
 		return nil, err
@@ -18,7 +19,7 @@ func (s service) GetNamespaceList() (*response.GetNamespaceListResponse, error) 
 	}, nil
 }
 
-func (s service) GetNamespaceInfo(req *request.GetNamespaceInfoRequest) (*response.GetNamespaceInfoResponse, error) {
+func (s service) GetNamespaceInfo(ctx core.Context, req *request.GetNamespaceInfoRequest) (*response.GetNamespaceInfoResponse, error) {
 	info, err := s.k8sRepo.GetNamespaceInfo(req.Namespace)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/k8s/servie_get_pod.go
+++ b/backend/pkg/services/k8s/servie_get_pod.go
@@ -4,11 +4,12 @@
 package k8s
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s service) GetPodList(req *request.GetPodListRequest) (*response.GetPodListResponse, error) {
+func (s service) GetPodList(ctx core.Context, req *request.GetPodListRequest) (*response.GetPodListResponse, error) {
 	list, err := s.k8sRepo.GetPodList(req.Namespace)
 	if err != nil {
 		return nil, err
@@ -18,7 +19,7 @@ func (s service) GetPodList(req *request.GetPodListRequest) (*response.GetPodLis
 	}, nil
 }
 
-func (s service) GetPodInfo(req *request.GetPodInfoRequest) (*response.GetPodInfoResponse, error) {
+func (s service) GetPodInfo(ctx core.Context, req *request.GetPodInfoRequest) (*response.GetPodInfoResponse, error) {
 	info, err := s.k8sRepo.GetPodInfo(req.Namespace, req.Pod)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/log/service.go
+++ b/backend/pkg/services/log/service.go
@@ -4,6 +4,7 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
@@ -16,44 +17,44 @@ var _ Service = (*service)(nil)
 
 type Service interface {
 	// Get fault site paging log
-	GetFaultLogPageList(req *request.GetFaultLogPageListRequest) (*response.GetFaultLogPageListResponse, error)
+	GetFaultLogPageList(ctx core.Context, req *request.GetFaultLogPageListRequest) (*response.GetFaultLogPageListResponse, error)
 
-	GetFaultLogContent(req *request.GetFaultLogContentRequest) (*response.GetFaultLogContentResponse, error)
+	GetFaultLogContent(ctx core.Context, req *request.GetFaultLogContentRequest) (*response.GetFaultLogContentResponse, error)
 
-	InitParseLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error)
+	InitParseLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error)
 
-	DropLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error)
+	DropLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error)
 
-	UpdateLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error)
+	UpdateLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error)
 
-	GetLogTableInfo(req *request.LogTableInfoRequest) (*response.LogTableInfoResponse, error)
+	GetLogTableInfo(ctx core.Context, req *request.LogTableInfoRequest) (*response.LogTableInfoResponse, error)
 
 	// Query full logs
-	QueryLog(req *request.LogQueryRequest) (*response.LogQueryResponse, error)
+	QueryLog(ctx core.Context, req *request.LogQueryRequest) (*response.LogQueryResponse, error)
 
-	QueryLogContext(req *request.LogQueryContextRequest) (*response.LogQueryContextResponse, error)
+	QueryLogContext(ctx core.Context, req *request.LogQueryContextRequest) (*response.LogQueryContextResponse, error)
 	// Log Trend Chart
-	GetLogChart(req *request.LogQueryRequest) (*response.LogChartResponse, error)
+	GetLogChart(ctx core.Context, req *request.LogQueryRequest) (*response.LogChartResponse, error)
 	// Field Analysis
-	GetLogIndex(req *request.LogIndexRequest) (*response.LogIndexResponse, error)
+	GetLogIndex(ctx core.Context, req *request.LogIndexRequest) (*response.LogIndexResponse, error)
 
-	GetServiceRoute(req *request.GetServiceRouteRequest) (*response.GetServiceRouteResponse, error)
+	GetServiceRoute(ctx core.Context, req *request.GetServiceRouteRequest) (*response.GetServiceRouteResponse, error)
 
-	GetLogParseRule(req *request.QueryLogParseRequest) (*response.LogParseResponse, error)
+	GetLogParseRule(ctx core.Context, req *request.QueryLogParseRequest) (*response.LogParseResponse, error)
 
-	UpdateLogParseRule(req *request.UpdateLogParseRequest) (*response.LogParseResponse, error)
+	UpdateLogParseRule(ctx core.Context, req *request.UpdateLogParseRequest) (*response.LogParseResponse, error)
 
-	AddLogParseRule(req *request.AddLogParseRequest) (*response.LogParseResponse, error)
+	AddLogParseRule(ctx core.Context, req *request.AddLogParseRequest) (*response.LogParseResponse, error)
 
-	DeleteLogParseRule(req *request.DeleteLogParseRequest) (*response.LogParseResponse, error)
+	DeleteLogParseRule(ctx core.Context, req *request.DeleteLogParseRequest) (*response.LogParseResponse, error)
 
-	OtherTable(req *request.OtherTableRequest) (*response.OtherTableResponse, error)
+	OtherTable(ctx core.Context, req *request.OtherTableRequest) (*response.OtherTableResponse, error)
 
-	OtherTableInfo(req *request.OtherTableInfoRequest) (*response.OtherTableInfoResponse, error)
+	OtherTableInfo(ctx core.Context, req *request.OtherTableInfoRequest) (*response.OtherTableInfoResponse, error)
 
-	AddOtherTable(req *request.AddOtherTableRequest) (*response.AddOtherTableResponse, error)
+	AddOtherTable(ctx core.Context, req *request.AddOtherTableRequest) (*response.AddOtherTableResponse, error)
 
-	DeleteOtherTable(req *request.DeleteOtherTableRequest) (*response.DeleteOtherTableResponse, error)
+	DeleteOtherTable(ctx core.Context, req *request.DeleteOtherTableRequest) (*response.DeleteOtherTableResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/log/service_add_log_parse_rule.go
+++ b/backend/pkg/services/log/service_add_log_parse_rule.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -33,7 +34,7 @@ func getRouteRule(routeMap map[string]string) string {
 
 var fieldsRegexp = regexp.MustCompile(`\?P<(?P<name>\w+)>`)
 
-func (s *service) AddLogParseRule(req *request.AddLogParseRequest) (*response.LogParseResponse, error) {
+func (s *service) AddLogParseRule(ctx core.Context, req *request.AddLogParseRequest) (*response.LogParseResponse, error) {
 	// build the table first
 	logReq := &request.LogTableRequest{
 		TableName: "logs_" + req.ParseName,

--- a/backend/pkg/services/log/service_add_other_table.go
+++ b/backend/pkg/services/log/service_add_other_table.go
@@ -4,12 +4,13 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) AddOtherTable(req *request.AddOtherTableRequest) (*response.AddOtherTableResponse, error) {
+func (s *service) AddOtherTable(ctx core.Context, req *request.AddOtherTableRequest) (*response.AddOtherTableResponse, error) {
 	res := &response.AddOtherTableResponse{}
 	model := &database.OtherLogTable{
 		Cluster:   req.Cluster,

--- a/backend/pkg/services/log/service_delete_log_parse_rule.go
+++ b/backend/pkg/services/log/service_delete_log_parse_rule.go
@@ -4,6 +4,7 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -11,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func (s *service) DeleteLogParseRule(req *request.DeleteLogParseRequest) (*response.LogParseResponse, error) {
+func (s *service) DeleteLogParseRule(ctx core.Context, req *request.DeleteLogParseRequest) (*response.LogParseResponse, error) {
 	logReq := &request.LogTableRequest{
 		TableName: req.TableName,
 		DataBase:  req.DataBase,

--- a/backend/pkg/services/log/service_delete_other_table.go
+++ b/backend/pkg/services/log/service_delete_other_table.go
@@ -4,12 +4,13 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) DeleteOtherTable(req *request.DeleteOtherTableRequest) (*response.DeleteOtherTableResponse, error) {
+func (s *service) DeleteOtherTable(ctx core.Context, req *request.DeleteOtherTableRequest) (*response.DeleteOtherTableResponse, error) {
 	res := &response.DeleteOtherTableResponse{}
 	model := &database.OtherLogTable{
 		DataBase: req.DataBase,

--- a/backend/pkg/services/log/service_get_fault_log_contents.go
+++ b/backend/pkg/services/log/service_get_fault_log_contents.go
@@ -4,12 +4,13 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
 // GetFaultLogContent implements Service.
-func (s *service) GetFaultLogContent(req *request.GetFaultLogContentRequest) (*response.GetFaultLogContentResponse, error) {
+func (s *service) GetFaultLogContent(ctx core.Context, req *request.GetFaultLogContentRequest) (*response.GetFaultLogContentResponse, error) {
 	logContest, sources, err := s.chRepo.QueryApplicationLogs(req)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/log/service_get_fault_log_page_list.go
+++ b/backend/pkg/services/log/service_get_fault_log_page_list.go
@@ -4,13 +4,14 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetFaultLogPageList(req *request.GetFaultLogPageListRequest) (*response.GetFaultLogPageListResponse, error) {
+func (s *service) GetFaultLogPageList(ctx core.Context, req *request.GetFaultLogPageListRequest) (*response.GetFaultLogPageListResponse, error) {
 	// Paging query fault site logs
 	query := &clickhouse.FaultLogQuery{
 		StartTime:      req.StartTime,

--- a/backend/pkg/services/log/service_get_log_chart.go
+++ b/backend/pkg/services/log/service_get_log_chart.go
@@ -7,13 +7,14 @@ import (
 	"sort"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
 const SecondToMirco = 1000000
 
-func (s *service) getChart(req *request.LogQueryRequest) (*response.LogChartResponse, error) {
+func (s *service) getChart(ctx core.Context, req *request.LogQueryRequest) (*response.LogChartResponse, error) {
 	res := &response.LogChartResponse{}
 	rows, interval, err := s.chRepo.GetLogChart(req)
 	if err != nil {
@@ -134,6 +135,6 @@ func (s *service) getChart(req *request.LogQueryRequest) (*response.LogChartResp
 	return res, nil
 }
 
-func (s *service) GetLogChart(req *request.LogQueryRequest) (*response.LogChartResponse, error) {
-	return s.getChart(req)
+func (s *service) GetLogChart(ctx core.Context, req *request.LogQueryRequest) (*response.LogChartResponse, error) {
+	return s.getChart(ctx, req)
 }

--- a/backend/pkg/services/log/service_get_log_parse_rule.go
+++ b/backend/pkg/services/log/service_get_log_parse_rule.go
@@ -6,10 +6,12 @@ package log
 import (
 	"encoding/json"
 	"errors"
-	"gorm.io/gorm"
 	"regexp"
 	"strings"
 
+	"gorm.io/gorm"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -41,7 +43,7 @@ func getRouteRuleMap(routeRule string) map[string]string {
 	return rc
 }
 
-func (s *service) GetLogParseRule(req *request.QueryLogParseRequest) (*response.LogParseResponse, error) {
+func (s *service) GetLogParseRule(ctx core.Context, req *request.QueryLogParseRequest) (*response.LogParseResponse, error) {
 	model := &database.LogTableInfo{
 		DataBase: req.DataBase,
 		Table:    req.TableName,

--- a/backend/pkg/services/log/service_get_log_table_info.go
+++ b/backend/pkg/services/log/service_get_log_table_info.go
@@ -4,11 +4,12 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetLogTableInfo(req *request.LogTableInfoRequest) (*response.LogTableInfoResponse, error) {
+func (s *service) GetLogTableInfo(ctx core.Context, req *request.LogTableInfoRequest) (*response.LogTableInfoResponse, error) {
 	rows, err := s.dbRepo.GetAllLogTable()
 	res := &response.LogTableInfoResponse{}
 	if err != nil {

--- a/backend/pkg/services/log/service_get_service_route.go
+++ b/backend/pkg/services/log/service_get_service_route.go
@@ -7,11 +7,12 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetServiceRoute(req *request.GetServiceRouteRequest) (*response.GetServiceRouteResponse, error) {
+func (s *service) GetServiceRoute(ctx core.Context, req *request.GetServiceRouteRequest) (*response.GetServiceRouteResponse, error) {
 	serviceNames := []string{}
 	now := time.Now()
 	currentTimestamp := now.UnixMicro()

--- a/backend/pkg/services/log/service_log_index.go
+++ b/backend/pkg/services/log/service_log_index.go
@@ -6,11 +6,12 @@ package log
 import (
 	"sort"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetLogIndex(req *request.LogIndexRequest) (*response.LogIndexResponse, error) {
+func (s *service) GetLogIndex(ctx core.Context, req *request.LogIndexRequest) (*response.LogIndexResponse, error) {
 	res := &response.LogIndexResponse{}
 	list, sum, err := s.chRepo.GetLogIndex(req)
 	if err != nil {

--- a/backend/pkg/services/log/service_log_table.go
+++ b/backend/pkg/services/log/service_log_table.go
@@ -6,6 +6,7 @@ package log
 import (
 	"encoding/json"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -27,7 +28,7 @@ var defaultRouteRuleMap = map[string]string{
 	"k8s.pod.name": "apo",
 }
 
-func (s *service) InitParseLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error) {
+func (s *service) InitParseLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error) {
 	sqls, err := s.chRepo.CreateLogTable(req)
 	res := &response.LogTableResponse{Sqls: sqls}
 	if err != nil {
@@ -62,7 +63,7 @@ func (s *service) InitParseLogTable(req *request.LogTableRequest) (*response.Log
 	return res, nil
 }
 
-func (s *service) DropLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error) {
+func (s *service) DropLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error) {
 
 	sqls, err := s.chRepo.DropLogTable(req)
 	res := &response.LogTableResponse{Sqls: sqls}
@@ -82,7 +83,7 @@ func (s *service) DropLogTable(req *request.LogTableRequest) (*response.LogTable
 	return res, nil
 }
 
-func (s *service) UpdateLogTable(req *request.LogTableRequest) (*response.LogTableResponse, error) {
+func (s *service) UpdateLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error) {
 	res := &response.LogTableResponse{}
 	logtable := &database.LogTableInfo{
 		Cluster:  req.Cluster,

--- a/backend/pkg/services/log/service_other_log.go
+++ b/backend/pkg/services/log/service_other_log.go
@@ -4,11 +4,12 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) OtherTable(req *request.OtherTableRequest) (*response.OtherTableResponse, error) {
+func (s *service) OtherTable(ctx core.Context, req *request.OtherTableRequest) (*response.OtherTableResponse, error) {
 	res := &response.OtherTableResponse{}
 	rows, err := s.chRepo.OtherLogTable()
 	if err != nil {

--- a/backend/pkg/services/log/service_other_log_info.go
+++ b/backend/pkg/services/log/service_other_log_info.go
@@ -4,11 +4,12 @@
 package log
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) OtherTableInfo(req *request.OtherTableInfoRequest) (*response.OtherTableInfoResponse, error) {
+func (s *service) OtherTableInfo(ctx core.Context, req *request.OtherTableInfoRequest) (*response.OtherTableInfoResponse, error) {
 	res := &response.OtherTableInfoResponse{}
 	rows, err := s.chRepo.OtherLogTableInfo(req)
 	if err != nil {

--- a/backend/pkg/services/log/service_query_log.go
+++ b/backend/pkg/services/log/service_query_log.go
@@ -8,16 +8,17 @@ import (
 	"errors"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) QueryLog(req *request.LogQueryRequest) (*response.LogQueryResponse, error) {
+func (s *service) QueryLog(ctx core.Context, req *request.LogQueryRequest) (*response.LogQueryResponse, error) {
 	// calculate offset, if offset > 10000, calculate from histogram
 	offset := (req.PageNum - 1) * req.PageSize
 	if offset > 10000 {
-		logcharts, _ := s.GetLogChart(req)
+		logcharts, _ := s.GetLogChart(ctx, req)
 		var count = 0
 		for _, chart := range logcharts.Histograms {
 			count += int(chart.Count)

--- a/backend/pkg/services/log/service_query_log_context.go
+++ b/backend/pkg/services/log/service_query_log_context.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -54,7 +55,7 @@ func log2item(logs []map[string]any, logFields map[string]interface{}) ([]respon
 	return logitems, nil
 }
 
-func (s *service) QueryLogContext(req *request.LogQueryContextRequest) (*response.LogQueryContextResponse, error) {
+func (s *service) QueryLogContext(ctx core.Context, req *request.LogQueryContextRequest) (*response.LogQueryContextResponse, error) {
 
 	logFields := map[string]interface{}{}
 	model := &database.LogTableInfo{

--- a/backend/pkg/services/log/service_update_log_parse_rule.go
+++ b/backend/pkg/services/log/service_update_log_parse_rule.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -14,7 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func (s *service) UpdateLogParseRule(req *request.UpdateLogParseRequest) (*response.LogParseResponse, error) {
+func (s *service) UpdateLogParseRule(ctx core.Context, req *request.UpdateLogParseRequest) (*response.LogParseResponse, error) {
 	// Update the log table
 	fields := make([]request.Field, 0)
 	if req.IsStructured {
@@ -47,7 +48,7 @@ func (s *service) UpdateLogParseRule(req *request.UpdateLogParseRequest) (*respo
 		IsStructured: req.IsStructured,
 	}
 	logReq.FillerValue()
-	_, err := s.UpdateLogTable(logReq)
+	_, err := s.UpdateLogTable(ctx, logReq)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service.go
+++ b/backend/pkg/services/service/service.go
@@ -6,6 +6,7 @@ package service
 import (
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -19,57 +20,57 @@ var _ Service = (*service)(nil)
 
 type Service interface {
 	// Get the relationship between upstream and downstream calls
-	GetServiceEndpointRelation(req *request.GetServiceEndpointRelationRequest) (*response.GetServiceEndpointRelationResponse, error)
+	GetServiceEndpointRelation(ctx core.Context, req *request.GetServiceEndpointRelationRequest) (*response.GetServiceEndpointRelationResponse, error)
 	// Get the upstream and downstream topology map
-	GetServiceEndpointTopology(req *request.GetServiceEndpointTopologyRequest) (*response.GetServiceEndpointTopologyResponse, error)
+	GetServiceEndpointTopology(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*response.GetServiceEndpointTopologyResponse, error)
 	// Get the delay curve of the dependent service
-	GetDescendantMetrics(req *request.GetDescendantMetricsRequest) ([]response.GetDescendantMetricsResponse, error)
+	GetDescendantMetrics(ctx core.Context, req *request.GetDescendantMetricsRequest) ([]response.GetDescendantMetricsResponse, error)
 	// Get the dependent node delay correlation.
-	GetDescendantRelevance(req *request.GetDescendantRelevanceRequest) ([]response.GetDescendantRelevanceResponse, error)
+	GetDescendantRelevance(ctx core.Context, req *request.GetDescendantRelevanceRequest) ([]response.GetDescendantRelevanceResponse, error)
 	// Get Polaris metric analysis
-	GetPolarisInfer(req *request.GetPolarisInferRequest) (*response.GetPolarisInferResponse, error)
+	GetPolarisInfer(ctx core.Context, req *request.GetPolarisInferRequest) (*response.GetPolarisInferResponse, error)
 	// Get error instance
-	GetErrorInstance(req *request.GetErrorInstanceRequest) (*response.GetErrorInstanceResponse, error)
+	GetErrorInstance(ctx core.Context, req *request.GetErrorInstanceRequest) (*response.GetErrorInstanceResponse, error)
 	// Get the error instance fault site log
-	GetErrorInstanceLogs(req *request.GetErrorInstanceLogsRequest) ([]clickhouse.FaultLogResult, error)
+	GetErrorInstanceLogs(ctx core.Context, req *request.GetErrorInstanceLogsRequest) ([]clickhouse.FaultLogResult, error)
 	// Get log metrics
-	GetLogMetrics(req *request.GetLogMetricsRequest) ([]*response.GetLogMetricsResponse, error)
+	GetLogMetrics(ctx core.Context, req *request.GetLogMetricsRequest) ([]*response.GetLogMetricsResponse, error)
 	// Get Log fault field log
-	GetLogLogs(req *request.GetLogLogsRequest) ([]clickhouse.FaultLogResult, error)
+	GetLogLogs(ctx core.Context, req *request.GetLogLogsRequest) ([]clickhouse.FaultLogResult, error)
 	// Get Trace related metrics
-	GetTraceMetrics(req *request.GetTraceMetricsRequest) ([]*response.GetTraceMetricsResponse, error)
+	GetTraceMetrics(ctx core.Context, req *request.GetTraceMetricsRequest) ([]*response.GetTraceMetricsResponse, error)
 	// Get SQL related metrics
-	GetSQLMetrics(req *request.GetSQLMetricsRequest) (*response.GetSQLMetricsResponse, error)
+	GetSQLMetrics(ctx core.Context, req *request.GetSQLMetricsRequest) (*response.GetSQLMetricsResponse, error)
 	// Get trace fault site log
-	GetTraceLogs(req *request.GetTraceLogsRequest) ([]clickhouse.FaultLogResult, error)
+	GetTraceLogs(ctx core.Context, req *request.GetTraceLogsRequest) ([]clickhouse.FaultLogResult, error)
 	// Get the list of services
-	GetServiceList(req *request.GetServiceListRequest) ([]string, error)
+	GetServiceList(ctx core.Context, req *request.GetServiceListRequest) ([]string, error)
 	// Get the list of service instances
 	// New interface
-	GetInstancesNew(startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error)
+	GetInstancesNew(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error)
 	// Old interface
-	GetInstances(startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error)
+	GetInstances(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error)
 	// Get the list of service instances
 	// DEPRECATED
-	GetServiceInstanceList(req *request.GetServiceInstanceListRequest) ([]string, error)
+	GetServiceInstanceList(ctx core.Context, req *request.GetServiceInstanceListRequest) ([]string, error)
 	// Get service instance details
-	GetServiceInstanceInfoList(req *request.GetServiceInstanceListRequest) ([]prometheus.InstanceKey, error)
+	GetServiceInstanceInfoList(ctx core.Context, req *request.GetServiceInstanceListRequest) ([]prometheus.InstanceKey, error)
 	// Get service instance drop-down list
-	GetServiceInstanceOptions(req *request.GetServiceInstanceOptionsRequest) (map[string]*model.ServiceInstance, error)
+	GetServiceInstanceOptions(ctx core.Context, req *request.GetServiceInstanceOptionsRequest) (map[string]*model.ServiceInstance, error)
 	// Get the list of service Endpoint
-	GetServiceEndPointList(req *request.GetServiceEndPointListRequest) ([]string, error)
+	GetServiceEndPointList(ctx core.Context, req *request.GetServiceEndPointListRequest) ([]string, error)
 	// Get the list of service portal Endpoint
-	GetServiceEntryEndpoints(req *request.GetServiceEntryEndpointsRequest) ([]clickhouse.EntryNode, error)
+	GetServiceEntryEndpoints(ctx core.Context, req *request.GetServiceEntryEndpointsRequest) ([]clickhouse.EntryNode, error)
 	// CountK8sEvents get the number of K8s events
-	CountK8sEvents(req *request.GetK8sEventsRequest) (*response.GetK8sEventsResponse, error)
+	CountK8sEvents(ctx core.Context, req *request.GetK8sEventsRequest) (*response.GetK8sEventsResponse, error)
 	// GetAlertEvents get alarm events
-	GetAlertEvents(req *request.GetAlertEventsRequest) (*response.GetAlertEventsResponse, error)
+	GetAlertEvents(ctx core.Context, req *request.GetAlertEventsRequest) (*response.GetAlertEventsResponse, error)
 
 	// GetAlertEventsSample get sampled alarm events
-	GetAlertEventsSample(req *request.GetAlertEventsSampleRequest) (*response.GetAlertEventsSampleResponse, error)
-	GetServiceNamespaceList(req *request.GetServiceNamespaceListRequest) (response.GetServiceNamespaceListResponse, error)
+	GetAlertEventsSample(ctx core.Context, req *request.GetAlertEventsSampleRequest) (*response.GetAlertEventsSampleResponse, error)
+	GetServiceNamespaceList(ctx core.Context, req *request.GetServiceNamespaceListRequest) (response.GetServiceNamespaceListResponse, error)
 
-	GetServiceREDCharts(req *request.GetServiceREDChartsRequest) (response.GetServiceREDChartsResponse, error)
+	GetServiceREDCharts(ctx core.Context, req *request.GetServiceREDChartsRequest) (response.GetServiceREDChartsResponse, error)
 }
 
 type service struct {

--- a/backend/pkg/services/service/service_count_k8s_events.go
+++ b/backend/pkg/services/service/service_count_k8s_events.go
@@ -4,12 +4,13 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
 // CountK8sEvents get K8s events
-func (s *service) CountK8sEvents(req *request.GetK8sEventsRequest) (*response.GetK8sEventsResponse, error) {
+func (s *service) CountK8sEvents(ctx core.Context, req *request.GetK8sEventsRequest) (*response.GetK8sEventsResponse, error) {
 	startTime := req.StartTime
 	endTime := req.EndTime
 	// Get all the instance information of the service first

--- a/backend/pkg/services/service/service_get_alert_events.go
+++ b/backend/pkg/services/service/service_get_alert_events.go
@@ -6,13 +6,14 @@ package service
 import (
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetAlertEventsSample(req *request.GetAlertEventsSampleRequest) (resp *response.GetAlertEventsSampleResponse, err error) {
+func (s *service) GetAlertEventsSample(ctx core.Context, req *request.GetAlertEventsSampleRequest) (resp *response.GetAlertEventsSampleResponse, err error) {
 	// Query the instance to which the Service belongs.
 	instances, err := s.promRepo.GetActiveInstanceList(req.StartTime, req.EndTime, req.Services)
 	if err != nil || instances == nil {
@@ -59,7 +60,7 @@ func (s *service) GetAlertEventsSample(req *request.GetAlertEventsSampleRequest)
 	}, nil
 }
 
-func (s *service) GetAlertEvents(req *request.GetAlertEventsRequest) (*response.GetAlertEventsResponse, error) {
+func (s *service) GetAlertEvents(ctx core.Context, req *request.GetAlertEventsRequest) (*response.GetAlertEventsResponse, error) {
 	// Query the instance to which the Service belongs.
 	instances, err := s.promRepo.GetActiveInstanceList(req.StartTime, req.EndTime, req.Services)
 	if err != nil {

--- a/backend/pkg/services/service/service_get_descendant_metrics.go
+++ b/backend/pkg/services/service/service_get_descendant_metrics.go
@@ -6,11 +6,12 @@ package service
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetDescendantMetrics(req *request.GetDescendantMetricsRequest) ([]response.GetDescendantMetricsResponse, error) {
+func (s *service) GetDescendantMetrics(ctx core.Context, req *request.GetDescendantMetricsRequest) ([]response.GetDescendantMetricsResponse, error) {
 	// Query all descendant nodes
 	nodes, err := s.chRepo.ListDescendantNodes(req)
 	if err != nil {

--- a/backend/pkg/services/service/service_get_descendant_relevance.go
+++ b/backend/pkg/services/service/service_get_descendant_relevance.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -17,7 +18,7 @@ import (
 )
 
 // GetDescendantRelevance implements Service.
-func (s *service) GetDescendantRelevance(req *request.GetDescendantRelevanceRequest) ([]response.GetDescendantRelevanceResponse, error) {
+func (s *service) GetDescendantRelevance(ctx core.Context, req *request.GetDescendantRelevanceRequest) ([]response.GetDescendantRelevanceResponse, error) {
 	// Query all descendant nodes
 	nodes, err := s.chRepo.ListDescendantNodes(req)
 	if err != nil {
@@ -108,6 +109,7 @@ func (s *service) GetDescendantRelevance(req *request.GetDescendantRelevanceRequ
 
 		// fill alarm status
 		descendantResp.AlertStatusCH = serviceoverview.GetAlertStatusCH(
+			ctx,
 			s.chRepo, &descendantResp.AlertReason, nil,
 			[]string{}, descendant.Service, instanceList,
 			startTime, endTime,

--- a/backend/pkg/services/service/service_get_error_instance.go
+++ b/backend/pkg/services/service/service_get_error_instance.go
@@ -4,12 +4,13 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetErrorInstance(req *request.GetErrorInstanceRequest) (*response.GetErrorInstanceResponse, error) {
+func (s *service) GetErrorInstance(ctx core.Context, req *request.GetErrorInstanceRequest) (*response.GetErrorInstanceResponse, error) {
 	serviceInstances, err := s.promRepo.GetInstanceList(req.StartTime, req.EndTime, req.Service, req.Endpoint)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/service/service_get_errorinstance_logs.go
+++ b/backend/pkg/services/service/service_get_errorinstance_logs.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetErrorInstanceLogs(req *request.GetErrorInstanceLogsRequest) ([]clickhouse.FaultLogResult, error) {
+func (s *service) GetErrorInstanceLogs(ctx core.Context, req *request.GetErrorInstanceLogsRequest) ([]clickhouse.FaultLogResult, error) {
 	// Get the error instance fault site log
 	query := &clickhouse.FaultLogQuery{
 		StartTime: req.StartTime,

--- a/backend/pkg/services/service/service_get_log_logs.go
+++ b/backend/pkg/services/service/service_get_log_logs.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetLogLogs(req *request.GetLogLogsRequest) ([]clickhouse.FaultLogResult, error) {
+func (s *service) GetLogLogs(ctx core.Context, req *request.GetLogLogsRequest) ([]clickhouse.FaultLogResult, error) {
 	// Get Log fault field log
 	query := &clickhouse.FaultLogQuery{
 		StartTime:   req.StartTime,

--- a/backend/pkg/services/service/service_get_log_metrics.go
+++ b/backend/pkg/services/service/service_get_log_metrics.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetLogMetrics(req *request.GetLogMetricsRequest) ([]*response.GetLogMetricsResponse, error) {
+func (s *service) GetLogMetrics(ctx core.Context, req *request.GetLogMetricsRequest) ([]*response.GetLogMetricsResponse, error) {
 	// Get log metrics
 	serviceInstances, err := s.promRepo.GetInstanceList(req.StartTime, req.EndTime, req.Service, req.Endpoint)
 	if err != nil {

--- a/backend/pkg/services/service/service_get_namespace_list.go
+++ b/backend/pkg/services/service/service_get_namespace_list.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetServiceNamespaceList(req *request.GetServiceNamespaceListRequest) (response.GetServiceNamespaceListResponse, error) {
+func (s *service) GetServiceNamespaceList(ctx core.Context, req *request.GetServiceNamespaceListRequest) (response.GetServiceNamespaceListResponse, error) {
 	list, err := s.promRepo.GetNamespaceList(req.StartTime, req.EndTime)
 	var resp response.GetServiceNamespaceListResponse
 	if err != nil {

--- a/backend/pkg/services/service/service_get_polaris_infer.go
+++ b/backend/pkg/services/service/service_get_polaris_infer.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
 // GetPolarisInfer implements Service.
-func (s *service) GetPolarisInfer(req *request.GetPolarisInferRequest) (*response.GetPolarisInferResponse, error) {
+func (s *service) GetPolarisInfer(ctx core.Context, req *request.GetPolarisInferRequest) (*response.GetPolarisInferResponse, error) {
 	return s.polRepo.QueryPolarisInfer(req)
 }

--- a/backend/pkg/services/service/service_get_red_charts.go
+++ b/backend/pkg/services/service/service_get_red_charts.go
@@ -7,12 +7,13 @@ import (
 	"log"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
-func (s *service) GetServiceREDCharts(req *request.GetServiceREDChartsRequest) (response.GetServiceREDChartsResponse, error) {
+func (s *service) GetServiceREDCharts(ctx core.Context, req *request.GetServiceREDChartsRequest) (response.GetServiceREDChartsResponse, error) {
 	step := time.Duration(req.Step * 1000)
 	filters := make([]string, 0, 4)
 	filters = append(filters, prometheus.ServiceRegexPQLFilter)
@@ -67,34 +68,34 @@ func (s *service) GetServiceREDCharts(req *request.GetServiceREDChartsRequest) (
 }
 
 func mergeResult(results []prometheus.MetricResult, serviceDetails map[string]map[string]response.RedCharts, metricType string) {
-    for _, result := range results {
-        svc, contentKey := result.Metric.SvcName, result.Metric.ContentKey
-        contents, ok := serviceDetails[svc]
-        if !ok {
-            contents = make(map[string]response.RedCharts)
-            serviceDetails[svc] = contents
-        }
+	for _, result := range results {
+		svc, contentKey := result.Metric.SvcName, result.Metric.ContentKey
+		contents, ok := serviceDetails[svc]
+		if !ok {
+			contents = make(map[string]response.RedCharts)
+			serviceDetails[svc] = contents
+		}
 
-        redCharts := contents[contentKey]
+		redCharts := contents[contentKey]
 
-        switch metricType {
-        case "latency":
-            for i := range result.Values {
-                result.Values[i].Value /= 1e3
-            }
-            redCharts.Latency = DataToChart(result.Values)
-        case "errorRate":
-            for i := range result.Values {
-                result.Values[i].Value *= 100
-            }
-            redCharts.ErrorRate = DataToChart(result.Values)
-        case "rps":
-            for i := range result.Values {
-                result.Values[i].Value *= 60
-            }
-            redCharts.RPS = DataToChart(result.Values)
-        }
+		switch metricType {
+		case "latency":
+			for i := range result.Values {
+				result.Values[i].Value /= 1e3
+			}
+			redCharts.Latency = DataToChart(result.Values)
+		case "errorRate":
+			for i := range result.Values {
+				result.Values[i].Value *= 100
+			}
+			redCharts.ErrorRate = DataToChart(result.Values)
+		case "rps":
+			for i := range result.Values {
+				result.Values[i].Value *= 60
+			}
+			redCharts.RPS = DataToChart(result.Values)
+		}
 
-        contents[contentKey] = redCharts
-    }
+		contents[contentKey] = redCharts
+	}
 }

--- a/backend/pkg/services/service/service_get_service_endpoint_list.go
+++ b/backend/pkg/services/service/service_get_service_endpoint_list.go
@@ -3,9 +3,12 @@
 
 package service
 
-import "github.com/CloudDetail/apo/backend/pkg/model/request"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
 
-func (s *service) GetServiceEndPointList(req *request.GetServiceEndPointListRequest) ([]string, error) {
+func (s *service) GetServiceEndPointList(ctx core.Context, req *request.GetServiceEndPointListRequest) ([]string, error) {
 	// Get the list of service Endpoint
 	return s.promRepo.GetServiceEndPointList(req.StartTime, req.EndTime, req.ServiceName)
 }

--- a/backend/pkg/services/service/service_get_service_endpoint_relation.go
+++ b/backend/pkg/services/service/service_get_service_endpoint_relation.go
@@ -4,12 +4,13 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetServiceEndpointRelation(req *request.GetServiceEndpointRelationRequest) (*response.GetServiceEndpointRelationResponse, error) {
+func (s *service) GetServiceEndpointRelation(ctx core.Context, req *request.GetServiceEndpointRelationRequest) (*response.GetServiceEndpointRelationResponse, error) {
 	// Query all upstream nodes
 	parents, err := s.chRepo.ListParentNodes(req)
 	if err != nil {

--- a/backend/pkg/services/service/service_get_service_endpoint_topology.go
+++ b/backend/pkg/services/service/service_get_service_endpoint_topology.go
@@ -4,12 +4,13 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetServiceEndpointTopology(req *request.GetServiceEndpointTopologyRequest) (*response.GetServiceEndpointTopologyResponse, error) {
+func (s *service) GetServiceEndpointTopology(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*response.GetServiceEndpointTopologyResponse, error) {
 	// Query all upstream nodes
 	parents, err := s.chRepo.ListParentNodes(req)
 	if err != nil {

--- a/backend/pkg/services/service/service_get_service_entry_endpoints.go
+++ b/backend/pkg/services/service/service_get_service_entry_endpoints.go
@@ -4,10 +4,11 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetServiceEntryEndpoints(req *request.GetServiceEntryEndpointsRequest) ([]clickhouse.EntryNode, error) {
+func (s *service) GetServiceEntryEndpoints(ctx core.Context, req *request.GetServiceEntryEndpointsRequest) ([]clickhouse.EntryNode, error) {
 	return s.chRepo.ListEntryEndpoints(req)
 }

--- a/backend/pkg/services/service/service_get_service_instance_list.go
+++ b/backend/pkg/services/service/service_get_service_instance_list.go
@@ -6,13 +6,14 @@ package service
 import (
 	"strconv"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
-func (s *service) GetServiceInstanceList(req *request.GetServiceInstanceListRequest) ([]string, error) {
+func (s *service) GetServiceInstanceList(ctx core.Context, req *request.GetServiceInstanceListRequest) ([]string, error) {
 	// Get the list of active service instances
-	instances, err := s.promRepo.GetActiveInstanceList(req.StartTime, req.EndTime,[]string{req.ServiceName})
+	instances, err := s.promRepo.GetActiveInstanceList(req.StartTime, req.EndTime, []string{req.ServiceName})
 	if err != nil {
 		return nil, err
 	}
@@ -20,7 +21,7 @@ func (s *service) GetServiceInstanceList(req *request.GetServiceInstanceListRequ
 	return instances.GetInstanceIds(), nil
 }
 
-func (s *service) GetServiceInstanceInfoList(req *request.GetServiceInstanceListRequest) ([]prometheus.InstanceKey, error) {
+func (s *service) GetServiceInstanceInfoList(ctx core.Context, req *request.GetServiceInstanceListRequest) ([]prometheus.InstanceKey, error) {
 	var ins []prometheus.InstanceKey
 	// Get instance
 	instanceList, err := s.promRepo.GetInstanceList(req.StartTime, req.EndTime, req.ServiceName, "")

--- a/backend/pkg/services/service/service_get_service_instance_options.go
+++ b/backend/pkg/services/service/service_get_service_instance_options.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) GetServiceInstanceOptions(req *request.GetServiceInstanceOptionsRequest) (map[string]*model.ServiceInstance, error) {
+func (s *service) GetServiceInstanceOptions(ctx core.Context, req *request.GetServiceInstanceOptionsRequest) (map[string]*model.ServiceInstance, error) {
 	// Get the list of active service instances
 	instances, err := s.promRepo.GetActiveInstanceList(req.StartTime, req.EndTime, []string{req.ServiceName})
 	if err != nil {

--- a/backend/pkg/services/service/service_get_service_list.go
+++ b/backend/pkg/services/service/service_get_service_list.go
@@ -4,9 +4,10 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) GetServiceList(req *request.GetServiceListRequest) ([]string, error) {
+func (s *service) GetServiceList(ctx core.Context, req *request.GetServiceListRequest) ([]string, error) {
 	return s.promRepo.GetServiceList(req.StartTime, req.EndTime, req.Namespace)
 }

--- a/backend/pkg/services/service/service_get_sql_metrics.go
+++ b/backend/pkg/services/service/service_get_sql_metrics.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -20,7 +21,7 @@ const (
 	SortByTps       = "tps"
 )
 
-func (s *service) GetSQLMetrics(req *request.GetSQLMetricsRequest) (*response.GetSQLMetricsResponse, error) {
+func (s *service) GetSQLMetrics(ctx core.Context, req *request.GetSQLMetricsRequest) (*response.GetSQLMetricsResponse, error) {
 	startTime := time.UnixMicro(req.StartTime)
 	endTime := time.UnixMicro(req.EndTime)
 	step := time.Duration(req.Step) * time.Microsecond

--- a/backend/pkg/services/service/service_get_trace_logs.go
+++ b/backend/pkg/services/service/service_get_trace_logs.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 )
 
-func (s *service) GetTraceLogs(req *request.GetTraceLogsRequest) ([]clickhouse.FaultLogResult, error) {
+func (s *service) GetTraceLogs(ctx core.Context, req *request.GetTraceLogsRequest) ([]clickhouse.FaultLogResult, error) {
 	// Get trace fault site log
 	query := &clickhouse.FaultLogQuery{
 		StartTime:   req.StartTime,

--- a/backend/pkg/services/service/service_get_trace_metrics.go
+++ b/backend/pkg/services/service/service_get_trace_metrics.go
@@ -4,11 +4,12 @@
 package service
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetTraceMetrics(req *request.GetTraceMetricsRequest) ([]*response.GetTraceMetricsResponse, error) {
+func (s *service) GetTraceMetrics(ctx core.Context, req *request.GetTraceMetricsRequest) ([]*response.GetTraceMetricsResponse, error) {
 	// Get Trace related metrics
 	serviceInstances, err := s.promRepo.GetInstanceList(req.StartTime, req.EndTime, req.Service, req.Endpoint)
 	if err != nil {

--- a/backend/pkg/services/service/service_instance_new.go
+++ b/backend/pkg/services/service/service_instance_new.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -16,7 +17,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/services/serviceoverview"
 )
 
-func (s *service) GetInstancesNew(startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
+func (s *service) GetInstancesNew(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
 	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
 	if err != nil {
 		return res, err
@@ -222,6 +223,7 @@ func (s *service) GetInstancesNew(startTime time.Time, endTime time.Time, step t
 		}
 		// fill alarm status
 		newInstance.AlertStatusCH = serviceoverview.GetAlertStatusCH(
+			ctx,
 			s.chRepo, &newInstance.AlertReason, nil,
 			nil, serviceName, instanceSingleList,
 			startTime, endTime,

--- a/backend/pkg/services/service/service_instances.go
+++ b/backend/pkg/services/service/service_instances.go
@@ -12,11 +12,12 @@ import (
 	prom "github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	"github.com/CloudDetail/apo/backend/pkg/services/serviceoverview"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetInstances(startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
+func (s *service) GetInstances(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
 	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
 	if err != nil {
 		return res, err
@@ -293,6 +294,7 @@ func (s *service) GetInstances(startTime time.Time, endTime time.Time, step time
 		}
 		// fill alarm status
 		newInstance.AlertStatusCH = serviceoverview.GetAlertStatusCH(
+			ctx,
 			s.chRepo, &newInstance.AlertReason, nil,
 			nil, serviceName, instanceSingleList,
 			startTime, endTime,

--- a/backend/pkg/services/serviceoverview/service.go
+++ b/backend/pkg/services/serviceoverview/service.go
@@ -9,6 +9,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 	"go.uber.org/zap"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -18,19 +19,19 @@ import (
 var _ Service = (*service)(nil)
 
 type Service interface {
-	GetServiceMoreUrl(startTime time.Time, endTime time.Time, step time.Duration, serviceNames string, sortRule request.SortType) (res []response.ServiceDetail, err error)
-	GetThreshold(level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error)
-	SetThreshold(level string, serviceName string, endPoint string, latency float64, errorRate float64, tps float64, log float64) (res response.SetThresholdResponse, err error)
-	GetServicesAlert(startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, returnData []string) (res []response.ServiceAlertRes, err error)
-	GetServicesEndPointData(startTime time.Time, endTime time.Time, step time.Duration, filter EndpointsFilter, sortRule request.SortType) (res []response.ServiceEndPointsRes, err error)
+	GetServiceMoreUrl(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceNames string, sortRule request.SortType) (res []response.ServiceDetail, err error)
+	GetThreshold(ctx core.Context, level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error)
+	SetThreshold(ctx core.Context, level string, serviceName string, endPoint string, latency float64, errorRate float64, tps float64, log float64) (res response.SetThresholdResponse, err error)
+	GetServicesAlert(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, returnData []string) (res []response.ServiceAlertRes, err error)
+	GetServicesEndPointData(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, filter EndpointsFilter, sortRule request.SortType) (res []response.ServiceEndPointsRes, err error)
 
 	// TODO move to prometheus package and avoid to repeated again
-	GetServicesEndpointDataWithChart(startTime time.Time, endTime time.Time, step time.Duration, filter EndpointsFilter, sortRule request.SortType) (res []response.ServiceEndPointsRes, err error)
+	GetServicesEndpointDataWithChart(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, filter EndpointsFilter, sortRule request.SortType) (res []response.ServiceEndPointsRes, err error)
 
-	GetServicesRYGLightStatus(startTime time.Time, endTime time.Time, filter EndpointsFilter) (response.ServiceRYGLightRes, error)
-	GetMonitorStatus(startTime time.Time, endTime time.Time) (response.GetMonitorStatusResponse, error)
+	GetServicesRYGLightStatus(ctx core.Context, startTime time.Time, endTime time.Time, filter EndpointsFilter) (response.ServiceRYGLightRes, error)
+	GetMonitorStatus(ctx core.Context, startTime time.Time, endTime time.Time) (response.GetMonitorStatusResponse, error)
 
-	GetAlertRelatedEntryData(startTime, endTime time.Time, namespaces []string, entry []response.AlertRelatedEntry) (res []response.AlertRelatedEntry, err error)
+	GetAlertRelatedEntryData(ctx core.Context, startTime, endTime time.Time, namespaces []string, entry []response.AlertRelatedEntry) (res []response.AlertRelatedEntry, err error)
 }
 
 type service struct {

--- a/backend/pkg/services/serviceoverview/service_alert.go
+++ b/backend/pkg/services/serviceoverview/service_alert.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -24,7 +25,7 @@ func contains(arr []string, str string) bool {
 	}
 	return false
 }
-func (s *service) GetServicesAlert(startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, returnData []string) (res []response.ServiceAlertRes, err error) {
+func (s *service) GetServicesAlert(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, returnData []string) (res []response.ServiceAlertRes, err error) {
 	svcInstances, err := s.promRepo.GetMultiServicesInstanceList(startTime.UnixMicro(), endTime.UnixMicro(), serviceNames)
 	if err != nil {
 		return nil, err
@@ -228,6 +229,7 @@ func (s *service) GetServicesAlert(startTime time.Time, endTime time.Time, step 
 
 		// fill alarm status
 		newServiceRes.AlertStatusCH = GetAlertStatusCH(
+			ctx,
 			s.chRepo, &newServiceRes.AlertReason, nil,
 			returnData, service.ServiceName, serviceInstances,
 			startTime, endTime,
@@ -248,7 +250,7 @@ func (s *service) GetServicesAlert(startTime time.Time, endTime time.Time, step 
 }
 
 // Fill in the alarm information from the Clickhouse and fill in the alertReason
-func GetAlertStatusCH(chRepo clickhouse.Repo,
+func GetAlertStatusCH(ctx core.Context, chRepo clickhouse.Repo,
 	alertReason *model.AlertReason, alertEventsCountMap *model.AlertEventLevelCountMap,
 	alertTypes []string, serviceName string, instances []*model.ServiceInstance, // filter
 	startTime, endTime time.Time,

--- a/backend/pkg/services/serviceoverview/service_get_endpoints_data.go
+++ b/backend/pkg/services/serviceoverview/service_get_endpoints_data.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -15,7 +16,7 @@ import (
 	"go.uber.org/zap"
 )
 
-func (s *service) GetServicesEndPointData(
+func (s *service) GetServicesEndPointData(ctx core.Context,
 	startTime, endTime time.Time, step time.Duration,
 	filter EndpointsFilter,
 	sortRule request.SortType,
@@ -43,7 +44,7 @@ func (s *service) GetServicesEndPointData(
 		s.logger.Error("failed to fetch endpoints data form", zap.Error(err))
 	}
 
-	s.sortWithRule(sortRule, endpointsMap)
+	s.sortWithRule(ctx, sortRule, endpointsMap)
 
 	services := groupEndpointsByService(endpointsMap.MetricGroupList, 3)
 	var servicesResMsg []response.ServiceEndPointsRes
@@ -82,7 +83,7 @@ func (s *service) GetServicesEndPointData(
 	return servicesResMsg, err
 }
 
-func (s *service) sortWithRule(sortRule request.SortType, endpointsMap *EndpointsMap) error {
+func (s *service) sortWithRule(ctx core.Context, sortRule request.SortType, endpointsMap *EndpointsMap) error {
 	switch sortRule {
 	case request.SortByLatency, request.SortByErrorRate, request.SortByThroughput, request.SortByLogErrorCount:
 		slices.SortStableFunc(endpointsMap.MetricGroupList, prometheus.ReverseSortWithMetrics(sortRule))

--- a/backend/pkg/services/serviceoverview/service_get_endpoints_data_with_chart.go
+++ b/backend/pkg/services/serviceoverview/service_get_endpoints_data_with_chart.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
@@ -14,7 +15,7 @@ import (
 )
 
 // TODO move to prometheus package and avoid to repeated self
-func (s *service) GetServicesEndpointDataWithChart(
+func (s *service) GetServicesEndpointDataWithChart(ctx core.Context,
 	startTime time.Time, endTime time.Time, step time.Duration,
 	filter EndpointsFilter, sortRule request.SortType,
 ) (res []response.ServiceEndPointsRes, err error) {
@@ -43,7 +44,7 @@ func (s *service) GetServicesEndpointDataWithChart(
 		return
 	}
 
-	s.sortWithRule(sortRule, endpointsMap)
+	s.sortWithRule(ctx, sortRule, endpointsMap)
 
 	// step4 Group Endpoints by service and maintain service ordering
 	services := groupEndpointsByService(endpointsMap.MetricGroupList, 3)

--- a/backend/pkg/services/serviceoverview/service_get_entry_data.go
+++ b/backend/pkg/services/serviceoverview/service_get_entry_data.go
@@ -7,12 +7,13 @@ import (
 	"sort"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	prom "github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
 // Fetch the endpoint overview information based on the input endpoints.
-func (s *service) GetAlertRelatedEntryData(
+func (s *service) GetAlertRelatedEntryData(ctx core.Context,
 	startTime, endTime time.Time, namespaces []string,
 	entry []response.AlertRelatedEntry,
 ) (res []response.AlertRelatedEntry, err error) {

--- a/backend/pkg/services/serviceoverview/service_get_monitor_status.go
+++ b/backend/pkg/services/serviceoverview/service_get_monitor_status.go
@@ -6,13 +6,14 @@ package serviceoverview
 import (
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
 const UP = 1.0
 
-func (s *service) GetMonitorStatus(startTime time.Time, endTime time.Time) (response.GetMonitorStatusResponse, error) {
+func (s *service) GetMonitorStatus(ctx core.Context, startTime time.Time, endTime time.Time) (response.GetMonitorStatusResponse, error) {
 	resp := response.GetMonitorStatusResponse{}
 	startMicroTS := startTime.UnixMicro()
 	endMicroTs := endTime.UnixMicro()

--- a/backend/pkg/services/serviceoverview/service_get_threshold.go
+++ b/backend/pkg/services/serviceoverview/service_get_threshold.go
@@ -4,10 +4,11 @@
 package serviceoverview
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetThreshold(level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error) {
+func (s *service) GetThreshold(ctx core.Context, level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error) {
 	threshold, err := s.dbRepo.GetOrCreateThreshold(serviceName, endPoint, level)
 	if err != nil {
 		return res, err

--- a/backend/pkg/services/serviceoverview/service_moreurl.go
+++ b/backend/pkg/services/serviceoverview/service_moreurl.go
@@ -9,11 +9,12 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 )
 
-func (s *service) GetServiceMoreUrl(startTime time.Time, endTime time.Time, step time.Duration, serviceNames string, sortRule request.SortType) (res []response.ServiceDetail, err error) {
+func (s *service) GetServiceMoreUrl(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceNames string, sortRule request.SortType) (res []response.ServiceDetail, err error) {
 	filter := EndpointsFilter{
 		ServiceName: serviceNames,
 	}

--- a/backend/pkg/services/serviceoverview/service_ryg_light.go
+++ b/backend/pkg/services/serviceoverview/service_ryg_light.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
@@ -14,7 +15,7 @@ import (
 	prom "github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 )
 
-func (s *service) GetServicesRYGLightStatus(startTime time.Time, endTime time.Time, filter EndpointsFilter) (response.ServiceRYGLightRes, error) {
+func (s *service) GetServicesRYGLightStatus(ctx core.Context, startTime time.Time, endTime time.Time, filter EndpointsFilter) (response.ServiceRYGLightRes, error) {
 	var servicesMap = &servicesRYGLightMap{
 		MetricGroupList: []*RYGLightStatus{},
 		MetricGroupMap:  map[prom.ServiceKey]*RYGLightStatus{},
@@ -62,8 +63,7 @@ func (s *service) GetServicesRYGLightStatus(startTime time.Time, endTime time.Ti
 		ServiceList: []*response.ServiceRYGResult{},
 	}
 
-	alertEventCount, _ := s.chRepo.GetAlertEventCountGroupByInstance(
-		startTime,
+	alertEventCount, _ := s.chRepo.GetAlertEventCountGroupByInstance(startTime,
 		endTime,
 		request.AlertFilter{Status: "firing"},
 		nil,

--- a/backend/pkg/services/serviceoverview/service_set_threshold.go
+++ b/backend/pkg/services/serviceoverview/service_set_threshold.go
@@ -4,11 +4,12 @@
 package serviceoverview
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
-func (s *service) SetThreshold(level string, serviceName string, endPoint string, latency float64, errorRate float64, tps float64, log float64) (res response.SetThresholdResponse, err error) {
+func (s *service) SetThreshold(ctx core.Context, level string, serviceName string, endPoint string, latency float64, errorRate float64, tps float64, log float64) (res response.SetThresholdResponse, err error) {
 	threshold := &database.Threshold{
 		Latency:   latency,
 		Tps:       tps,


### PR DESCRIPTION
## Summary by Sourcery

Propagate core.Context through service and handler layers by adding context parameters to service interface methods and implementations, update API handlers to supply context in service calls and permission checks, and adjust tests accordingly.

Enhancements:
- Propagate core.Context through service interfaces and implementations across service, log, data, k8s, and serviceoverview packages
- Update API handlers and permission checks to pass context to service methods
- Adjust tests to accommodate the new context parameter in CheckDatasourcePermission and related calls
- Refactor mergeResult function formatting for consistent indentation