### PR TITLE
Refactor/Passing context between controller and repository layers - Part3 Passing context to repository Layer 

### DIFF
--- a/backend/pkg/receiver/handle_record.go
+++ b/backend/pkg/receiver/handle_record.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/prometheus/alertmanager/notify"
@@ -17,7 +18,7 @@ import (
 	pmodel "github.com/prometheus/common/model"
 )
 
-func (r *InnerReceivers) HandleAlertCheckRecord(ctx context.Context, record *model.WorkflowRecord) error {
+func (r *InnerReceivers) HandleAlertCheckRecord(ctx core.Context, record *model.WorkflowRecord) error {
 	if record.WorkflowName != "AlertCheck" {
 		return nil
 	}

--- a/backend/pkg/receiver/receiver.go
+++ b/backend/pkg/receiver/receiver.go
@@ -35,7 +35,7 @@ import (
 )
 
 type Receivers interface {
-	HandleAlertCheckRecord(ctx context.Context, record *model.WorkflowRecord) error
+	HandleAlertCheckRecord(ctx core.Context, record *model.WorkflowRecord) error
 
 	GetAMConfigReceiver(ctx core.Context, filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int)
 	AddAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver) error
@@ -72,7 +72,7 @@ func SetupReceiver(externalURL string, logger *zap.Logger, dbRepo database.Repo,
 		return nil, err
 	}
 
-	receivers, _, err := dbRepo.GetAMConfigReceiver(nil, nil)
+	receivers, _, err := dbRepo.GetAMConfigReceiver(nil, nil, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -91,7 +91,8 @@ func SetupReceiver(externalURL string, logger *zap.Logger, dbRepo database.Repo,
 		amReceiver.ch = chRepo
 	}
 
-	slienceCfgs, err := dbRepo.GetAlertSlience()
+	// ctx
+	slienceCfgs, err := dbRepo.GetAlertSlience(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +216,8 @@ func (r *InnerReceivers) cleanupSlience(ctx context.Context, interval time.Durat
 			r.slientCFGMap.Range(func(key, value any) bool {
 				val := value.(*slienceconfig.AlertSlienceConfig)
 				if now.After(val.EndAt) {
-					if err := r.database.DeleteAlertSlience(val.ID); err == nil {
+					// ctx
+					if err := r.database.DeleteAlertSlience(nil, val.ID); err == nil {
 						r.slientCFGMap.Delete(key)
 					}
 				}

--- a/backend/pkg/receiver/receiver_config.go
+++ b/backend/pkg/receiver/receiver_config.go
@@ -26,7 +26,7 @@ func (r *InnerReceivers) updateReceiversInMemory(receivers []amconfig.Receiver) 
 }
 
 func (r *InnerReceivers) GetAMConfigReceiver(ctx core.Context, filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int) {
-	receivers, count, err := r.database.GetAMConfigReceiver(filter, pageParam)
+	receivers, count, err := r.database.GetAMConfigReceiver(ctx, filter, pageParam)
 	if err != nil {
 		r.logger.Error("failed to list amconfigReceiver", "err", err)
 		return []amconfig.Receiver{}, 0
@@ -35,12 +35,12 @@ func (r *InnerReceivers) GetAMConfigReceiver(ctx core.Context, filter *request.A
 }
 
 func (r *InnerReceivers) AddAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver) error {
-	err := r.database.AddAMConfigReceiver(receiver)
+	err := r.database.AddAMConfigReceiver(ctx, receiver)
 	if err != nil {
 		return err
 	}
 
-	receivers, _, err := r.database.GetAMConfigReceiver(nil, nil)
+	receivers, _, err := r.database.GetAMConfigReceiver(ctx, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -48,11 +48,11 @@ func (r *InnerReceivers) AddAMConfigReceiver(ctx core.Context, receiver amconfig
 }
 
 func (r *InnerReceivers) UpdateAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver, oldName string) error {
-	err := r.database.UpdateAMConfigReceiver(receiver, oldName)
+	err := r.database.UpdateAMConfigReceiver(ctx, receiver, oldName)
 	if err != nil {
 		return err
 	}
-	receivers, _, err := r.database.GetAMConfigReceiver(nil, nil)
+	receivers, _, err := r.database.GetAMConfigReceiver(ctx, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -60,11 +60,11 @@ func (r *InnerReceivers) UpdateAMConfigReceiver(ctx core.Context, receiver amcon
 }
 
 func (r *InnerReceivers) DeleteAMConfigReceiver(ctx core.Context, name string) error {
-	err := r.database.DeleteAMConfigReceiver(name)
+	err := r.database.DeleteAMConfigReceiver(ctx, name)
 	if err != nil {
 		return err
 	}
-	receivers, _, err := r.database.GetAMConfigReceiver(nil, nil)
+	receivers, _, err := r.database.GetAMConfigReceiver(ctx, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/receiver/slient_config.go
+++ b/backend/pkg/receiver/slient_config.go
@@ -19,7 +19,7 @@ func (r *InnerReceivers) GetSlienceConfigByAlertID(ctx core.Context, alertID str
 }
 
 func (r *InnerReceivers) ListSlienceConfig(ctx core.Context) ([]sc.AlertSlienceConfig, error) {
-	return r.database.GetAlertSlience()
+	return r.database.GetAlertSlience(ctx)
 }
 
 func (r *InnerReceivers) SetSlienceConfigByAlertID(ctx core.Context, alertID string, forDuration string) error {
@@ -42,22 +42,22 @@ func (r *InnerReceivers) SetSlienceConfigByAlertID(ctx core.Context, alertID str
 		slienceconfig.AlertName = cfg.AlertName
 		slienceconfig.Group = cfg.Group
 		slienceconfig.Tags = cfg.Tags
-		return r.database.UpdateAlertSlience(slienceconfig)
+		return r.database.UpdateAlertSlience(ctx, slienceconfig)
 	} else {
-		event, err := r.ch.GetLatestAlertEventByAlertID(alertID)
+		event, err := r.ch.GetLatestAlertEventByAlertID(ctx, alertID)
 		if err == nil && event != nil {
 			slienceconfig.AlertName = event.Name
 			slienceconfig.Tags = event.EnrichTags
 			slienceconfig.Group = event.Group
 		}
-		return r.database.AddAlertSlience(slienceconfig)
+		return r.database.AddAlertSlience(ctx, slienceconfig)
 	}
 }
 
 func (r *InnerReceivers) RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error {
 	if cfgPtr, loaded := r.slientCFGMap.LoadAndDelete(alertID); loaded {
 		cfg := cfgPtr.(*sc.AlertSlienceConfig)
-		return r.database.DeleteAlertSlience(cfg.ID)
+		return r.database.DeleteAlertSlience(ctx, cfg.ID)
 	}
 
 	return fmt.Errorf("alert[%s] is not slient", alertID)

--- a/backend/pkg/repository/cache/cache.go
+++ b/backend/pkg/repository/cache/cache.go
@@ -7,24 +7,25 @@ import (
 	"sync"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/util/jwt"
 )
 
 type Repo interface {
-	AddToken(token string) error
-	IsInBlacklist(token string) (bool, error)
+	AddToken(ctx core.Context, token string) error
+	IsInBlacklist(ctx core.Context, token string) (bool, error)
 }
 
 type cache struct {
 	blackList sync.Map
 }
 
-func (c *cache) IsInBlacklist(token string) (bool, error) {
+func (c *cache) IsInBlacklist(ctx core.Context, token string) (bool, error) {
 	_, ok := c.blackList.Load(token)
 	return ok, nil
 }
 
-func (c *cache) AddToken(token string) error {
+func (c *cache) AddToken(ctx core.Context, token string) error {
 	c.blackList.Store(token, struct{}{})
 	return nil
 }

--- a/backend/pkg/repository/clickhouse/dao.go
+++ b/backend/pkg/repository/clickhouse/dao.go
@@ -5,9 +5,7 @@ package clickhouse
 
 import (
 	"context"
-	"database/sql"
 	"fmt"
-	"net/url"
 	"time"
 
 	"github.com/google/uuid"
@@ -16,116 +14,118 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
+	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse/factory"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse/integration"
 )
 
 type Repo interface {
 	// ========== service_relationship ==========
 	// Query the list of upstream nodes
-	ListParentNodes(req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error)
+	ListParentNodes(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error)
 	// Query the list of downstream nodes
-	ListChildNodes(req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error)
+	ListChildNodes(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error)
 	// Query the list of all descendant service nodes
-	ListDescendantNodes(req *request.GetDescendantMetricsRequest) (*model.TopologyNodes, error)
+	ListDescendantNodes(ctx core.Context, req *request.GetDescendantMetricsRequest) (*model.TopologyNodes, error)
 	// Query the calling relationship of all descendant nodes
-	ListDescendantRelations(req *request.GetServiceEndpointTopologyRequest) ([]*model.ToplogyRelation, error)
+	ListDescendantRelations(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) ([]*model.ToplogyRelation, error)
 	// Query the entry node list
-	ListEntryEndpoints(req *request.GetServiceEntryEndpointsRequest) ([]EntryNode, error)
+	ListEntryEndpoints(ctx core.Context, req *request.GetServiceEntryEndpointsRequest) ([]EntryNode, error)
 
 	// ========== error_propagation ==========
 	// Query instance-related error propagation chain
-	ListErrorPropagation(req *request.GetErrorInstanceRequest) ([]ErrorInstancePropagation, error)
+	ListErrorPropagation(ctx core.Context, req *request.GetErrorInstanceRequest) ([]ErrorInstancePropagation, error)
 
 	// ========== span_trace ==========
-	GetAvailableFilterKey(startTime, endTime time.Time, needUpdate bool) ([]request.SpanTraceFilter, error)
-	UpdateFilterKey(startTime, endTime time.Time) ([]request.SpanTraceFilter, error)
-	GetFieldValues(searchText string, filter *request.SpanTraceFilter, startTime, endTime time.Time) (*SpanTraceOptions, error)
+	GetAvailableFilterKey(ctx core.Context, startTime, endTime time.Time, needUpdate bool) ([]request.SpanTraceFilter, error)
+	UpdateFilterKey(ctx core.Context, startTime, endTime time.Time) ([]request.SpanTraceFilter, error)
+	GetFieldValues(ctx core.Context, searchText string, filter *request.SpanTraceFilter, startTime, endTime time.Time) (*SpanTraceOptions, error)
 	// Paging query the fault site log list
-	GetFaultLogPageList(query *FaultLogQuery) ([]FaultLogResult, int64, error)
+	GetFaultLogPageList(ctx core.Context, query *FaultLogQuery) ([]FaultLogResult, int64, error)
 	// Paged Trace List
-	GetTracePageList(req *request.GetTracePageListRequest) ([]QueryTraceResult, int64, error)
+	GetTracePageList(ctx core.Context, req *request.GetTracePageListRequest) ([]QueryTraceResult, int64, error)
 
 	// InfrastructureAlert(startTime time.Time, endTime time.Time, nodeNames []string) (*model.AlertEvent, bool, error)
 	// NetworkAlert(startTime time.Time, endTime time.Time, pods []string, nodeNames []string, pids []string) (bool, error)
 
-	CountK8sEvents(startTime int64, endTim int64, pods []string) ([]K8sEventsCount, error)
+	CountK8sEvents(ctx core.Context, startTime int64, endTim int64, pods []string) ([]K8sEventsCount, error)
 
 	// ========== application_logs ==========
 	// Query the log content of the fault site. The sourceFrom can be blank. The log in the first source that can be found will be returned.
-	QueryApplicationLogs(req *request.GetFaultLogContentRequest) (logContents *Logs, availableSource []string, err error)
+	QueryApplicationLogs(ctx core.Context, req *request.GetFaultLogContentRequest) (logContents *Logs, availableSource []string, err error)
 	// Query the available source of the fault field log content
-	QueryApplicationLogsAvailableSource(faultLog FaultLogResult) ([]string, error)
+	QueryApplicationLogsAvailableSource(ctx core.Context, faultLog FaultLogResult) ([]string, error)
 
-	CreateLogTable(req *request.LogTableRequest) ([]string, error)
-	DropLogTable(req *request.LogTableRequest) ([]string, error)
-	UpdateLogTable(req *request.LogTableRequest, old []request.Field) ([]string, error)
+	CreateLogTable(ctx core.Context, req *request.LogTableRequest) ([]string, error)
+	DropLogTable(ctx core.Context, req *request.LogTableRequest) ([]string, error)
+	UpdateLogTable(ctx core.Context, req *request.LogTableRequest, old []request.Field) ([]string, error)
 
-	queryRowsData(sql string) ([]map[string]any, error)
+	queryRowsData(ctx core.Context, sql string) ([]map[string]any, error)
 
-	QueryAllLogs(req *request.LogQueryRequest) ([]map[string]any, string, error)
-	QueryLogContext(req *request.LogQueryContextRequest) ([]map[string]any, []map[string]any, error)
-	GetLogChart(req *request.LogQueryRequest) ([]map[string]any, int64, error)
-	GetLogIndex(req *request.LogIndexRequest) (map[string]uint64, uint64, error)
+	QueryAllLogs(ctx core.Context, req *request.LogQueryRequest) ([]map[string]any, string, error)
+	QueryLogContext(ctx core.Context, req *request.LogQueryContextRequest) ([]map[string]any, []map[string]any, error)
+	GetLogChart(ctx core.Context, req *request.LogQueryRequest) ([]map[string]any, int64, error)
+	GetLogIndex(ctx core.Context, req *request.LogIndexRequest) (map[string]uint64, uint64, error)
 
-	OtherLogTable() ([]map[string]any, error)
-	OtherLogTableInfo(req *request.OtherTableInfoRequest) ([]map[string]any, error)
+	OtherLogTable(ctx core.Context) ([]map[string]any, error)
+	OtherLogTableInfo(ctx core.Context, req *request.OtherTableInfoRequest) ([]map[string]any, error)
 
-	InsertBatchAlertEvents(ctx context.Context, events []*model.AlertEvent) error
-	ReadAlertEvent(ctx context.Context, id uuid.UUID) (*model.AlertEvent, error)
-	GetConn() driver.Conn
+	InsertBatchAlertEvents(ctx core.Context, events []*model.AlertEvent) error
+	ReadAlertEvent(ctx core.Context, id uuid.UUID) (*model.AlertEvent, error)
+	GetConn(ctx core.Context) driver.Conn
 
 	//config
-	ModifyTableTTL(ctx context.Context, mapResult []model.ModifyTableTTLMap) error
-	GetTables(tables []model.Table) ([]model.TablesQuery, error)
+	ModifyTableTTL(ctx core.Context, mapResult []model.ModifyTableTTLMap) error
+	GetTables(ctx core.Context, tables []model.Table) ([]model.TablesQuery, error)
 
 	// ========== alert =================
-	GetAlertsWithEventCount(startTime, endTime time.Time, filter *alert.AlertEventFilter, maxSize int) ([]alert.AlertWithEventCount, uint64, error)
+	GetAlertsWithEventCount(ctx core.Context, startTime, endTime time.Time, filter *alert.AlertEventFilter, maxSize int) ([]alert.AlertWithEventCount, uint64, error)
 
 	// ========== alert events ==========
 	// Query the alarm events sampled by group and level, and sampleCount the number of samples for each group and level.
-	GetAlertEventCountGroupByInstance(startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]model.AlertEventCount, error)
+	GetAlertEventCountGroupByInstance(ctx core.Context, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]model.AlertEventCount, error)
 	// Query alarm events sampled by labels, sampleCount the number of samples for each label.
-	GetAlertEventsSample(sampleCount int, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]AlertEventSample, error)
+	GetAlertEventsSample(ctx core.Context, sampleCount int, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]AlertEventSample, error)
 	// Query alarm events by pageParam
-	GetAlertEvents(startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances, pageParam *request.PageParam) ([]alert.AlertEvent, uint64, error)
+	GetAlertEvents(ctx core.Context, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances, pageParam *request.PageParam) ([]alert.AlertEvent, uint64, error)
 	// ========== k8s events ============
 	// SeverityNumber > 9 (warning)
-	GetK8sAlertEventsSample(startTime time.Time, endTime time.Time, instances []*model.ServiceInstance) ([]K8sEvents, error)
+	GetK8sAlertEventsSample(ctx core.Context, startTime time.Time, endTime time.Time, instances []*model.ServiceInstance) ([]K8sEvents, error)
 
 	// profiling_event
 	// GetOnOffCPU get span execution consumption
-	GetOnOffCPU(pid uint32, nodeName string, startTime, endTime int64) (*[]ProfilingEvent, error)
+	GetOnOffCPU(ctx core.Context, pid uint32, nodeName string, startTime, endTime int64) (*[]ProfilingEvent, error)
 
 	// ========== network (deepflow) ==========
-	GetNetworkSpanSegments(traceId string, spanId string) ([]NetSegments, error)
+	GetNetworkSpanSegments(ctx core.Context, traceId string, spanId string) ([]NetSegments, error)
 
 	// ========== flame graph ===========
-	GetFlameGraphData(startTime, endTime int64, nodeName string, pid, tid int64, sampleType, spanId, traceId string) (*[]FlameGraphData, error)
+	GetFlameGraphData(ctx core.Context, startTime, endTime int64, nodeName string, pid, tid int64, sampleType, spanId, traceId string) (*[]FlameGraphData, error)
 
-	AddWorkflowRecord(ctx context.Context, record *model.WorkflowRecord) error
-	AddWorkflowRecords(ctx context.Context, records []model.WorkflowRecord) error
-	GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error)
-	GetAlertEventCounts(req *request.AlertEventSearchRequest, cacheMinutes int) (map[string]int64, error)
+	AddWorkflowRecord(ctx core.Context, record *model.WorkflowRecord) error
+	AddWorkflowRecords(ctx core.Context, records []model.WorkflowRecord) error
+	GetAlertEventWithWorkflowRecord(ctx core.Context, req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error)
+	GetAlertEventCounts(ctx core.Context, req *request.AlertEventSearchRequest, cacheMinutes int) (map[string]int64, error)
 
-	GetAlertDetail(req *request.GetAlertDetailRequest, cacheMinutes int) (*alert.AEventWithWRecord, error)
-	GetRelatedAlertEvents(req *request.GetAlertDetailRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error)
+	GetAlertDetail(ctx core.Context, req *request.GetAlertDetailRequest, cacheMinutes int) (*alert.AEventWithWRecord, error)
+	GetRelatedAlertEvents(ctx core.Context, req *request.GetAlertDetailRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error)
 
-	CreateAlertNotifyRecord(ctx context.Context, record model.AlertNotifyRecord) error
-	GetLatestAlertEventByAlertID(alertID string) (*alert.AlertEvent, error)
+	CreateAlertNotifyRecord(ctx core.Context, record model.AlertNotifyRecord) error
+	GetLatestAlertEventByAlertID(ctx core.Context, alertID string) (*alert.AlertEvent, error)
 
-	ManualResolveLatestAlertEventByAlertID(alertID string) error
+	ManualResolveLatestAlertEventByAlertID(ctx core.Context, alertID string) error
 
 	integration.Input
 }
 
 type chRepo struct {
-	conn     driver.Conn
+	*factory.Conn
+
 	database string
 	availableFilters
-	db *sql.DB
 
 	integration.Input
 }
@@ -150,37 +150,30 @@ func New(logger *zap.Logger, address []string, database string, username string,
 		return nil, fmt.Errorf("failed to connect to clickhouse: %s", err)
 	}
 
-	dsn := fmt.Sprintf("clickhouse://%s:%s@%s/%s", username, url.QueryEscape(password), address[0], database)
-	db, err := sql.Open("clickhouse", dsn)
-	if err != nil {
-		return nil, err
-	}
 	var repo *chRepo
 	// Use the wrapped Conn at the Debug log level, and output the time taken to execute SQL.
 	if logger.Level() == zap.DebugLevel {
 		repo = &chRepo{
 			database: database,
-			conn: &WrappedConn{
+			Conn: &factory.Conn{Conn: &WrappedConn{
 				Conn:   conn,
 				logger: logger,
-			},
-			db: db,
+			}},
 		}
 	} else {
 		repo = &chRepo{
 			database: database,
-			conn:     conn,
-			db:       db,
+			Conn:     &factory.Conn{Conn: conn},
 		}
 	}
 
 	now := time.Now()
-	filters, err := repo.UpdateFilterKey(now.Add(-48*time.Hour), now)
+	filters, err := repo.UpdateFilterKey(nil, now.Add(-48*time.Hour), now)
 	if err == nil {
 		repo.SetAvailableFilters(filters, now)
 	}
 
-	repo.Input, err = integration.NewInputRepo(repo.conn, repo.database)
+	repo.Input, err = integration.NewInputRepo(repo.Conn, repo.database)
 	if err != nil {
 		return nil, err
 	}
@@ -188,6 +181,6 @@ func New(logger *zap.Logger, address []string, database string, username string,
 	return repo, nil
 }
 
-func (ch *chRepo) GetConn() driver.Conn {
-	return ch.conn
+func (ch *chRepo) GetConn(ctx core.Context) driver.Conn {
+	return ch.GetContextDB(ctx)
 }

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
@@ -174,7 +175,7 @@ func sortbyParam(sortBy string) ([]string, []bool) {
 	return fields, ascs
 }
 
-func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error) {
+func (ch *chRepo) GetAlertEventWithWorkflowRecord(ctx core.Context, req *request.AlertEventSearchRequest, cacheMinutes int) ([]alert.AEventWithWRecord, int64, error) {
 	alertFilter := NewQueryBuilder().
 		Between("update_time", req.StartTime/1e6, req.EndTime/1e6).
 		NotGreaterThan("end_time", req.EndTime/1e6)
@@ -203,7 +204,7 @@ func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchR
 
 	values := append(alertFilter.values, recordFilter.values...)
 	values = append(values, resultFilter.values...)
-	err := ch.conn.QueryRow(context.Background(), countSql, values...).Scan(&count)
+	err := ch.GetContextDB(ctx).QueryRow(context.Background(), countSql, values...).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -211,7 +212,7 @@ func (ch *chRepo) GetAlertEventWithWorkflowRecord(req *request.AlertEventSearchR
 	sql, values := getSqlAndValueForSortedAlertEvent(req, cacheMinutes)
 
 	result := make([]alert.AEventWithWRecord, 0)
-	err = ch.conn.Select(context.Background(), &result, sql, values...)
+	err = ch.GetContextDB(ctx).Select(context.Background(), &result, sql, values...)
 	return result, int64(count), err
 }
 
@@ -277,7 +278,7 @@ func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest, cac
 	return sql, values
 }
 
-func (ch *chRepo) GetAlertEventCounts(req *request.AlertEventSearchRequest, cacheMinutes int) (map[string]int64, error) {
+func (ch *chRepo) GetAlertEventCounts(ctx core.Context, req *request.AlertEventSearchRequest, cacheMinutes int) (map[string]int64, error) {
 	alertFilter := NewQueryBuilder().
 		Between("update_time", req.StartTime/1e6, req.EndTime/1e6).
 		NotGreaterThan("end_time", req.EndTime/1e6)
@@ -292,7 +293,7 @@ func (ch *chRepo) GetAlertEventCounts(req *request.AlertEventSearchRequest, cach
 		recordFilter.String(),
 	)
 	values := append(alertFilter.values, recordFilter.values...)
-	err := ch.conn.Select(context.Background(), &counts, countSql, values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &counts, countSql, values...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_alert_events.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_events.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/google/uuid"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
@@ -83,7 +84,7 @@ const (
 )
 
 // GetAlertEventCountGroupByInstance to quickly query the number of alarms associated with each Instance (counted separately by alarm level)
-func (ch *chRepo) GetAlertEventCountGroupByInstance(startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]model.AlertEventCount, error) {
+func (ch *chRepo) GetAlertEventCountGroupByInstance(ctx core.Context, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]model.AlertEventCount, error) {
 	builder := NewQueryBuilder().
 		Between("received_time", startTime.Unix(), endTime.Unix()).
 		EqualsNotEmpty("source", filter.Source).
@@ -108,12 +109,12 @@ func (ch *chRepo) GetAlertEventCountGroupByInstance(startTime time.Time, endTime
 	sql := fmt.Sprintf(SQL_GET_GROUP_COUNTS_ALERT_EVENT, groupByInstance, groupByInstance, builder.String())
 
 	var events []model.AlertEventCount
-	err := ch.conn.Select(context.Background(), &events, sql, builder.values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &events, sql, builder.values...)
 	return events, err
 }
 
 // Obtain all alarm events of the instance GetAlarmsEvents
-func (ch *chRepo) GetAlertEventsSample(sampleCount int, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]AlertEventSample, error) {
+func (ch *chRepo) GetAlertEventsSample(ctx core.Context, sampleCount int, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances) ([]AlertEventSample, error) {
 	// Combined generation:
 	//  1. group = 'app' AND svc = svc_name
 	//  2. group = 'container' AND ((namespace,pod) in (...))
@@ -138,11 +139,11 @@ func (ch *chRepo) GetAlertEventsSample(sampleCount int, startTime time.Time, end
 	sql := fmt.Sprintf(SQL_GET_SAMPLE_ALERT_EVENT, builder.String(), sampleCount, byBuilder.String())
 
 	var events []AlertEventSample
-	err := ch.conn.Select(context.Background(), &events, sql, builder.values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &events, sql, builder.values...)
 	return events, err
 }
 
-func (ch *chRepo) GetAlertEvents(startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances, pageParam *request.PageParam) ([]alert.AlertEvent, uint64, error) {
+func (ch *chRepo) GetAlertEvents(ctx core.Context, startTime time.Time, endTime time.Time, filter request.AlertFilter, instances *model.RelatedInstances, pageParam *request.PageParam) ([]alert.AlertEvent, uint64, error) {
 	var whereInstance *whereSQL = ALWAYS_TRUE
 	if len(filter.Services) > 0 ||
 		len(filter.Endpoint) > 0 ||
@@ -163,7 +164,7 @@ func (ch *chRepo) GetAlertEvents(startTime time.Time, endTime time.Time, filter 
 
 	var count uint64
 	countSql := buildAlertEventsCountQuery(GET_ALERT_EVENTS_COUNT, builder)
-	err := ch.conn.QueryRow(context.Background(), countSql, builder.values...).Scan(&count)
+	err := ch.GetContextDB(ctx).QueryRow(context.Background(), countSql, builder.values...).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -179,7 +180,7 @@ func (ch *chRepo) GetAlertEvents(startTime time.Time, endTime time.Time, filter 
 
 	sql := buildGetPagedAlertEventQuery(SQL_GET_PAGED_ALERT_EVENT, builder, orderBuilder)
 	var events []alert.AlertEvent
-	err = ch.conn.Select(context.Background(), &events, sql, builder.values...)
+	err = ch.GetContextDB(ctx).Select(context.Background(), &events, sql, builder.values...)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -197,8 +198,8 @@ func buildAlertEventsCountQuery(baseQuery string, builder *QueryBuilder) string 
 	return countSql
 }
 
-func (ch *chRepo) InsertBatchAlertEvents(ctx context.Context, events []*model.AlertEvent) error {
-	batch, err := ch.conn.PrepareBatch(ctx, `
+func (ch *chRepo) InsertBatchAlertEvents(ctx core.Context, events []*model.AlertEvent) error {
+	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
 		INSERT INTO alert_event (source, id, alert_id, create_time, update_time, end_time, received_time, severity, group,
 		                         name, detail, tags, status)
 		VALUES
@@ -222,7 +223,7 @@ func (ch *chRepo) InsertBatchAlertEvents(ctx context.Context, events []*model.Al
 }
 
 // ReadAlertEvent implement the Read method of the AlertEventDAO interface
-func (ch *chRepo) ReadAlertEvent(ctx context.Context, id uuid.UUID) (*model.AlertEvent, error) {
+func (ch *chRepo) ReadAlertEvent(ctx core.Context, id uuid.UUID) (*model.AlertEvent, error) {
 	var event model.AlertEvent
 	query := `
 		SELECT source, id, create_time, update_time, end_time, received_time, severity
@@ -230,7 +231,7 @@ func (ch *chRepo) ReadAlertEvent(ctx context.Context, id uuid.UUID) (*model.Aler
 		FROM alert_event
 		WHERE id = ?
 	`
-	err := ch.conn.QueryRow(ctx, query, id).Scan(
+	err := ch.GetContextDB(ctx).QueryRow(ctx.GetContext(), query, id).Scan(
 		&event.Source, &event.ID, &event.CreateTime, &event.UpdateTime, &event.EndTime,
 		&event.ReceivedTime, &event.Severity, &event.Group, &event.Name, &event.Detail, &event.Tags, &event.Status,
 	)

--- a/backend/pkg/repository/clickhouse/dao_alert_notify.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_notify.go
@@ -4,14 +4,14 @@
 package clickhouse
 
 import (
-	"context"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (ch *chRepo) CreateAlertNotifyRecord(ctx context.Context, record model.AlertNotifyRecord) error {
-	batch, err := ch.conn.PrepareBatch(ctx, `
+func (ch *chRepo) CreateAlertNotifyRecord(ctx core.Context, record model.AlertNotifyRecord) error {
+	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
 		INSERT INTO alert_notify_record (alert_id, created_at, event_id, success,failed)
 		VALUES
 	`)

--- a/backend/pkg/repository/clickhouse/dao_alerts_with_event_count.go
+++ b/backend/pkg/repository/clickhouse/dao_alerts_with_event_count.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
@@ -28,7 +29,7 @@ FROM alert a LEFT JOIN event_count ec on a.alert_id = ec.alert_id
 ORDER BY received_time DESC LIMIT 5000;
 `
 
-func (ch *chRepo) GetAlertsWithEventCount(
+func (ch *chRepo) GetAlertsWithEventCount(ctx core.Context,
 	startTime, endTime time.Time,
 	filter *alert.AlertEventFilter, maxSize int,
 ) ([]alert.AlertWithEventCount, uint64, error) {
@@ -39,7 +40,7 @@ func (ch *chRepo) GetAlertsWithEventCount(
 
 	var count uint64
 	countSql := buildAlertQuery(GET_ALERT_EVENTS_COUNT, alertFilter)
-	err := ch.conn.QueryRow(context.Background(), countSql, alertFilter.values...).Scan(&count)
+	err := ch.GetContextDB(ctx).QueryRow(context.Background(), countSql, alertFilter.values...).Scan(&count)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -50,7 +51,7 @@ func (ch *chRepo) GetAlertsWithEventCount(
 
 	sql := fmt.Sprintf(GET_ALERTS_WITH_EVENT_COUNT, alertFilter.String(), alertFilter.String())
 	result := make([]alert.AlertWithEventCount, 0)
-	err = ch.conn.Select(context.Background(), &result, sql, values...)
+	err = ch.GetContextDB(ctx).Select(context.Background(), &result, sql, values...)
 	return result, count, err
 }
 

--- a/backend/pkg/repository/clickhouse/dao_error_propagation.go
+++ b/backend/pkg/repository/clickhouse/dao_error_propagation.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -45,7 +46,7 @@ const (
 )
 
 // Query instance-related error propagation chain
-func (ch *chRepo) ListErrorPropagation(req *request.GetErrorInstanceRequest) ([]ErrorInstancePropagation, error) {
+func (ch *chRepo) ListErrorPropagation(ctx core.Context, req *request.GetErrorInstanceRequest) ([]ErrorInstancePropagation, error) {
 	startTime := req.StartTime / 1000000
 	endTime := req.EndTime / 1000000
 	queryBuilder := NewQueryBuilder().
@@ -62,7 +63,7 @@ func (ch *chRepo) ListErrorPropagation(req *request.GetErrorInstanceRequest) ([]
 		Limit(2000).String()
 	var results []ErrorInstancePropagation
 	sql := fmt.Sprintf(SQL_GET_INSTANCE_ERROR_PROPAGATION, ch.database, queryBuilder.String(), bySql, startTime, endTime, startTime, endTime)
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 	return results, nil

--- a/backend/pkg/repository/clickhouse/dao_flame_graph.go
+++ b/backend/pkg/repository/clickhouse/dao_flame_graph.go
@@ -6,6 +6,8 @@ package clickhouse
 import (
 	"context"
 	"fmt"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
 type FlameGraphData struct {
@@ -21,7 +23,7 @@ type FlameGraphData struct {
 
 const flame_graph_sql = `SELECT DISTINCT toUnixTimestamp64Nano(start_time) as start_time, toUnixTimestamp64Nano(end_time) as end_time, pid, tid, sample_type, sample_rate, labels, flamebearer FROM flame_graph %s ORDER BY start_time DESC`
 
-func (ch *chRepo) GetFlameGraphData(startTime, endTime int64, nodeName string, pid, tid int64, sampleType, spanId, traceId string) (*[]FlameGraphData, error) {
+func (ch *chRepo) GetFlameGraphData(ctx core.Context, startTime, endTime int64, nodeName string, pid, tid int64, sampleType, spanId, traceId string) (*[]FlameGraphData, error) {
 	queryBuilder := NewQueryBuilder()
 	queryBuilder.Between("start_time", startTime*1000, endTime*1000).
 		Between("end_time", startTime*1000, endTime*1000).
@@ -37,7 +39,7 @@ func (ch *chRepo) GetFlameGraphData(startTime, endTime int64, nodeName string, p
 	}
 	sql := buildFlameGraphQuery(queryBuilder)
 	result := make([]FlameGraphData, 0)
-	err := ch.conn.Select(context.Background(), &result, sql, queryBuilder.values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &result, sql, queryBuilder.values...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_k8s_event.go
+++ b/backend/pkg/repository/clickhouse/dao_k8s_event.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
@@ -27,7 +28,7 @@ const (
 )
 
 // K8sAlert query K8S alarm
-func (ch *chRepo) GetK8sAlertEventsSample(startTime time.Time, endTime time.Time, instances []*model.ServiceInstance) ([]K8sEvents, error) {
+func (ch *chRepo) GetK8sAlertEventsSample(ctx core.Context, startTime time.Time, endTime time.Time, instances []*model.ServiceInstance) ([]K8sEvents, error) {
 	relatedObj := make([]string, 0)
 	for _, instance := range instances {
 		if instance == nil {
@@ -52,7 +53,7 @@ func (ch *chRepo) GetK8sAlertEventsSample(startTime time.Time, endTime time.Time
 	query := fmt.Sprintf(SQL_GET_K8S_EVENTS, builder.String(), 1)
 	// Execute query
 	var res []K8sEvents
-	err := ch.conn.Select(context.Background(), &res, query, builder.values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &res, query, builder.values...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_k8s_event_test.go
+++ b/backend/pkg/repository/clickhouse/dao_k8s_event_test.go
@@ -23,7 +23,7 @@ func TestChRepo_K8sAlert(t *testing.T) {
 			NodeName: "worker-23",
 		},
 	}
-	k8sAlert, err := repo.GetK8sAlertEventsSample(oneHourAgo, currentTime, instances)
+	k8sAlert, err := repo.GetK8sAlertEventsSample(nil, oneHourAgo, currentTime, instances)
 	if err != nil {
 		t.Fatalf("Error to get k8sAlert: %v", err)
 	}

--- a/backend/pkg/repository/clickhouse/dao_log_chart.go
+++ b/backend/pkg/repository/clickhouse/dao_log_chart.go
@@ -6,6 +6,7 @@ package clickhouse
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -43,9 +44,9 @@ func chartSQL(baseQuery string, req *request.LogQueryRequest) (string, int64) {
 	return sql, interval
 }
 
-func (ch *chRepo) GetLogChart(req *request.LogQueryRequest) ([]map[string]any, int64, error) {
+func (ch *chRepo) GetLogChart(ctx core.Context, req *request.LogQueryRequest) ([]map[string]any, int64, error) {
 	sql, interval := chartSQL(queryLogChart, req)
-	results, err := ch.queryRowsData(sql)
+	results, err := ch.queryRowsData(ctx, sql)
 	if err != nil {
 		return nil, interval, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_log_index.go
+++ b/backend/pkg/repository/clickhouse/dao_log_index.go
@@ -6,6 +6,7 @@ package clickhouse
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -35,9 +36,9 @@ func countSQL(baseQuery string, req *request.LogIndexRequest) string {
 	return sql
 }
 
-func (ch *chRepo) GetLogIndex(req *request.LogIndexRequest) (map[string]uint64, uint64, error) {
+func (ch *chRepo) GetLogIndex(ctx core.Context, req *request.LogIndexRequest) (map[string]uint64, uint64, error) {
 	groupSQL := groupBySQL(groupLogIndexQuery, req)
-	groupRows, err := ch.queryRowsData(groupSQL)
+	groupRows, err := ch.queryRowsData(ctx, groupSQL)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -78,7 +79,7 @@ func (ch *chRepo) GetLogIndex(req *request.LogIndexRequest) (map[string]uint64, 
 		}
 	}
 	countSQL := countSQL(countLogIndexQuery, req)
-	countRows, err := ch.queryRowsData(countSQL)
+	countRows, err := ch.queryRowsData(ctx, countSQL)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_log_table.go
+++ b/backend/pkg/repository/clickhouse/dao_log_table.go
@@ -6,14 +6,15 @@ package clickhouse
 import (
 	"context"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse/factory"
 )
 
-func (ch *chRepo) CreateLogTable(params *request.LogTableRequest) ([]string, error) {
+func (ch *chRepo) CreateLogTable(ctx core.Context, params *request.LogTableRequest) ([]string, error) {
 	sqls := factory.GetCreateTableSQL(params)
 	for _, sql := range sqls {
-		err := ch.conn.Exec(context.Background(), sql)
+		err := ch.GetContextDB(ctx).Exec(context.Background(), sql)
 		if err != nil {
 			return nil, err
 		}
@@ -21,10 +22,10 @@ func (ch *chRepo) CreateLogTable(params *request.LogTableRequest) ([]string, err
 	return sqls, nil
 }
 
-func (ch *chRepo) DropLogTable(params *request.LogTableRequest) ([]string, error) {
+func (ch *chRepo) DropLogTable(ctx core.Context, params *request.LogTableRequest) ([]string, error) {
 	sqls := factory.GetDropTableSQL(params)
 	for _, sql := range sqls {
-		err := ch.conn.Exec(context.Background(), sql)
+		err := ch.GetContextDB(ctx).Exec(context.Background(), sql)
 		if err != nil {
 			return nil, err
 		}
@@ -32,10 +33,10 @@ func (ch *chRepo) DropLogTable(params *request.LogTableRequest) ([]string, error
 	return sqls, nil
 }
 
-func (ch *chRepo) UpdateLogTable(req *request.LogTableRequest, old []request.Field) ([]string, error) {
+func (ch *chRepo) UpdateLogTable(ctx core.Context, req *request.LogTableRequest, old []request.Field) ([]string, error) {
 	sqls := factory.GetUpdateTableSQLByFields(req, old)
 	for _, sql := range sqls {
-		err := ch.conn.Exec(context.Background(), sql)
+		err := ch.GetContextDB(ctx).Exec(context.Background(), sql)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/pkg/repository/clickhouse/dao_network_span_segments.go
+++ b/backend/pkg/repository/clickhouse/dao_network_span_segments.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
 type NetSegments struct {
@@ -18,13 +20,13 @@ type NetSegments struct {
 	TraceId          string    `ch:"trace_id"`
 }
 
-func (ch *chRepo) GetNetworkSpanSegments(traceId string, spanId string) ([]NetSegments, error) {
+func (ch *chRepo) GetNetworkSpanSegments(ctx core.Context, traceId string, spanId string) ([]NetSegments, error) {
 	queryBuilder := NewQueryBuilder().
 		EqualsNotEmpty("trace_id", traceId).
 		EqualsNotEmpty("span_id", spanId)
 	executeSql := buildQuery(queryBuilder)
 	var netSegments []NetSegments
-	if err := ch.conn.Select(context.Background(), &netSegments, executeSql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &netSegments, executeSql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 	return netSegments, nil

--- a/backend/pkg/repository/clickhouse/dao_other_log_table.go
+++ b/backend/pkg/repository/clickhouse/dao_other_log_table.go
@@ -6,6 +6,7 @@ package clickhouse
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -17,18 +18,18 @@ FROM system.tables;
 `
 
 const queryOtherTableInfoSQL = `
-SELECT 
+SELECT
     name,type
-FROM 
+FROM
     system.columns
 WHERE database = '%s' And table = '%s';
 `
 
-func (ch *chRepo) OtherLogTable() ([]map[string]any, error) {
-	return ch.queryRowsData(queryOtherTablesSQL)
+func (ch *chRepo) OtherLogTable(ctx core.Context) ([]map[string]any, error) {
+	return ch.queryRowsData(ctx, queryOtherTablesSQL)
 }
 
-func (ch *chRepo) OtherLogTableInfo(req *request.OtherTableInfoRequest) ([]map[string]any, error) {
+func (ch *chRepo) OtherLogTableInfo(ctx core.Context, req *request.OtherTableInfoRequest) ([]map[string]any, error) {
 	sql := fmt.Sprintf(queryOtherTableInfoSQL, req.DataBase, req.TableName)
-	return ch.queryRowsData(sql)
+	return ch.queryRowsData(ctx, sql)
 }

--- a/backend/pkg/repository/clickhouse/dao_profilling_event.go
+++ b/backend/pkg/repository/clickhouse/dao_profilling_event.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fmt"
 	"time"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
 type ProfilingEvent struct {
@@ -27,7 +29,7 @@ type ProfilingEvent struct {
 
 const profiling_event_sql = `SELECT %s FROM profiling_event %s LIMIT %s`
 
-func (ch *chRepo) GetOnOffCPU(pid uint32, nodeName string, startTime, endTime int64) (*[]ProfilingEvent, error) {
+func (ch *chRepo) GetOnOffCPU(ctx core.Context, pid uint32, nodeName string, startTime, endTime int64) (*[]ProfilingEvent, error) {
 	queryBuilder := NewQueryBuilder()
 	querySql := queryBuilder.
 		Between("startTime", startTime, endTime).
@@ -47,7 +49,7 @@ func (ch *chRepo) GetOnOffCPU(pid uint32, nodeName string, startTime, endTime in
 		Alias("intDiv(endTime, 1000)", "endTime").String()
 	sql := buildProfilingEventQuery(fieldSql, querySql)
 	result := make([]ProfilingEvent, 0)
-	err := ch.conn.Select(context.Background(), &result, sql, queryBuilder.values...)
+	err := ch.GetContextDB(ctx).Select(context.Background(), &result, sql, queryBuilder.values...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_query_all_log.go
+++ b/backend/pkg/repository/clickhouse/dao_query_all_log.go
@@ -6,6 +6,7 @@ package clickhouse
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -13,7 +14,7 @@ const (
 	logsBaseQuery = "SELECT * FROM `%s`.`%s` WHERE %s %s"
 )
 
-func (ch *chRepo) QueryAllLogs(req *request.LogQueryRequest) ([]map[string]any, string, error) {
+func (ch *chRepo) QueryAllLogs(ctx core.Context, req *request.LogQueryRequest) ([]map[string]any, string, error) {
 	condition := NewQueryCondition(req.StartTime, req.EndTime, req.TimeField, req.Query)
 	bySql := NewByLimitBuilder().
 		OrderBy(fmt.Sprintf("`%s`", req.TimeField), false).
@@ -22,7 +23,7 @@ func (ch *chRepo) QueryAllLogs(req *request.LogQueryRequest) ([]map[string]any, 
 		String()
 	sql := buildAllLogsQuery(logsBaseQuery, req, condition, bySql)
 
-	results, err := ch.queryRowsData(sql)
+	results, err := ch.queryRowsData(ctx, sql)
 	if err != nil {
 		return nil, sql, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_query_log_context.go
+++ b/backend/pkg/repository/clickhouse/dao_query_log_context.go
@@ -6,6 +6,7 @@ package clickhouse
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
@@ -39,7 +40,7 @@ func reverseSlice(s []map[string]any) {
 		s[i], s[j] = s[j], s[i]
 	}
 }
-func (ch *chRepo) QueryLogContext(req *request.LogQueryContextRequest) ([]map[string]any, []map[string]any, error) {
+func (ch *chRepo) QueryLogContext(ctx core.Context, req *request.LogQueryContextRequest) ([]map[string]any, []map[string]any, error) {
 	//condition := NewQueryCondition(req.StartTime, req.EndTime, req.TimeField, req.Query)
 	logtime := req.Time / 1000000
 	timefront := fmt.Sprintf("toUnixTimestamp(timestamp) < %d AND  toUnixTimestamp(timestamp) > %d ", logtime, logtime-60)
@@ -50,7 +51,7 @@ func (ch *chRepo) QueryLogContext(req *request.LogQueryContextRequest) ([]map[st
 		Limit(50).
 		String()
 	frontSql := fmt.Sprintf(logsBaseQuery, req.DataBase, req.TableName, timefront+tags, bySqlfront)
-	front, err := ch.queryRowsData(frontSql)
+	front, err := ch.queryRowsData(ctx, frontSql)
 	if err != nil {
 		front = []map[string]any{}
 	}
@@ -61,7 +62,7 @@ func (ch *chRepo) QueryLogContext(req *request.LogQueryContextRequest) ([]map[st
 		Limit(50).
 		String()
 	endSql := fmt.Sprintf(logsBaseQuery, req.DataBase, req.TableName, timeend+tags, bySqlend)
-	end, err := ch.queryRowsData(endSql)
+	end, err := ch.queryRowsData(ctx, endSql)
 	if err != nil {
 		end = []map[string]any{}
 	}

--- a/backend/pkg/repository/clickhouse/dao_query_rows.go
+++ b/backend/pkg/repository/clickhouse/dao_query_rows.go
@@ -3,17 +3,16 @@
 
 package clickhouse
 
-func (ch *chRepo) queryRowsData(sql string) ([]map[string]any, error) {
-	rows, err := ch.db.Query(sql)
+import core "github.com/CloudDetail/apo/backend/pkg/core"
+
+func (ch *chRepo) queryRowsData(ctx core.Context, sql string) ([]map[string]any, error) {
+	rows, err := ch.GetContextDB(ctx).Query(ctx.GetContext(), sql)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	columns, err := rows.Columns()
-	if err != nil {
-		return nil, err
-	}
+	columns := rows.Columns()
 	results := make([]map[string]interface{}, 0)
 	for rows.Next() {
 		values := make([]interface{}, len(columns))

--- a/backend/pkg/repository/clickhouse/dao_service_k8s_events.go
+++ b/backend/pkg/repository/clickhouse/dao_service_k8s_events.go
@@ -6,6 +6,8 @@ package clickhouse
 import (
 	"context"
 	"log"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
 const (
@@ -49,10 +51,10 @@ const (
 
 // CountK8sEvents count the number of K8s events
 // Time in microseconds
-func (ch *chRepo) CountK8sEvents(startTime int64, endTim int64, pods []string) ([]K8sEventsCount, error) {
+func (ch *chRepo) CountK8sEvents(ctx core.Context, startTime int64, endTim int64, pods []string) ([]K8sEventsCount, error) {
 	result := make([]K8sEventsCount, 0)
 	// Execute query
-	rows, err := ch.conn.Query(context.Background(), countK8sEventsSQL, startTime/1e6, endTim/1e6, pods)
+	rows, err := ch.GetContextDB(ctx).Query(context.Background(), countK8sEventsSQL, startTime/1e6, endTim/1e6, pods)
 	if err != nil {
 		return result, err
 	}

--- a/backend/pkg/repository/clickhouse/dao_service_relationship.go
+++ b/backend/pkg/repository/clickhouse/dao_service_relationship.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
@@ -54,7 +55,7 @@ const (
 )
 
 // Query the list of upstream nodes
-func (ch *chRepo) ListParentNodes(req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error) {
+func (ch *chRepo) ListParentNodes(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error) {
 	queryBuilder := NewQueryBuilder().
 		Between("timestamp", req.StartTime/1000000, req.EndTime/1000000).
 		Equals("service", req.Service).
@@ -66,7 +67,7 @@ func (ch *chRepo) ListParentNodes(req *request.GetServiceEndpointTopologyRequest
 
 	results := []ParentNode{}
 	sql := fmt.Sprintf(SQL_GET_PARENT_NODES, queryBuilder.String())
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 
@@ -74,7 +75,7 @@ func (ch *chRepo) ListParentNodes(req *request.GetServiceEndpointTopologyRequest
 }
 
 // Query the downstream outbound call list
-func (ch *chRepo) ListChildNodes(req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error) {
+func (ch *chRepo) ListChildNodes(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*model.TopologyNodes, error) {
 	queryBuilder := NewQueryBuilder().
 		Between("timestamp", req.StartTime/1000000, req.EndTime/1000000).
 		Equals("parent_service", req.Service).
@@ -84,7 +85,7 @@ func (ch *chRepo) ListChildNodes(req *request.GetServiceEndpointTopologyRequest)
 
 	results := []ChildNode{}
 	sql := fmt.Sprintf(SQL_GET_CHILD_NODES, queryBuilder.String())
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 
@@ -92,7 +93,7 @@ func (ch *chRepo) ListChildNodes(req *request.GetServiceEndpointTopologyRequest)
 }
 
 // Query the list of all descendant nodes
-func (ch *chRepo) ListDescendantNodes(req *request.GetDescendantMetricsRequest) (*model.TopologyNodes, error) {
+func (ch *chRepo) ListDescendantNodes(ctx core.Context, req *request.GetDescendantMetricsRequest) (*model.TopologyNodes, error) {
 	startTime := req.StartTime / 1000000
 	endTime := req.EndTime / 1000000
 	queryBuilder := NewQueryBuilder().
@@ -103,14 +104,14 @@ func (ch *chRepo) ListDescendantNodes(req *request.GetDescendantMetricsRequest) 
 		EqualsNotEmpty("entry_url", req.EntryEndpoint)
 	sql := fmt.Sprintf(SQL_GET_DESCENDANT_TOPOLOGY, ch.database, queryBuilder.String())
 	results := []ChildRelation{}
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 	return getDescendantNodes(results), nil
 }
 
 // Query the topological relationships of all descendants
-func (ch *chRepo) ListDescendantRelations(req *request.GetServiceEndpointTopologyRequest) ([]*model.ToplogyRelation, error) {
+func (ch *chRepo) ListDescendantRelations(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) ([]*model.ToplogyRelation, error) {
 	startTime := req.StartTime / 1000000
 	endTime := req.EndTime / 1000000
 	queryBuilder := NewQueryBuilder().
@@ -121,14 +122,14 @@ func (ch *chRepo) ListDescendantRelations(req *request.GetServiceEndpointTopolog
 		EqualsNotEmpty("entry_url", req.EntryEndpoint)
 	sql := fmt.Sprintf(SQL_GET_DESCENDANT_TOPOLOGY, ch.database, queryBuilder.String())
 	results := []ChildRelation{}
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 	return getDescendantRelations(results), nil
 }
 
 // Query the list of related entry nodes
-func (ch *chRepo) ListEntryEndpoints(req *request.GetServiceEntryEndpointsRequest) ([]EntryNode, error) {
+func (ch *chRepo) ListEntryEndpoints(ctx core.Context, req *request.GetServiceEntryEndpointsRequest) ([]EntryNode, error) {
 	startTime := req.StartTime / 1000000
 	endTime := req.EndTime / 1000000
 	queryBuilder := NewQueryBuilder().
@@ -140,7 +141,7 @@ func (ch *chRepo) ListEntryEndpoints(req *request.GetServiceEntryEndpointsReques
 	}
 	results := []EntryNode{}
 	sql := fmt.Sprintf(SQL_GET_ENTRY_NODES, queryBuilder.String())
-	if err := ch.conn.Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
+	if err := ch.GetContextDB(ctx).Select(context.Background(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}
 	return results, nil

--- a/backend/pkg/repository/clickhouse/dao_test.go
+++ b/backend/pkg/repository/clickhouse/dao_test.go
@@ -43,7 +43,7 @@ func testListParentNodes(t *testing.T, repo Repo) {
 		Service:   "stuck-demo-undertow",
 		Endpoint:  "GET /db/query",
 	}
-	resp, err := repo.ListParentNodes(req)
+	resp, err := repo.ListParentNodes(nil, req)
 	if err != nil {
 		t.Errorf("Error to list parent nodes: %v", err)
 	}
@@ -66,7 +66,7 @@ func testKafkaListParentNodes(t *testing.T, repo Repo) {
 		Service:   "kafka-consumer",
 		Endpoint:  "topic_login process",
 	}
-	resp, err := repo.ListParentNodes(req)
+	resp, err := repo.ListParentNodes(nil, req)
 	if err != nil {
 		t.Errorf("Error to list parent nodes: %v", err)
 	}
@@ -89,7 +89,7 @@ func testListChildNodes(t *testing.T, repo Repo) {
 		Service:   "stuck-demo-tomcat",
 		Endpoint:  "GET /redis/query",
 	}
-	resp, err := repo.ListChildNodes(req)
+	resp, err := repo.ListChildNodes(nil, req)
 	if err != nil {
 		t.Errorf("Error to list child nodes: %v", err)
 	}
@@ -126,7 +126,7 @@ func testDescendantNodes(t *testing.T, repo Repo) {
 		Service:   "kafka-provider",
 		Endpoint:  "GET /send",
 	}
-	resp, err := repo.ListDescendantNodes(req)
+	resp, err := repo.ListDescendantNodes(nil, req)
 	if err != nil {
 		t.Errorf("Error to list child nodes: %v", err)
 	}
@@ -156,7 +156,7 @@ func testDescendantRelations(t *testing.T, repo Repo) {
 		Service:   "stuck-demo-tomcat",
 		Endpoint:  "GET /wait/callOthers",
 	}
-	resp, err := repo.ListDescendantRelations(req)
+	resp, err := repo.ListDescendantRelations(nil, req)
 	if err != nil {
 		t.Errorf("Error to list descendant relation: %v", err)
 	}
@@ -199,7 +199,7 @@ func testKafkaDescendantRelations(t *testing.T, repo Repo) {
 		Service:   "kafka-provider",
 		Endpoint:  "GET /send",
 	}
-	resp, err := repo.ListDescendantRelations(req)
+	resp, err := repo.ListDescendantRelations(nil, req)
 	if err != nil {
 		t.Errorf("Error to list descendant relation: %v", err)
 	}
@@ -228,7 +228,7 @@ func testKafkaDescendantRelations(t *testing.T, repo Repo) {
 
 func testCountK8sEvents(t *testing.T, repo Repo) {
 	pods := []string{"ts-travel2-service-fdbbd5946-l4h2r"}
-	count, err := repo.CountK8sEvents(1722244803099000, 1722245703099000, pods)
+	count, err := repo.CountK8sEvents(nil, 1722244803099000, 1722245703099000, pods)
 	if err != nil {
 		t.Errorf("Error to get k8s events: %v", err)
 	}

--- a/backend/pkg/repository/clickhouse/dao_workflow_records.go
+++ b/backend/pkg/repository/clickhouse/dao_workflow_records.go
@@ -4,14 +4,14 @@
 package clickhouse
 
 import (
-	"context"
 	"time"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 )
 
-func (ch *chRepo) AddWorkflowRecord(ctx context.Context, record *model.WorkflowRecord) error {
-	batch, err := ch.conn.PrepareBatch(ctx, `
+func (ch *chRepo) AddWorkflowRecord(ctx core.Context, record *model.WorkflowRecord) error {
+	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
 		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at, rounded_time)
 		VALUES
 	`)
@@ -36,8 +36,8 @@ func (ch *chRepo) AddWorkflowRecord(ctx context.Context, record *model.WorkflowR
 	return nil
 }
 
-func (ch *chRepo) AddWorkflowRecords(ctx context.Context, records []model.WorkflowRecord) error {
-	batch, err := ch.conn.PrepareBatch(ctx, `
+func (ch *chRepo) AddWorkflowRecords(ctx core.Context, records []model.WorkflowRecord) error {
+	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
 		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at, rounded_time)
 		VALUES
 	`)

--- a/backend/pkg/repository/clickhouse/factory/conn.go
+++ b/backend/pkg/repository/clickhouse/factory/conn.go
@@ -1,0 +1,14 @@
+package factory
+
+import (
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+)
+
+type Conn struct {
+	driver.Conn
+}
+
+func (c *Conn) GetContextDB(ctx core.Context) driver.Conn {
+	return c.Conn
+}

--- a/backend/pkg/repository/clickhouse/factory/conn.go
+++ b/backend/pkg/repository/clickhouse/factory/conn.go
@@ -1,3 +1,6 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package factory
 
 import (

--- a/backend/pkg/repository/clickhouse/integration/alert.go
+++ b/backend/pkg/repository/clickhouse/integration/alert.go
@@ -4,15 +4,15 @@
 package integration
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
-func (ch *chRepo) InsertAlertEvent(ctx context.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error {
-	batch, err := ch.conn.PrepareBatch(ctx, `
+func (ch *chRepo) InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error {
+	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
 		INSERT INTO alert_event (id,name,group,severity, status, detail, alert_id, raw_tags, tags,create_time, update_time, end_time, received_time, source_id, source)
 		VALUES
 	`)

--- a/backend/pkg/repository/clickhouse/integration/input.go
+++ b/backend/pkg/repository/clickhouse/integration/input.go
@@ -4,26 +4,27 @@
 package integration
 
 import (
-	"context"
-
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse/factory"
 )
 
 type Input interface {
-	InsertAlertEvent(ctx context.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error
+	InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error
 }
 
 var _ Input = &chRepo{}
 
 type chRepo struct {
-	conn     driver.Conn
+	factory.Conn
 	database string
 }
 
 func NewInputRepo(conn driver.Conn, database string) (*chRepo, error) {
+	c := factory.Conn{Conn: conn}
 	return &chRepo{
-		conn:     conn,
+		Conn:     c,
 		database: database,
 	}, nil
 }

--- a/backend/pkg/repository/database/alert_manager.go
+++ b/backend/pkg/repository/database/alert_manager.go
@@ -5,26 +5,28 @@ package database
 
 import (
 	"errors"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"gorm.io/gorm"
 )
 
-func (repo *daoRepo) CreateDingTalkReceiver(dingTalkConfig *amconfig.DingTalkConfig) error {
-	return repo.db.Create(dingTalkConfig).Error
+func (repo *daoRepo) CreateDingTalkReceiver(ctx core.Context, dingTalkConfig *amconfig.DingTalkConfig) error {
+	return repo.GetContextDB(ctx).Create(dingTalkConfig).Error
 }
 
-func (repo *daoRepo) GetDingTalkReceiver(uuid string) (amconfig.DingTalkConfig, error) {
+func (repo *daoRepo) GetDingTalkReceiver(ctx core.Context, uuid string) (amconfig.DingTalkConfig, error) {
 	config := amconfig.DingTalkConfig{}
-	err := repo.db.Select("url, secret").Where("uuid = ?", uuid).First(&config).Error
+	err := repo.GetContextDB(ctx).Select("url, secret").Where("uuid = ?", uuid).First(&config).Error
 	return config, err
 }
 
-func (repo *daoRepo) GetDingTalkReceiverByAlertName(configFile string, alertName string, page, pageSize int) ([]*amconfig.DingTalkConfig, int64, error) {
+func (repo *daoRepo) GetDingTalkReceiverByAlertName(ctx core.Context, configFile string, alertName string, page, pageSize int) ([]*amconfig.DingTalkConfig, int64, error) {
 	var dingTalkConfigs []*amconfig.DingTalkConfig
 	offset := (page - 1) * pageSize
 
-	query := repo.db.Select("alert_name, url, secret").Where("config_file = ?", configFile)
-	countQuery := repo.db.Model(&amconfig.DingTalkConfig{}).Select("*").Where("config_file = ?", configFile)
+	query := repo.GetContextDB(ctx).Select("alert_name, url, secret").Where("config_file = ?", configFile)
+	countQuery := repo.GetContextDB(ctx).Model(&amconfig.DingTalkConfig{}).Select("*").Where("config_file = ?", configFile)
 
 	if len(alertName) > 0 {
 		query = query.Where("alert_name = ?", alertName)
@@ -41,10 +43,10 @@ func (repo *daoRepo) GetDingTalkReceiverByAlertName(configFile string, alertName
 	return dingTalkConfigs, count, nil
 }
 
-func (repo *daoRepo) UpdateDingTalkReceiver(dingTalkConfig *amconfig.DingTalkConfig, oldName string) error {
-	return repo.db.Where("config_file = ? AND alert_name = ?", dingTalkConfig.ConfigFile, oldName).Updates(dingTalkConfig).Error
+func (repo *daoRepo) UpdateDingTalkReceiver(ctx core.Context, dingTalkConfig *amconfig.DingTalkConfig, oldName string) error {
+	return repo.GetContextDB(ctx).Where("config_file = ? AND alert_name = ?", dingTalkConfig.ConfigFile, oldName).Updates(dingTalkConfig).Error
 }
 
-func (repo *daoRepo) DeleteDingTalkReceiver(configFile, alertName string) error {
-	return repo.db.Where("config_file = ? AND alert_name = ?", configFile, alertName).Delete(&amconfig.DingTalkConfig{}).Error
+func (repo *daoRepo) DeleteDingTalkReceiver(ctx core.Context, configFile, alertName string) error {
+	return repo.GetContextDB(ctx).Where("config_file = ? AND alert_name = ?", configFile, alertName).Delete(&amconfig.DingTalkConfig{}).Error
 }

--- a/backend/pkg/repository/database/dao.go
+++ b/backend/pkg/repository/database/dao.go
@@ -4,7 +4,6 @@
 package database
 
 import (
-	"context"
 	"database/sql"
 	"errors"
 	"fmt"
@@ -21,135 +20,135 @@ import (
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 )
 
 // Define the Database query interface
 type Repo interface {
-	CreateOrUpdateThreshold(model *Threshold) error
-	GetOrCreateThreshold(serviceName string, endPoint string, level string) (Threshold, error)
-	DeleteThreshold(serviceName string, endPoint string) error
-	OperateLogTableInfo(model *LogTableInfo, op Operator) error
-	GetAllLogTable() ([]LogTableInfo, error)
-	UpdateLogParseRule(model *LogTableInfo) error
-	GetAllOtherLogTable() ([]OtherLogTable, error)
-	OperatorOtherLogTable(model *OtherLogTable, op Operator) error
-	CreateDingTalkReceiver(dingTalkConfig *amconfig.DingTalkConfig) error
+	CreateOrUpdateThreshold(ctx core.Context, model *Threshold) error
+	GetOrCreateThreshold(ctx core.Context, serviceName string, endPoint string, level string) (Threshold, error)
+	DeleteThreshold(ctx core.Context, serviceName string, endPoint string) error
+	OperateLogTableInfo(ctx core.Context, model *LogTableInfo, op Operator) error
+	GetAllLogTable(ctx core.Context) ([]LogTableInfo, error)
+	UpdateLogParseRule(ctx core.Context, model *LogTableInfo) error
+	GetAllOtherLogTable(ctx core.Context) ([]OtherLogTable, error)
+	OperatorOtherLogTable(ctx core.Context, model *OtherLogTable, op Operator) error
+	CreateDingTalkReceiver(ctx core.Context, dingTalkConfig *amconfig.DingTalkConfig) error
 	// GetDingTalkReceiver get the webhook URL secret corresponding to the uuid.
-	GetDingTalkReceiver(uuid string) (amconfig.DingTalkConfig, error)
-	GetDingTalkReceiverByAlertName(configFile string, alertName string, page, pageSize int) ([]*amconfig.DingTalkConfig, int64, error)
-	UpdateDingTalkReceiver(dingTalkConfig *amconfig.DingTalkConfig, oldName string) error
-	DeleteDingTalkReceiver(configFile, alertName string) error
+	GetDingTalkReceiver(ctx core.Context, uuid string) (amconfig.DingTalkConfig, error)
+	GetDingTalkReceiverByAlertName(ctx core.Context, configFile string, alertName string, page, pageSize int) ([]*amconfig.DingTalkConfig, int64, error)
+	UpdateDingTalkReceiver(ctx core.Context, dingTalkConfig *amconfig.DingTalkConfig, oldName string) error
+	DeleteDingTalkReceiver(ctx core.Context, configFile, alertName string) error
 
-	ListQuickAlertRuleMetric(lang string) ([]AlertMetricsData, error)
+	ListQuickAlertRuleMetric(ctx core.Context) ([]AlertMetricsData, error)
 
-	Login(username, password string) (*User, error)
-	CreateUser(ctx context.Context, user *User) error
-	UpdateUserPhone(userID int64, phone string) error
-	UpdateUserEmail(userID int64, email string) error
-	UpdateUserPassword(userID int64, oldPassword, newPassword string) error
-	UpdateUserInfo(ctx context.Context, userID int64, phone string, email string, corporation string) error
-	GetUserInfo(userID int64) (User, error)
-	GetAnonymousUser() (User, error)
-	GetUserList(req *request.GetUserListRequest) ([]User, int64, error)
-	RemoveUser(ctx context.Context, userID int64) error
-	RestPassword(userID int64, newPassword string) error
-	UserExists(userID ...int64) (bool, error)
+	Login(ctx core.Context, username, password string) (*User, error)
+	CreateUser(ctx core.Context, user *User) error
+	UpdateUserPhone(ctx core.Context, userID int64, phone string) error
+	UpdateUserEmail(ctx core.Context, userID int64, email string) error
+	UpdateUserPassword(ctx core.Context, userID int64, oldPassword, newPassword string) error
+	UpdateUserInfo(ctx core.Context, userID int64, phone string, email string, corporation string) error
+	GetUserInfo(ctx core.Context, userID int64) (User, error)
+	GetAnonymousUser(ctx core.Context) (User, error)
+	GetUserList(ctx core.Context, req *request.GetUserListRequest) ([]User, int64, error)
+	RemoveUser(ctx core.Context, userID int64) error
+	RestPassword(ctx core.Context, userID int64, newPassword string) error
+	UserExists(ctx core.Context, userID ...int64) (bool, error)
 
-	GetUserRole(userID int64) ([]UserRole, error)
-	GetUsersRole(userIDs []int64) ([]UserRole, error)
-	GetRoles(filter model.RoleFilter) ([]Role, error)
-	GetFeature(featureIDs []int) ([]Feature, error)
-	GetFeatureByName(name string) (int, error)
-	GrantRoleWithUser(ctx context.Context, userID int64, roleIDs []int) error
-	GrantRoleWithRole(ctx context.Context, roleID int, userIDs []int64) error
-	RevokeRole(ctx context.Context, userID int64, roleIDs []int) error
-	RevokeRoleWithRole(ctx context.Context, roleID int) error
-	GetSubjectPermission(subID int64, subType string, typ string) ([]int, error)
-	GetSubjectsPermission(subIDs []int64, subType string, typ string) ([]AuthPermission, error)
-	RoleExists(roleID int) (bool, error)
-	GrantPermission(ctx context.Context, subID int64, subType string, typ string, permissionIDs []int) error
-	RevokePermission(ctx context.Context, subID int64, subType string, typ string, permissionIDs []int) error
-	GetAddAndDeletePermissions(subID int64, subType, typ string, permList []int) (toAdd []int, toDelete []int, err error)
-	RoleGrantedToUser(userID int64, roleID int) (bool, error)
-	RoleGranted(roleID int) (bool, error)
-	FillItemRouter(items *[]MenuItem) error
-	GetItemsRouter(itemIDs []int) ([]Router, error)
-	GetRouterByIDs(routerIDs []int) ([]Router, error)
-	GetRouterInsertedPage(routers []*Router, language string) error
-	GetFeatureTans(features *[]Feature, language string) error
-	GetMenuItemTans(menuItems *[]MenuItem, language string) error
+	GetUserRole(ctx core.Context, userID int64) ([]UserRole, error)
+	GetUsersRole(ctx core.Context, userIDs []int64) ([]UserRole, error)
+	GetRoles(ctx core.Context, filter model.RoleFilter) ([]Role, error)
+	GetFeature(ctx core.Context, featureIDs []int) ([]Feature, error)
+	GetFeatureByName(ctx core.Context, name string) (int, error)
+	GrantRoleWithUser(ctx core.Context, userID int64, roleIDs []int) error
+	GrantRoleWithRole(ctx core.Context, roleID int, userIDs []int64) error
+	RevokeRole(ctx core.Context, userID int64, roleIDs []int) error
+	RevokeRoleWithRole(ctx core.Context, roleID int) error
+	GetSubjectPermission(ctx core.Context, subID int64, subType string, typ string) ([]int, error)
+	GetSubjectsPermission(ctx core.Context, subIDs []int64, subType string, typ string) ([]AuthPermission, error)
+	RoleExists(ctx core.Context, roleID int) (bool, error)
+	GrantPermission(ctx core.Context, subID int64, subType string, typ string, permissionIDs []int) error
+	RevokePermission(ctx core.Context, subID int64, subType string, typ string, permissionIDs []int) error
+	GetAddAndDeletePermissions(ctx core.Context, subID int64, subType, typ string, permList []int) (toAdd []int, toDelete []int, err error)
+	RoleGrantedToUser(ctx core.Context, userID int64, roleID int) (bool, error)
+	RoleGranted(ctx core.Context, roleID int) (bool, error)
+	FillItemRouter(ctx core.Context, items *[]MenuItem) error
+	GetItemsRouter(ctx core.Context, itemIDs []int) ([]Router, error)
+	GetRouterByIDs(ctx core.Context, routerIDs []int) ([]Router, error)
+	GetRouterInsertedPage(ctx core.Context, routers []*Router, language string) error
+	GetFeatureTans(ctx core.Context, features *[]Feature, language string) error
+	GetMenuItemTans(ctx core.Context, menuItems *[]MenuItem, language string) error
 
-	CreateDataGroup(ctx context.Context, group *DataGroup) error
-	DeleteDataGroup(ctx context.Context, groupID int64) error
-	CreateDatasourceGroup(ctx context.Context, datasource []model.Datasource, dataGroupID int64) error
-	DeleteDSGroup(ctx context.Context, groupID int64) error
-	DataGroupExist(filter model.DataGroupFilter) (bool, error)
-	UpdateDataGroup(ctx context.Context, groupID int64, groupName string, description string) error
-	GetDataGroup(filter model.DataGroupFilter) ([]DataGroup, int64, error)
-	RetrieveDataFromGroup(ctx context.Context, groupID int64, datasource []string) error
-	GetGroupDatasource(groupID ...int64) ([]DatasourceGroup, error)
+	CreateDataGroup(ctx core.Context, group *DataGroup) error
+	DeleteDataGroup(ctx core.Context, groupID int64) error
+	CreateDatasourceGroup(ctx core.Context, datasource []model.Datasource, dataGroupID int64) error
+	DeleteDSGroup(ctx core.Context, groupID int64) error
+	DataGroupExist(ctx core.Context, filter model.DataGroupFilter) (bool, error)
+	UpdateDataGroup(ctx core.Context, groupID int64, groupName string, description string) error
+	GetDataGroup(ctx core.Context, filter model.DataGroupFilter) ([]DataGroup, int64, error)
+	RetrieveDataFromGroup(ctx core.Context, groupID int64, datasource []string) error
+	GetGroupDatasource(ctx core.Context, groupID ...int64) ([]DatasourceGroup, error)
 
-	GetFeatureMappingByFeature(featureIDs []int, mappedType string) ([]FeatureMapping, error)
-	GetFeatureMappingByMapped(mappedID int, mappedType string) (FeatureMapping, error)
-	GetMenuItems() ([]MenuItem, error)
+	GetFeatureMappingByFeature(ctx core.Context, featureIDs []int, mappedType string) ([]FeatureMapping, error)
+	GetFeatureMappingByMapped(ctx core.Context, mappedID int, mappedType string) (FeatureMapping, error)
+	GetMenuItems(ctx core.Context) ([]MenuItem, error)
 
-	GetTeamList(req *request.GetTeamRequest) ([]Team, int64, error)
-	DeleteTeam(ctx context.Context, teamID int64) error
-	CreateTeam(ctx context.Context, team Team) error
-	TeamExist(filter model.TeamFilter) (bool, error)
-	GetTeam(teamID int64) (Team, error)
-	UpdateTeam(ctx context.Context, team Team) error
-	InviteUserToTeam(ctx context.Context, teamID int64, userIDs []int64) error
-	AssignUserToTeam(ctx context.Context, userID int64, teamIDs []int64) error
-	GetUserTeams(userID int64) ([]int64, error)
-	GetTeamUsers(teamID int64) ([]int64, error)
-	GetTeamUserList(teamID int64) ([]User, error)
-	RemoveFromTeamByUser(ctx context.Context, userID int64, teamIDs []int64) error
-	RemoveFromTeamByTeam(ctx context.Context, teamID int64, userIDs []int64) error
-	DeleteAllUserTeam(ctx context.Context, id int64, by string) error
-	GetAssignedTeam(userID int64) ([]Team, error)
+	GetTeamList(ctx core.Context, req *request.GetTeamRequest) ([]Team, int64, error)
+	DeleteTeam(ctx core.Context, teamID int64) error
+	CreateTeam(ctx core.Context, team Team) error
+	TeamExist(ctx core.Context, filter model.TeamFilter) (bool, error)
+	GetTeam(ctx core.Context, teamID int64) (Team, error)
+	UpdateTeam(ctx core.Context, team Team) error
+	InviteUserToTeam(ctx core.Context, teamID int64, userIDs []int64) error
+	AssignUserToTeam(ctx core.Context, userID int64, teamIDs []int64) error
+	GetUserTeams(ctx core.Context, userID int64) ([]int64, error)
+	GetTeamUsers(ctx core.Context, teamID int64) ([]int64, error)
+	GetTeamUserList(ctx core.Context, teamID int64) ([]User, error)
+	RemoveFromTeamByUser(ctx core.Context, userID int64, teamIDs []int64) error
+	RemoveFromTeamByTeam(ctx core.Context, teamID int64, userIDs []int64) error
+	DeleteAllUserTeam(ctx core.Context, id int64, by string) error
+	GetAssignedTeam(ctx core.Context, userID int64) ([]Team, error)
 
-	CreateRole(ctx context.Context, role *Role) error
-	DeleteRole(ctx context.Context, roleID int) error
-	UpdateRole(ctx context.Context, roleID int, roleName, description string) error
+	CreateRole(ctx core.Context, role *Role) error
+	DeleteRole(ctx core.Context, roleID int) error
+	UpdateRole(ctx core.Context, roleID int, roleName, description string) error
 
-	GetAuthDataGroupBySub(subjectID int64, subjectType string) ([]AuthDataGroup, error)
-	GetGroupAuthDataGroupByGroup(groupID int64, subjectType string) ([]AuthDataGroup, error)
-	AssignDataGroup(ctx context.Context, authDataGroups []AuthDataGroup) error
-	RevokeDataGroupByGroup(ctx context.Context, dataGroupIDs []int64, subjectID int64) error
-	RevokeDataGroupBySub(ctx context.Context, subjectIDs []int64, groupID int64) error
-	GetSubjectDataGroupList(subjectID int64, subjectType string, category string) ([]DataGroup, error)
-	GetModifyAndDeleteDataGroup(subjectID int64, subjectType string, dgPermissions []request.DataGroupPermission) (toModify []AuthDataGroup, toDelete []int64, err error)
-	DeleteAuthDataGroup(ctx context.Context, subjectID int64, subjectType string) error
-	GetDataGroupUsers(groupID int64) ([]AuthDataGroup, error)
-	GetDataGroupTeams(groupID int64) ([]AuthDataGroup, error)
-	CheckGroupPermission(userID, groupID int64, typ string) (bool, error)
+	GetAuthDataGroupBySub(ctx core.Context, subjectID int64, subjectType string) ([]AuthDataGroup, error)
+	GetGroupAuthDataGroupByGroup(ctx core.Context, groupID int64, subjectType string) ([]AuthDataGroup, error)
+	AssignDataGroup(ctx core.Context, authDataGroups []AuthDataGroup) error
+	RevokeDataGroupByGroup(ctx core.Context, dataGroupIDs []int64, subjectID int64) error
+	RevokeDataGroupBySub(ctx core.Context, subjectIDs []int64, groupID int64) error
+	GetSubjectDataGroupList(ctx core.Context, subjectID int64, subjectType string, category string) ([]DataGroup, error)
+	GetModifyAndDeleteDataGroup(ctx core.Context, subjectID int64, subjectType string, dgPermissions []request.DataGroupPermission) (toModify []AuthDataGroup, toDelete []int64, err error)
+	DeleteAuthDataGroup(ctx core.Context, subjectID int64, subjectType string) error
+	GetDataGroupUsers(ctx core.Context, groupID int64) ([]AuthDataGroup, error)
+	GetDataGroupTeams(ctx core.Context, groupID int64) ([]AuthDataGroup, error)
+	CheckGroupPermission(ctx core.Context, userID, groupID int64, typ string) (bool, error)
 
-	GetAPIByPath(path string, method string) (*API, error)
+	GetAPIByPath(ctx core.Context, path string, method string) (*API, error)
 
 	// GetContextDB Gets transaction form ctx.
-	GetContextDB(ctx context.Context) *gorm.DB
+	GetContextDB(ctx core.Context) *gorm.DB
 	// WithTransaction Puts transaction into ctx.
-	WithTransaction(ctx context.Context, tx *gorm.DB) context.Context
+	WithTransaction(ctx core.Context, tx *gorm.DB) core.Context
 	// Transaction Starts a transaction and automatically commit and rollback.
-	Transaction(ctx context.Context, funcs ...func(txCtx context.Context) error) error
+	Transaction(ctx core.Context, funcs ...func(txCtx core.Context) error) error
 
-	GetAMConfigReceiver(filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int, error)
-	AddAMConfigReceiver(receiver amconfig.Receiver) error
-	UpdateAMConfigReceiver(receiver amconfig.Receiver, oldName string) error
-	DeleteAMConfigReceiver(name string) error
+	GetAMConfigReceiver(ctx core.Context, filter *request.AMConfigReceiverFilter, pageParam *request.PageParam) ([]amconfig.Receiver, int, error)
+	AddAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver) error
+	UpdateAMConfigReceiver(ctx core.Context, receiver amconfig.Receiver, oldName string) error
+	DeleteAMConfigReceiver(ctx core.Context, name string) error
 
-	CheckAMReceiverCount() int64
-	MigrateAMReceiver(receivers []amconfig.Receiver) ([]amconfig.Receiver, error)
+	CheckAMReceiverCount(ctx core.Context) int64
+	MigrateAMReceiver(ctx core.Context, receivers []amconfig.Receiver) ([]amconfig.Receiver, error)
 
 	integration.ObservabilityInputManage
 }
 
 type daoRepo struct {
-	db             *gorm.DB
-	sqlDB          *sql.DB
-	transactionCtx struct{}
+	*driver.DB
+	sqlDB *sql.DB
 
 	integration.ObservabilityInputManage
 }
@@ -196,51 +195,52 @@ func New(zapLogger *zap.Logger) (repo Repo, err error) {
 		return nil, err
 	}
 	daoRepo := &daoRepo{
-		db:    database,
+		DB:    &driver.DB{DB: database},
 		sqlDB: sqlDb,
 	}
 
-	if err = driver.InitSQL(daoRepo.db, &AlertMetricsData{}); err != nil {
+	if err = driver.InitSQL(database, &AlertMetricsData{}); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initRole(); err != nil {
+	if err = daoRepo.initRole(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initFeature(); err != nil {
+	if err = daoRepo.initFeature(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initRouterData(); err != nil {
+	if err = daoRepo.initRouterData(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initMenuItems(); err != nil {
+	if err = daoRepo.initMenuItems(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initInsertPages(); err != nil {
+	if err = daoRepo.initInsertPages(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initRouterPage(); err != nil {
+	if err = daoRepo.initRouterPage(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initFeatureMenuItems(); err != nil {
+	if err = daoRepo.initFeatureMenuItems(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initFeatureRouter(); err != nil {
+	if err = daoRepo.initFeatureRouter(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initPermissions(); err != nil {
+	if err = daoRepo.initPermissions(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.initI18nTranslation(); err != nil {
+	if err = daoRepo.initI18nTranslation(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.createAdmin(); err != nil {
+	// TODO core.Context
+	if err = daoRepo.createAdmin(nil); err != nil {
 		return nil, err
 	}
-	if err = daoRepo.createAnonymousUser(); err != nil {
+	if err = daoRepo.createAnonymousUser(nil); err != nil {
 		return nil, err
 	}
 
-	if daoRepo.ObservabilityInputManage, err = integration.NewObservabilityInputManage(daoRepo.db, globalCfg); err != nil {
+	if daoRepo.ObservabilityInputManage, err = integration.NewObservabilityInputManage(database, globalCfg); err != nil {
 		return nil, err
 	}
 

--- a/backend/pkg/repository/database/dao_api.go
+++ b/backend/pkg/repository/database/dao_api.go
@@ -3,7 +3,11 @@
 
 package database
 
+import
+
 // API represents an API endpoint definition
+core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type API struct {
 	ID      int    `gorm:"primary_key;auto_increment"`
 	Path    string `gorm:"column:path;type:varchar(255);index:idx_path_method,unique" mapstructure:"path"`
@@ -15,8 +19,8 @@ func (API) TableName() string {
 	return "api"
 }
 
-func (repo *daoRepo) GetAPIByPath(path string, method string) (*API, error) {
+func (repo *daoRepo) GetAPIByPath(ctx core.Context, path string, method string) (*API, error) {
 	var api API
-	err := repo.db.Where("path = ? AND method = ?", path, method).Find(&api).Error
+	err := repo.GetContextDB(ctx).Where("path = ? AND method = ?", path, method).Find(&api).Error
 	return &api, err
 }

--- a/backend/pkg/repository/database/dao_auth_data_group.go
+++ b/backend/pkg/repository/database/dao_auth_data_group.go
@@ -4,11 +4,10 @@
 package database
 
 import (
-	"context"
 	"encoding/json"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"gorm.io/gorm"
@@ -68,28 +67,28 @@ func (AuthDataGroup) TableName() string {
 	return "auth_data_group"
 }
 
-func (repo *daoRepo) GetAuthDataGroupBySub(subjectID int64, subjectType string) ([]AuthDataGroup, error) {
+func (repo *daoRepo) GetAuthDataGroupBySub(ctx core.Context, subjectID int64, subjectType string) ([]AuthDataGroup, error) {
 	var authDataGroups []AuthDataGroup
-	err := repo.db.Where("subject_id = ? AND subject_type = ?", subjectID, subjectType).Find(&authDataGroups).Error
+	err := repo.GetContextDB(ctx).Where("subject_id = ? AND subject_type = ?", subjectID, subjectType).Find(&authDataGroups).Error
 	return authDataGroups, err
 }
 
-func (repo *daoRepo) AssignDataGroup(ctx context.Context, authDataGroups []AuthDataGroup) error {
+func (repo *daoRepo) AssignDataGroup(ctx core.Context, authDataGroups []AuthDataGroup) error {
 	if len(authDataGroups) == 0 {
 		return nil
 	}
 	return repo.GetContextDB(ctx).Save(&authDataGroups).Error
 }
 
-func (repo *daoRepo) RevokeDataGroupByGroup(ctx context.Context, dataGroupIDs []int64, subjectID int64) error {
+func (repo *daoRepo) RevokeDataGroupByGroup(ctx core.Context, dataGroupIDs []int64, subjectID int64) error {
 	if len(dataGroupIDs) == 0 {
 		return nil
 	}
 	return repo.GetContextDB(ctx).Model(&AuthDataGroup{}).Where("data_group_id IN ? AND subject_id = ?", dataGroupIDs, subjectID).Delete(nil).Error
 }
 
-func (repo *daoRepo) GetModifyAndDeleteDataGroup(subjectID int64, subjectType string, dgPermissions []request.DataGroupPermission) (toModify []AuthDataGroup, toDelete []int64, err error) {
-	authGroups, err := repo.GetAuthDataGroupBySub(subjectID, subjectType)
+func (repo *daoRepo) GetModifyAndDeleteDataGroup(ctx core.Context, subjectID int64, subjectType string, dgPermissions []request.DataGroupPermission) (toModify []AuthDataGroup, toDelete []int64, err error) {
+	authGroups, err := repo.GetAuthDataGroupBySub(ctx, subjectID, subjectType)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -102,7 +101,7 @@ func (repo *daoRepo) GetModifyAndDeleteDataGroup(subjectID int64, subjectType st
 		filter := model.DataGroupFilter{
 			IDs: ids,
 		}
-		exists, err := repo.DataGroupExist(filter)
+		exists, err := repo.DataGroupExist(ctx, filter)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -142,7 +141,7 @@ func (repo *daoRepo) GetModifyAndDeleteDataGroup(subjectID int64, subjectType st
 	return toModify, toDelete, nil
 }
 
-func (repo *daoRepo) DeleteAuthDataGroup(ctx context.Context, subjectID int64, subjectType string) error {
+func (repo *daoRepo) DeleteAuthDataGroup(ctx core.Context, subjectID int64, subjectType string) error {
 	return repo.GetContextDB(ctx).
 		Model(&AuthDataGroup{}).
 		Where("subject_id = ? AND subject_type = ?", subjectID, subjectType).
@@ -150,16 +149,16 @@ func (repo *daoRepo) DeleteAuthDataGroup(ctx context.Context, subjectID int64, s
 		Error
 }
 
-func (repo *daoRepo) RevokeDataGroupBySub(ctx context.Context, subjectIDs []int64, groupID int64) error {
+func (repo *daoRepo) RevokeDataGroupBySub(ctx core.Context, subjectIDs []int64, groupID int64) error {
 	if len(subjectIDs) == 0 {
 		return nil
 	}
 	return repo.GetContextDB(ctx).Model(&AuthDataGroup{}).Where("subject_id IN ? AND data_group_id = ?", subjectIDs, groupID).Delete(nil).Error
 }
 
-func (repo *daoRepo) GetGroupAuthDataGroupByGroup(groupID int64, subjectType string) ([]AuthDataGroup, error) {
+func (repo *daoRepo) GetGroupAuthDataGroupByGroup(ctx core.Context, groupID int64, subjectType string) ([]AuthDataGroup, error) {
 	var dataGroups []AuthDataGroup
-	err := repo.db.Table("auth_data_group").
+	err := repo.GetContextDB(ctx).Table("auth_data_group").
 		Joins("INNER JOIN data_group dg ON dg.group_id = auth_data_group.data_group_id").
 		Where("dg.group_id = ? AND auth_data_group.subject_type = ?", groupID, subjectType).
 		Find(&dataGroups).Error
@@ -169,9 +168,9 @@ func (repo *daoRepo) GetGroupAuthDataGroupByGroup(groupID int64, subjectType str
 	return dataGroups, nil
 }
 
-func (repo *daoRepo) GetDataGroupUsers(groupID int64) ([]AuthDataGroup, error) {
+func (repo *daoRepo) GetDataGroupUsers(ctx core.Context, groupID int64) ([]AuthDataGroup, error) {
 	var ags []AuthDataGroup
-	err := repo.db.
+	err := repo.GetContextDB(ctx).
 		Select("subject_id", "type").
 		Where("data_group_id = ? AND subject_type = ?", groupID, model.DATA_GROUP_SUB_TYP_USER).
 		Find(&ags).Error
@@ -185,7 +184,7 @@ func (repo *daoRepo) GetDataGroupUsers(groupID int64) ([]AuthDataGroup, error) {
 
 	for i := 0; i < len(ags); i++ {
 		var user User
-		err = repo.db.
+		err = repo.GetContextDB(ctx).
 			Select("user_id", "username").
 			First(&user, "user_id = ?", ags[i].SubjectID).Error
 		if err != nil && err != gorm.ErrRecordNotFound {
@@ -200,10 +199,10 @@ func (repo *daoRepo) GetDataGroupUsers(groupID int64) ([]AuthDataGroup, error) {
 	return ags, nil
 }
 
-func (repo *daoRepo) GetDataGroupTeams(groupID int64) ([]AuthDataGroup, error) {
+func (repo *daoRepo) GetDataGroupTeams(ctx core.Context, groupID int64) ([]AuthDataGroup, error) {
 	var ags []AuthDataGroup
 
-	err := repo.db.
+	err := repo.GetContextDB(ctx).
 		Select("subject_id", "type").
 		Where("data_group_id = ? AND subject_type = ?", groupID, model.DATA_GROUP_SUB_TYP_TEAM).
 		Find(&ags).Error
@@ -217,7 +216,7 @@ func (repo *daoRepo) GetDataGroupTeams(groupID int64) ([]AuthDataGroup, error) {
 
 	for i := 0; i < len(ags); i++ {
 		var team Team
-		err = repo.db.
+		err = repo.GetContextDB(ctx).
 			Select("team_id", "team_name").
 			First(&team, "team_id = ?", ags[i].SubjectID).Error
 		if err != nil && err != gorm.ErrRecordNotFound {
@@ -232,13 +231,13 @@ func (repo *daoRepo) GetDataGroupTeams(groupID int64) ([]AuthDataGroup, error) {
 	return ags, err
 }
 
-func (repo *daoRepo) CheckGroupPermission(userID, groupID int64, typ string) (bool, error) {
+func (repo *daoRepo) CheckGroupPermission(ctx core.Context, userID, groupID int64, typ string) (bool, error) {
 	var (
 		count int64
 		err   error
 	)
 
-	query := repo.db.Model(&AuthDataGroup{}).
+	query := repo.GetContextDB(ctx).Model(&AuthDataGroup{}).
 		Where("subject_id = ? AND data_group_id = ? AND subject_type = ?", userID, groupID, model.DATA_GROUP_SUB_TYP_USER)
 
 	if typ == "edit" {
@@ -254,12 +253,12 @@ func (repo *daoRepo) CheckGroupPermission(userID, groupID int64, typ string) (bo
 		return true, nil
 	}
 
-	teamIDs, err := repo.GetUserTeams(userID)
+	teamIDs, err := repo.GetUserTeams(ctx, userID)
 	if err != nil {
 		return false, err
 	}
 
-	query = repo.db.Model(&AuthDataGroup{}).
+	query = repo.GetContextDB(ctx).Model(&AuthDataGroup{}).
 		Where("subject_id IN ? AND data_group_id = ? AND subject_type = ?", teamIDs, groupID, model.DATA_GROUP_SUB_TYP_TEAM)
 
 	if typ == "edit" {

--- a/backend/pkg/repository/database/dao_feature.go
+++ b/backend/pkg/repository/database/dao_feature.go
@@ -3,8 +3,12 @@
 
 package database
 
+import
+
 // Feature is a collection of APIs, frontend routes and menu items
 // that represents the embodiment of access control.
+core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type Feature struct {
 	FeatureID   int    `gorm:"column:feature_id;primary_key;auto_increment" json:"featureId"`
 	FeatureName string `gorm:"column:feature_name;type:varchar(20)" json:"featureName"`
@@ -31,9 +35,9 @@ func (t *FeatureMapping) TableName() string {
 	return "feature_mapping"
 }
 
-func (repo *daoRepo) GetFeature(featureIDs []int) ([]Feature, error) {
+func (repo *daoRepo) GetFeature(ctx core.Context, featureIDs []int) ([]Feature, error) {
 	var features []Feature
-	query := repo.db
+	query := repo.GetContextDB(ctx)
 	if featureIDs != nil {
 		query = query.Where("feature_id in ?", featureIDs)
 	}
@@ -42,20 +46,20 @@ func (repo *daoRepo) GetFeature(featureIDs []int) ([]Feature, error) {
 	return features, err
 }
 
-func (repo *daoRepo) GetFeatureMappingByFeature(featureIDs []int, mappedType string) ([]FeatureMapping, error) {
+func (repo *daoRepo) GetFeatureMappingByFeature(ctx core.Context, featureIDs []int, mappedType string) ([]FeatureMapping, error) {
 	var featureMenuItem []FeatureMapping
-	err := repo.db.Where("feature_id in ? AND mapped_type = ?", featureIDs, mappedType).Order("mapped_id").Find(&featureMenuItem).Error
+	err := repo.GetContextDB(ctx).Where("feature_id in ? AND mapped_type = ?", featureIDs, mappedType).Order("mapped_id").Find(&featureMenuItem).Error
 	return featureMenuItem, err
 }
 
-func (repo *daoRepo) GetFeatureMappingByMapped(mappedID int, mappedType string) (FeatureMapping, error) {
+func (repo *daoRepo) GetFeatureMappingByMapped(ctx core.Context, mappedID int, mappedType string) (FeatureMapping, error) {
 	var fm FeatureMapping
-	err := repo.db.Where("mapped_id = ? AND mapped_type = ?", mappedID, mappedType).Find(&fm).Error
+	err := repo.GetContextDB(ctx).Where("mapped_id = ? AND mapped_type = ?", mappedID, mappedType).Find(&fm).Error
 	return fm, err
 }
 
-func (repo *daoRepo) GetFeatureByName(name string) (int, error) {
+func (repo *daoRepo) GetFeatureByName(ctx core.Context, name string) (int, error) {
 	var id int
-	err := repo.db.Model(&Feature{}).Select("feature_id").Where("feature_name = ?", name).Find(&id).Error
+	err := repo.GetContextDB(ctx).Model(&Feature{}).Select("feature_id").Where("feature_name = ?", name).Find(&id).Error
 	return id, err
 }

--- a/backend/pkg/repository/database/dao_i18n.go
+++ b/backend/pkg/repository/database/dao_i18n.go
@@ -3,7 +3,10 @@
 
 package database
 
-import "github.com/CloudDetail/apo/backend/pkg/model"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model"
+)
 
 type I18nTranslation struct {
 	ID          int    `gorm:"column:id;primary_key;auto_increment" json:"-"`
@@ -18,18 +21,18 @@ func (I18nTranslation) TableName() string {
 	return "i18n_translation"
 }
 
-func (repo *daoRepo) GetTranslation(targetIDs []int, targetType string, language string) ([]I18nTranslation, error) {
+func (repo *daoRepo) GetTranslation(ctx core.Context, targetIDs []int, targetType string, language string) ([]I18nTranslation, error) {
 	var translations []I18nTranslation
-	err := repo.db.Where(`entity_id in ? AND entity_type = ? AND "language" = ?`, targetIDs, targetType, language).Find(&translations).Error
+	err := repo.GetContextDB(ctx).Where(`entity_id in ? AND entity_type = ? AND "language" = ?`, targetIDs, targetType, language).Find(&translations).Error
 	return translations, err
 }
 
-func (repo *daoRepo) GetFeatureTans(features *[]Feature, language string) error {
+func (repo *daoRepo) GetFeatureTans(ctx core.Context, features *[]Feature, language string) error {
 	featureIDs := make([]int, len(*features))
 	for i, f := range *features {
 		featureIDs[i] = f.FeatureID
 	}
-	translations, err := repo.GetTranslation(featureIDs, model.TRANSLATION_TYP_FEATURE, language)
+	translations, err := repo.GetTranslation(ctx, featureIDs, model.TRANSLATION_TYP_FEATURE, language)
 	if err != nil {
 		return err
 	}
@@ -46,12 +49,12 @@ func (repo *daoRepo) GetFeatureTans(features *[]Feature, language string) error 
 	return nil
 }
 
-func (repo *daoRepo) GetMenuItemTans(menuItems *[]MenuItem, language string) error {
+func (repo *daoRepo) GetMenuItemTans(ctx core.Context, menuItems *[]MenuItem, language string) error {
 	featureIDs := make([]int, len(*menuItems))
 	for i, f := range *menuItems {
 		featureIDs[i] = f.ItemID
 	}
-	translations, err := repo.GetTranslation(featureIDs, model.TRANSLATION_TYP_MENU, language)
+	translations, err := repo.GetTranslation(ctx, featureIDs, model.TRANSLATION_TYP_MENU, language)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/repository/database/dao_insert_page.go
+++ b/backend/pkg/repository/database/dao_insert_page.go
@@ -6,6 +6,7 @@ package database
 import (
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -33,14 +34,14 @@ func (t *InsertPage) TableName() string {
 	return "insert_page"
 }
 
-func (repo *daoRepo) GetRouterInsertedPage(routers []*Router, language string) error {
+func (repo *daoRepo) GetRouterInsertedPage(ctx core.Context, routers []*Router, language string) error {
 	if len(routers) == 0 {
 		return nil
 	}
 
 	for i := range routers {
 		var page InsertPage
-		err := repo.db.Table("router_insert_page").
+		err := repo.GetContextDB(ctx).Table("router_insert_page").
 			Select("insert_page.*").
 			Joins("JOIN insert_page ON router_insert_page.page_id = insert_page.page_id").
 			Where(`router_insert_page.router_id = ? AND router_insert_page."language" = ? OR (router_insert_page."language" IS NULL AND insert_page.custom = true)`, routers[i].RouterID, language).

--- a/backend/pkg/repository/database/dao_logtableinfo.go
+++ b/backend/pkg/repository/database/dao_logtableinfo.go
@@ -3,6 +3,8 @@
 
 package database
 
+import core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type LogTableInfo struct {
 	ID           uint   `gorm:"primaryKey;autoIncrement"`
 	DataBase     string `gorm:"type:varchar(255);column:database"`
@@ -30,29 +32,29 @@ const (
 	DELETE
 )
 
-func (repo *daoRepo) OperateLogTableInfo(model *LogTableInfo, op Operator) error {
+func (repo *daoRepo) OperateLogTableInfo(ctx core.Context, model *LogTableInfo, op Operator) error {
 	var err error
 	switch op {
 	case INSERT:
-		err = repo.db.Create(model).Error
+		err = repo.GetContextDB(ctx).Create(model).Error
 	case QUERY:
-		err = repo.db.Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).First(model).Error
+		err = repo.GetContextDB(ctx).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).First(model).Error
 	case UPDATE:
-		err = repo.db.Model(&LogTableInfo{}).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Update("fields", model.Fields).Error
+		err = repo.GetContextDB(ctx).Model(&LogTableInfo{}).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Update("fields", model.Fields).Error
 	case DELETE:
-		return repo.db.Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Delete(&LogTableInfo{}).Error
+		return repo.GetContextDB(ctx).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Delete(&LogTableInfo{}).Error
 	}
 	return err
 }
 
-func (repo *daoRepo) GetAllLogTable() ([]LogTableInfo, error) {
+func (repo *daoRepo) GetAllLogTable(ctx core.Context) ([]LogTableInfo, error) {
 	var logTableInfo []LogTableInfo
-	err := repo.db.Find(&logTableInfo).Error
+	err := repo.GetContextDB(ctx).Find(&logTableInfo).Error
 	return logTableInfo, err
 }
 
-func (repo *daoRepo) UpdateLogParseRule(model *LogTableInfo) error {
-	return repo.db.Model(&LogTableInfo{}).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Updates(map[string]interface{}{
+func (repo *daoRepo) UpdateLogParseRule(ctx core.Context, model *LogTableInfo) error {
+	return repo.GetContextDB(ctx).Model(&LogTableInfo{}).Where(`"database" = ? AND "tablename" = ?`, model.DataBase, model.Table).Updates(map[string]interface{}{
 		"parseinfo":  model.ParseInfo,
 		"parserule":  model.ParseRule,
 		"routerule":  model.RouteRule,

--- a/backend/pkg/repository/database/dao_menu.go
+++ b/backend/pkg/repository/database/dao_menu.go
@@ -3,9 +3,13 @@
 
 package database
 
+import
+
 // MenuItem is a menu item on the left or top menu bar.
 //
 // ! Handle the `Key` field carefully, it is a reserved word in MySQL, and must be delimited with the identifier '"'
+core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type MenuItem struct {
 	ItemID       int    `gorm:"column:item_id;primary_key" json:"itemId"`
 	Key          string `gorm:"column:key;type:varchar(20);uniqueIndex" json:"key"`
@@ -24,9 +28,9 @@ func (t *MenuItem) TableName() string {
 	return "menu_item"
 }
 
-func (repo *daoRepo) GetMenuItems() ([]MenuItem, error) {
+func (repo *daoRepo) GetMenuItems(ctx core.Context) ([]MenuItem, error) {
 	var menuItems []MenuItem
 
-	err := repo.db.Find(&menuItems).Error
+	err := repo.GetContextDB(ctx).Find(&menuItems).Error
 	return menuItems, err
 }

--- a/backend/pkg/repository/database/dao_othertableinfo.go
+++ b/backend/pkg/repository/database/dao_othertableinfo.go
@@ -3,6 +3,8 @@
 
 package database
 
+import core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type OtherLogTable struct {
 	ID        uint   `gorm:"primaryKey;autoIncrement"`
 	DataBase  string `gorm:"type:varchar(255);column:database"`
@@ -17,21 +19,21 @@ func (OtherLogTable) TableName() string {
 	return "otherlogtable"
 }
 
-func (repo *daoRepo) GetAllOtherLogTable() ([]OtherLogTable, error) {
+func (repo *daoRepo) GetAllOtherLogTable(ctx core.Context) ([]OtherLogTable, error) {
 	var logTableInfo []OtherLogTable
-	err := repo.db.Find(&logTableInfo).Error
+	err := repo.GetContextDB(ctx).Find(&logTableInfo).Error
 	return logTableInfo, err
 }
 
-func (repo *daoRepo) OperatorOtherLogTable(model *OtherLogTable, op Operator) error {
+func (repo *daoRepo) OperatorOtherLogTable(ctx core.Context, model *OtherLogTable, op Operator) error {
 	var err error
 	switch op {
 	case INSERT:
-		err = repo.db.Create(model).Error
+		err = repo.GetContextDB(ctx).Create(model).Error
 	case QUERY:
-		err = repo.db.Where("database=? AND tablename=? And instance=?", model.DataBase, model.Table, model.Instance).First(model).Error
+		err = repo.GetContextDB(ctx).Where("database=? AND tablename=? And instance=?", model.DataBase, model.Table, model.Instance).First(model).Error
 	case DELETE:
-		err = repo.db.Where("database=? AND tablename=? And instance=?", model.DataBase, model.Table, model.Instance).Delete(&OtherLogTable{}).Error
+		err = repo.GetContextDB(ctx).Where("database=? AND tablename=? And instance=?", model.DataBase, model.Table, model.Instance).Delete(&OtherLogTable{}).Error
 	}
 	return err
 }

--- a/backend/pkg/repository/database/dao_quick_alert_rule_metric.go
+++ b/backend/pkg/repository/database/dao_quick_alert_rule_metric.go
@@ -5,6 +5,8 @@ package database
 
 import (
 	"strings"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
 // AlertMetricsData provide PQL corresponding to user selectable metrics
@@ -23,10 +25,10 @@ func (a *AlertMetricsData) TableName() string {
 }
 
 // ListQuickMutationMetric list of all quick metrics
-func (repo *daoRepo) ListQuickAlertRuleMetric(lang string) ([]AlertMetricsData, error) {
+func (repo *daoRepo) ListQuickAlertRuleMetric(ctx core.Context) ([]AlertMetricsData, error) {
 	var quickAlertMetrics []AlertMetricsData
-	err := repo.db.Model(&AlertMetricsData{}).
-		Select(getQuickAlertRuleNameField(lang), "pql", "unit", "group").
+	err := repo.GetContextDB(ctx).Model(&AlertMetricsData{}).
+		Select(getQuickAlertRuleNameField(ctx.LANG()), "pql", "unit", "group").
 		Scan(&quickAlertMetrics).
 		Error
 	return quickAlertMetrics, err

--- a/backend/pkg/repository/database/dao_role.go
+++ b/backend/pkg/repository/database/dao_role.go
@@ -4,9 +4,9 @@
 package database
 
 import (
-	"context"
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -33,9 +33,9 @@ func (t *UserRole) TableName() string {
 }
 
 // GetRoles Get all roles for the given condition.
-func (repo *daoRepo) GetRoles(filter model.RoleFilter) ([]Role, error) {
+func (repo *daoRepo) GetRoles(ctx core.Context, filter model.RoleFilter) ([]Role, error) {
 	var roles []Role
-	query := repo.db.Where("role_name != ?", AnonymousUsername)
+	query := repo.GetContextDB(ctx).Where("role_name != ?", AnonymousUsername)
 
 	if len(filter.Names) > 0 {
 		query = query.Where("role_name in ?", filter.Names)
@@ -55,29 +55,29 @@ func (repo *daoRepo) GetRoles(filter model.RoleFilter) ([]Role, error) {
 }
 
 // GetUserRole Get user's role.
-func (repo *daoRepo) GetUserRole(userID int64) ([]UserRole, error) {
+func (repo *daoRepo) GetUserRole(ctx core.Context, userID int64) ([]UserRole, error) {
 	var userRoles []UserRole
-	err := repo.db.Where("user_id = ?", userID).Find(&userRoles).Error
+	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).Find(&userRoles).Error
 	return userRoles, err
 }
 
 // GetUsersRole Get user's role in batch.
-func (repo *daoRepo) GetUsersRole(userIDs []int64) ([]UserRole, error) {
+func (repo *daoRepo) GetUsersRole(ctx core.Context, userIDs []int64) ([]UserRole, error) {
 	var userRoles []UserRole
-	err := repo.db.Where("user_id in ?", userIDs).Find(&userRoles).Error
+	err := repo.GetContextDB(ctx).Where("user_id in ?", userIDs).Find(&userRoles).Error
 	return userRoles, err
 }
 
-func (repo *daoRepo) RoleGrantedToUser(userID int64, roleID int) (bool, error) {
+func (repo *daoRepo) RoleGrantedToUser(ctx core.Context, userID int64, roleID int) (bool, error) {
 	var count int64
-	if err := repo.db.Model(&UserRole{}).Where("role_id = ? AND user_id = ?", roleID, userID).Count(&count).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Model(&UserRole{}).Where("role_id = ? AND user_id = ?", roleID, userID).Count(&count).Error; err != nil {
 		return false, err
 	}
 
 	return count > 0, nil
 }
 
-func (repo *daoRepo) GrantRoleWithUser(ctx context.Context, userID int64, roleIDs []int) error {
+func (repo *daoRepo) GrantRoleWithUser(ctx core.Context, userID int64, roleIDs []int) error {
 	if len(roleIDs) == 0 {
 		return nil
 	}
@@ -93,14 +93,14 @@ func (repo *daoRepo) GrantRoleWithUser(ctx context.Context, userID int64, roleID
 	return db.Create(&userRole).Error
 }
 
-func (repo *daoRepo) RevokeRole(ctx context.Context, userID int64, roleIDs []int) error {
+func (repo *daoRepo) RevokeRole(ctx core.Context, userID int64, roleIDs []int) error {
 	return repo.GetContextDB(ctx).
 		Model(&UserRole{}).Where("user_id = ? AND role_id in ?", userID, roleIDs).Delete(nil).Error
 }
 
-func (repo *daoRepo) RoleExists(roleID int) (bool, error) {
+func (repo *daoRepo) RoleExists(ctx core.Context, roleID int) (bool, error) {
 	var count int64
-	if err := repo.db.Model(&Role{}).Where("role_id = ?", roleID).Count(&count).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Model(&Role{}).Where("role_id = ?", roleID).Count(&count).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return false, nil
 		}
@@ -110,11 +110,11 @@ func (repo *daoRepo) RoleExists(roleID int) (bool, error) {
 	return count > 0, nil
 }
 
-func (repo *daoRepo) CreateRole(ctx context.Context, role *Role) error {
+func (repo *daoRepo) CreateRole(ctx core.Context, role *Role) error {
 	return repo.GetContextDB(ctx).Create(&role).Error
 }
 
-func (repo *daoRepo) DeleteRole(ctx context.Context, roleID int) error {
+func (repo *daoRepo) DeleteRole(ctx core.Context, roleID int) error {
 	err := repo.GetContextDB(ctx).Model(&Role{}).Where("role_id = ?", roleID).Delete(nil).Error
 	if err != nil {
 		return err
@@ -126,7 +126,7 @@ func (repo *daoRepo) DeleteRole(ctx context.Context, roleID int) error {
 		Delete(nil).Error
 }
 
-func (repo *daoRepo) UpdateRole(ctx context.Context, roleID int, roleName, description string) error {
+func (repo *daoRepo) UpdateRole(ctx core.Context, roleID int, roleName, description string) error {
 	role := Role{
 		RoleID:      roleID,
 		RoleName:    roleName,
@@ -136,7 +136,7 @@ func (repo *daoRepo) UpdateRole(ctx context.Context, roleID int, roleName, descr
 	return repo.GetContextDB(ctx).Updates(&role).Error
 }
 
-func (repo *daoRepo) GrantRoleWithRole(ctx context.Context, roleID int, userIDs []int64) error {
+func (repo *daoRepo) GrantRoleWithRole(ctx core.Context, roleID int, userIDs []int64) error {
 	if len(userIDs) == 0 {
 		return nil
 	}
@@ -156,15 +156,15 @@ func (repo *daoRepo) GrantRoleWithRole(ctx context.Context, roleID int, userIDs 
 		}).Create(&userRoles).Error
 }
 
-func (repo *daoRepo) RevokeRoleWithRole(ctx context.Context, roleID int) error {
+func (repo *daoRepo) RevokeRoleWithRole(ctx core.Context, roleID int) error {
 	return repo.GetContextDB(ctx).
 		Model(&UserRole{}).Where("role_id = ?", roleID).Delete(nil).Error
 }
 
-func (repo *daoRepo) RoleGranted(roleID int) (bool, error) {
+func (repo *daoRepo) RoleGranted(ctx core.Context, roleID int) (bool, error) {
 	var count int64
 
-	err := repo.db.Model(&UserRole{}).Where("role_id = ?", roleID).Count(&count).Error
+	err := repo.GetContextDB(ctx).Model(&UserRole{}).Where("role_id = ?", roleID).Count(&count).Error
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/repository/database/dao_router.go
+++ b/backend/pkg/repository/database/dao_router.go
@@ -3,7 +3,11 @@
 
 package database
 
+import
+
 // Router front end router.
+core "github.com/CloudDetail/apo/backend/pkg/core"
+
 type Router struct {
 	RouterID         int    `gorm:"column:router_id;primary_key" json:"routerId"`
 	RouterTo         string `gorm:"column:router_to;uniqueIndex;type:varchar(200)" json:"to"`
@@ -17,7 +21,7 @@ func (t *Router) TableName() string {
 	return "router"
 }
 
-func (repo *daoRepo) FillItemRouter(items *[]MenuItem) error {
+func (repo *daoRepo) FillItemRouter(ctx core.Context, items *[]MenuItem) error {
 	if items == nil {
 		return nil
 	}
@@ -27,7 +31,7 @@ func (repo *daoRepo) FillItemRouter(items *[]MenuItem) error {
 	}
 
 	var routers []Router
-	if err := repo.db.Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
 		return err
 	}
 
@@ -45,25 +49,25 @@ func (repo *daoRepo) FillItemRouter(items *[]MenuItem) error {
 	return nil
 }
 
-func (repo *daoRepo) GetItemsRouter(itemIDs []int) ([]Router, error) {
+func (repo *daoRepo) GetItemsRouter(ctx core.Context, itemIDs []int) ([]Router, error) {
 	var routers []Router
 	var routerIDs []int
 
-	if err := repo.db.Model(&MenuItem{}).Select("router_id").Where("item_id IN ?", itemIDs).Find(&routerIDs).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Model(&MenuItem{}).Select("router_id").Where("item_id IN ?", itemIDs).Find(&routerIDs).Error; err != nil {
 		return nil, err
 	}
 
-	if err := repo.db.Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
 		return nil, err
 	}
 
 	return routers, nil
 }
 
-func (repo *daoRepo) GetRouterByIDs(routerIDs []int) ([]Router, error) {
+func (repo *daoRepo) GetRouterByIDs(ctx core.Context, routerIDs []int) ([]Router, error) {
 	var routers []Router
 
-	if err := repo.db.Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Where("router_id IN ?", routerIDs).Find(&routers).Error; err != nil {
 		return nil, err
 	}
 

--- a/backend/pkg/repository/database/dao_team.go
+++ b/backend/pkg/repository/database/dao_team.go
@@ -4,10 +4,8 @@
 package database
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"gorm.io/gorm"
@@ -35,7 +33,7 @@ func (Team) TableName() string {
 	return "team"
 }
 
-func (repo *daoRepo) CreateTeam(ctx context.Context, team Team) error {
+func (repo *daoRepo) CreateTeam(ctx core.Context, team Team) error {
 	var count int64
 	err := repo.GetContextDB(ctx).Model(&Team{}).Where("team_name = ?", team.TeamName).Count(&count).Error
 	if err != nil {
@@ -48,10 +46,10 @@ func (repo *daoRepo) CreateTeam(ctx context.Context, team Team) error {
 	return repo.GetContextDB(ctx).Create(&team).Error
 }
 
-func (repo *daoRepo) TeamExist(filter model.TeamFilter) (bool, error) {
+func (repo *daoRepo) TeamExist(ctx core.Context, filter model.TeamFilter) (bool, error) {
 	var count int64
 
-	query := repo.db.Model(&Team{})
+	query := repo.GetContextDB(ctx).Model(&Team{})
 	if filter.ID != 0 {
 		query.Where("team_id = ?", filter.ID)
 	} else if len(filter.IDs) > 0 {
@@ -68,21 +66,21 @@ func (repo *daoRepo) TeamExist(filter model.TeamFilter) (bool, error) {
 	return count > 0, nil
 }
 
-func (repo *daoRepo) GetTeam(teamID int64) (Team, error) {
+func (repo *daoRepo) GetTeam(ctx core.Context, teamID int64) (Team, error) {
 	var team Team
-	err := repo.db.Find(&team, teamID).Error
+	err := repo.GetContextDB(ctx).Find(&team, teamID).Error
 	return team, err
 }
 
-func (repo *daoRepo) UpdateTeam(ctx context.Context, team Team) error {
+func (repo *daoRepo) UpdateTeam(ctx core.Context, team Team) error {
 	return repo.GetContextDB(ctx).Save(&team).Error
 }
 
-func (repo *daoRepo) GetTeamList(req *request.GetTeamRequest) ([]Team, int64, error) {
+func (repo *daoRepo) GetTeamList(ctx core.Context, req *request.GetTeamRequest) ([]Team, int64, error) {
 	var teams []Team
 	var count int64
 
-	query := repo.db.Model(&Team{}).Preload("UserList", func(db *gorm.DB) *gorm.DB {
+	query := repo.GetContextDB(ctx).Model(&Team{}).Preload("UserList", func(db *gorm.DB) *gorm.DB {
 		return db.Select("user_id, username")
 	})
 
@@ -91,7 +89,7 @@ func (repo *daoRepo) GetTeamList(req *request.GetTeamRequest) ([]Team, int64, er
 	}
 
 	if len(req.FeatureList) > 0 {
-		subQuery := repo.db.Model(&AuthPermission{}).
+		subQuery := repo.GetContextDB(ctx).Model(&AuthPermission{}).
 			Select("subject_id").
 			Joins("JOIN feature f ON f.feature_id = auth_permission.permission_id").
 			Where("f.feature_id IN ? AND auth_permission.subject_type = ?", req.FeatureList, model.PERMISSION_SUB_TYP_TEAM)
@@ -123,7 +121,7 @@ func (repo *daoRepo) GetTeamList(req *request.GetTeamRequest) ([]Team, int64, er
 	}
 
 	var tempFeatures []TempFeature
-	err = repo.db.Model(&AuthPermission{}).
+	err = repo.GetContextDB(ctx).Model(&AuthPermission{}).
 		Select("auth_permission.subject_id as team_id, f.feature_id, f.feature_name").
 		Joins("JOIN feature f ON f.feature_id = auth_permission.permission_id").
 		Where("auth_permission.subject_type = ? AND auth_permission.subject_id IN ?", model.PERMISSION_SUB_TYP_TEAM, teamIDs).
@@ -148,7 +146,7 @@ func (repo *daoRepo) GetTeamList(req *request.GetTeamRequest) ([]Team, int64, er
 	return teams, count, nil
 }
 
-func (repo *daoRepo) DeleteTeam(ctx context.Context, teamID int64) error {
+func (repo *daoRepo) DeleteTeam(ctx core.Context, teamID int64) error {
 	if err := repo.GetContextDB(ctx).Model(&Team{}).Where("team_id = ?", teamID).Delete(nil).Error; err != nil {
 		return err
 	}
@@ -156,29 +154,29 @@ func (repo *daoRepo) DeleteTeam(ctx context.Context, teamID int64) error {
 	return repo.GetContextDB(ctx).Model(&UserTeam{}).Where("team_id = ?", teamID).Delete(nil).Error
 }
 
-func (repo *daoRepo) GetUserTeams(userID int64) ([]int64, error) {
+func (repo *daoRepo) GetUserTeams(ctx core.Context, userID int64) ([]int64, error) {
 	var teamIDs []int64
-	err := repo.db.Model(&UserTeam{}).Select("team_id").Where("user_id = ?", userID).Find(&teamIDs).Error
+	err := repo.GetContextDB(ctx).Model(&UserTeam{}).Select("team_id").Where("user_id = ?", userID).Find(&teamIDs).Error
 	return teamIDs, err
 }
 
-func (repo *daoRepo) GetTeamUsers(teamID int64) ([]int64, error) {
+func (repo *daoRepo) GetTeamUsers(ctx core.Context, teamID int64) ([]int64, error) {
 	var userIDs []int64
-	err := repo.db.Model(&UserTeam{}).Select("user_id").Where("team_id = ?", teamID).Find(&userIDs).Error
+	err := repo.GetContextDB(ctx).Model(&UserTeam{}).Select("user_id").Where("team_id = ?", teamID).Find(&userIDs).Error
 	return userIDs, err
 }
 
-func (repo *daoRepo) GetAssignedTeam(userID int64) ([]Team, error) {
+func (repo *daoRepo) GetAssignedTeam(ctx core.Context, userID int64) ([]Team, error) {
 	var teams []Team
-	subQuery := repo.db.
+	subQuery := repo.GetContextDB(ctx).
 		Model(&UserTeam{}).
 		Select("team_id").
 		Where("user_id = ?", userID)
-	err := repo.db.Where("team_id IN (?)", subQuery).Find(&teams).Error
+	err := repo.GetContextDB(ctx).Where("team_id IN (?)", subQuery).Find(&teams).Error
 	return teams, err
 }
 
-func (repo *daoRepo) AssignUserToTeam(ctx context.Context, userID int64, teamIDs []int64) error {
+func (repo *daoRepo) AssignUserToTeam(ctx core.Context, userID int64, teamIDs []int64) error {
 	if len(teamIDs) == 0 {
 		return nil
 	}
@@ -194,7 +192,7 @@ func (repo *daoRepo) AssignUserToTeam(ctx context.Context, userID int64, teamIDs
 	return repo.GetContextDB(ctx).Create(&userTeams).Error
 }
 
-func (repo *daoRepo) InviteUserToTeam(ctx context.Context, teamID int64, userIDs []int64) error {
+func (repo *daoRepo) InviteUserToTeam(ctx core.Context, teamID int64, userIDs []int64) error {
 	if len(userIDs) == 0 {
 		return nil
 	}
@@ -211,18 +209,18 @@ func (repo *daoRepo) InviteUserToTeam(ctx context.Context, teamID int64, userIDs
 }
 
 // RemoveFromTeamByUser remove user from some of his teams.
-func (repo *daoRepo) RemoveFromTeamByUser(ctx context.Context, userID int64, teamIDs []int64) error {
+func (repo *daoRepo) RemoveFromTeamByUser(ctx core.Context, userID int64, teamIDs []int64) error {
 	return repo.GetContextDB(ctx).Model(&UserTeam{}).Where("user_id = ? AND team_id IN ?", userID, teamIDs).Delete(nil).Error
 }
 
 // RemoveFromTeamByTeam remove team's some users.
-func (repo *daoRepo) RemoveFromTeamByTeam(ctx context.Context, teamID int64, userIDs []int64) error {
+func (repo *daoRepo) RemoveFromTeamByTeam(ctx core.Context, teamID int64, userIDs []int64) error {
 	return repo.GetContextDB(ctx).Model(&UserTeam{}).Where("team_id = ? AND user_id IN ?", teamID, userIDs).Delete(nil).Error
 }
 
 // DeleteAllUserTeam Used for user or team was deleted.
 // If delete the user-related records, by is "user" otherwise by is "team"
-func (repo *daoRepo) DeleteAllUserTeam(ctx context.Context, id int64, by string) error {
+func (repo *daoRepo) DeleteAllUserTeam(ctx core.Context, id int64, by string) error {
 	query := repo.GetContextDB(ctx).Model(&UserTeam{})
 	if by == "user" {
 		query.Where("user_id = ?", id)
@@ -233,9 +231,9 @@ func (repo *daoRepo) DeleteAllUserTeam(ctx context.Context, id int64, by string)
 	return query.Delete(nil).Error
 }
 
-func (repo *daoRepo) GetTeamUserList(teamID int64) ([]User, error) {
+func (repo *daoRepo) GetTeamUserList(ctx core.Context, teamID int64) ([]User, error) {
 	var users []User
-	subQuery := repo.db.Model(&UserTeam{}).Select("user_id").Where("team_id = ?", teamID)
-	err := repo.db.Where("user_id IN (?)", subQuery).Find(&users).Error
+	subQuery := repo.GetContextDB(ctx).Model(&UserTeam{}).Select("user_id").Where("team_id = ?", teamID)
+	err := repo.GetContextDB(ctx).Where("user_id IN (?)", subQuery).Find(&users).Error
 	return users, err
 }

--- a/backend/pkg/repository/database/dao_threshold.go
+++ b/backend/pkg/repository/database/dao_threshold.go
@@ -6,6 +6,7 @@ package database
 import (
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -32,28 +33,28 @@ func (Threshold) TableName() string {
 	return "threshold"
 }
 
-func (repo *daoRepo) CreateOrUpdateThreshold(model *Threshold) error {
+func (repo *daoRepo) CreateOrUpdateThreshold(ctx core.Context, model *Threshold) error {
 	var existing Threshold
-	result := repo.db.Where("service_name = ? AND end_point = ? AND Level = ?", model.ServiceName, model.EndPoint, model.Level).First(&existing)
+	result := repo.GetContextDB(ctx).Where("service_name = ? AND end_point = ? AND Level = ?", model.ServiceName, model.EndPoint, model.Level).First(&existing)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		// If no record is found, insert a new record
-		return repo.db.Create(model).Error
+		return repo.GetContextDB(ctx).Create(model).Error
 	} else if result.Error != nil {
 		// return error if other errors occur
 		return result.Error
 	} else {
 		// Update record if found
-		return repo.db.Model(&existing).Updates(model).Error
+		return repo.GetContextDB(ctx).Model(&existing).Updates(model).Error
 	}
 }
 
-func (repo *daoRepo) GetOrCreateThreshold(serviceName string, endPoint string, level string) (Threshold, error) {
+func (repo *daoRepo) GetOrCreateThreshold(ctx core.Context, serviceName string, endPoint string, level string) (Threshold, error) {
 	var threshold Threshold
 	// Query based on serviceName and endPoint provided
-	result := repo.db.Where("service_name = ? AND end_point = ? AND Level = ?", serviceName, endPoint, level).First(&threshold)
+	result := repo.GetContextDB(ctx).Where("service_name = ? AND end_point = ? AND Level = ?", serviceName, endPoint, level).First(&threshold)
 	if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 		// If no record is found, query again based on serviceName = "global" and endPoint = "global"
-		result = repo.db.Where("Level = ?", GLOBAL).First(&threshold)
+		result = repo.GetContextDB(ctx).Where("Level = ?", GLOBAL).First(&threshold)
 		if errors.Is(result.Error, gorm.ErrRecordNotFound) {
 			// If the record is still not found, create a new threshold data
 			newThreshold := Threshold{
@@ -63,7 +64,7 @@ func (repo *daoRepo) GetOrCreateThreshold(serviceName string, endPoint string, l
 				ErrorRate: ERROR_RATE,
 				Log:       LOG,
 			}
-			if createErr := repo.db.Create(&newThreshold).Error; createErr != nil {
+			if createErr := repo.GetContextDB(ctx).Create(&newThreshold).Error; createErr != nil {
 				return newThreshold, createErr
 			}
 			return newThreshold, nil
@@ -73,9 +74,9 @@ func (repo *daoRepo) GetOrCreateThreshold(serviceName string, endPoint string, l
 	}
 	return threshold, nil
 }
-func (repo *daoRepo) DeleteThreshold(serviceName string, endPoint string) error {
+func (repo *daoRepo) DeleteThreshold(ctx core.Context, serviceName string, endPoint string) error {
 	// Delete records based on serviceName and endPoint
-	result := repo.db.Where("service_name = ? AND end_point = ?", serviceName, endPoint).Delete(&Threshold{})
+	result := repo.GetContextDB(ctx).Where("service_name = ? AND end_point = ?", serviceName, endPoint).Delete(&Threshold{})
 	if result.Error != nil {
 		return result.Error
 	}

--- a/backend/pkg/repository/database/dao_user.go
+++ b/backend/pkg/repository/database/dao_user.go
@@ -4,7 +4,6 @@
 package database
 
 import (
-	"context"
 	"crypto/md5"
 	"encoding/hex"
 	"errors"
@@ -13,7 +12,7 @@ import (
 
 	"github.com/CloudDetail/apo/backend/config"
 	"github.com/CloudDetail/apo/backend/pkg/code"
-	"github.com/CloudDetail/apo/backend/pkg/core"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/util"
@@ -45,9 +44,9 @@ func (t *User) TableName() string {
 	return "user"
 }
 
-func (repo *daoRepo) createAdmin() error {
+func (repo *daoRepo) createAdmin(ctx core.Context) error {
 	var admin User
-	err := repo.db.Where("username = ?", model.ROLE_ADMIN).First(&admin).Error
+	err := repo.GetContextDB(ctx).Where("username = ?", model.ROLE_ADMIN).First(&admin).Error
 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -57,7 +56,7 @@ func (repo *daoRepo) createAdmin() error {
 				Password: Encrypt(adminPasswd),
 			}
 
-			if err = repo.db.Create(&admin).Error; err != nil {
+			if err = repo.GetContextDB(ctx).Create(&admin).Error; err != nil {
 				return err
 			}
 		} else {
@@ -66,20 +65,20 @@ func (repo *daoRepo) createAdmin() error {
 	}
 
 	var role Role
-	if err = repo.db.Where("role_name = ?", model.ROLE_ADMIN).First(&role).Error; err != nil {
+	if err = repo.GetContextDB(ctx).Where("role_name = ?", model.ROLE_ADMIN).First(&role).Error; err != nil {
 		return err
 	}
 	userRole := &UserRole{
 		UserID: admin.UserID,
 		RoleID: role.RoleID,
 	}
-	return repo.db.Save(userRole).Error
+	return repo.GetContextDB(ctx).Save(userRole).Error
 }
 
-func (repo *daoRepo) createAnonymousUser() error {
+func (repo *daoRepo) createAnonymousUser(ctx core.Context) error {
 	conf := config.Get().User.AnonymousUser
 	var anonymousUser User
-	err := repo.db.Where("username = ?", AnonymousUsername).First(&anonymousUser).Error
+	err := repo.GetContextDB(ctx).Where("username = ?", AnonymousUsername).First(&anonymousUser).Error
 
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -90,7 +89,7 @@ func (repo *daoRepo) createAnonymousUser() error {
 				Password: Encrypt(strconv.FormatInt(util.Generator.GenerateID(), 10)),
 			}
 
-			if err = repo.db.Create(&anonymousUser).Error; err != nil {
+			if err = repo.GetContextDB(ctx).Create(&anonymousUser).Error; err != nil {
 				return err
 			}
 		} else {
@@ -103,7 +102,7 @@ func (repo *daoRepo) createAnonymousUser() error {
 		return errors.New("invalid role")
 	}
 
-	if err = repo.db.Where("role_name = ?", conf.Role).First(&role).Error; err != nil {
+	if err = repo.GetContextDB(ctx).Where("role_name = ?", conf.Role).First(&role).Error; err != nil {
 		return err
 	}
 
@@ -116,19 +115,19 @@ func (repo *daoRepo) createAnonymousUser() error {
 	}
 
 	var existingUserRole UserRole
-	err = repo.db.Where("user_id = ?", anonymousUser.UserID).First(&existingUserRole).Error
+	err = repo.GetContextDB(ctx).Where("user_id = ?", anonymousUser.UserID).First(&existingUserRole).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			userRole := &UserRole{
 				UserID: anonymousUser.UserID,
 				RoleID: role.RoleID,
 			}
-			err = repo.db.Create(userRole).Error
+			err = repo.GetContextDB(ctx).Create(userRole).Error
 		} else {
 			return err
 		}
 	} else {
-		err = repo.db.Model(&existingUserRole).Update("role_id", role.RoleID).Error
+		err = repo.GetContextDB(ctx).Model(&existingUserRole).Update("role_id", role.RoleID).Error
 	}
 
 	return err
@@ -140,9 +139,9 @@ func Encrypt(raw string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-func (repo *daoRepo) Login(username, password string) (*User, error) {
+func (repo *daoRepo) Login(ctx core.Context, username, password string) (*User, error) {
 	var user User
-	err := repo.db.Where("username = ?", username).First(&user).Error
+	err := repo.GetContextDB(ctx).Where("username = ?", username).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, core.Error(code.UserNotExistsError, "user does not exists")
 	} else if err != nil {
@@ -156,7 +155,7 @@ func (repo *daoRepo) Login(username, password string) (*User, error) {
 	return &user, nil
 }
 
-func (repo *daoRepo) CreateUser(ctx context.Context, user *User) error {
+func (repo *daoRepo) CreateUser(ctx core.Context, user *User) error {
 	db := repo.GetContextDB(ctx)
 	var count int64
 	err := db.Model(&User{}).Where("username = ?", user.Username).Count(&count).Error
@@ -170,33 +169,33 @@ func (repo *daoRepo) CreateUser(ctx context.Context, user *User) error {
 	return db.Create(user).Error
 }
 
-func (repo *daoRepo) UpdateUserPhone(userID int64, phone string) error {
+func (repo *daoRepo) UpdateUserPhone(ctx core.Context, userID int64, phone string) error {
 	var user User
-	err := repo.db.Where("user_id = ?", userID).First(&user).Error
+	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return core.Error(code.UserNotExistsError, "user does not exists")
 	} else if err != nil {
 		return err
 	}
 	user.Phone = phone
-	return repo.db.Updates(&user).Error
+	return repo.GetContextDB(ctx).Updates(&user).Error
 }
 
-func (repo *daoRepo) UpdateUserEmail(userID int64, email string) error {
+func (repo *daoRepo) UpdateUserEmail(ctx core.Context, userID int64, email string) error {
 	var user User
-	err := repo.db.Where("user_id = ?", userID).First(&user).Error
+	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return core.Error(code.UserNotExistsError, "user does not exists")
 	} else if err != nil {
 		return err
 	}
 	user.Email = email
-	return repo.db.Updates(&user).Error
+	return repo.GetContextDB(ctx).Updates(&user).Error
 }
 
-func (repo *daoRepo) UpdateUserPassword(userID int64, oldPassword, newPassword string) error {
+func (repo *daoRepo) UpdateUserPassword(ctx core.Context, userID int64, oldPassword, newPassword string) error {
 	var user User
-	err := repo.db.Where("user_id = ?", userID).First(&user).Error
+	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return core.Error(code.UserNotExistsError, "user does not exists")
 	} else if err != nil {
@@ -206,12 +205,12 @@ func (repo *daoRepo) UpdateUserPassword(userID int64, oldPassword, newPassword s
 		return core.Error(code.UserPasswdIncorrectError, "password incorrect")
 	}
 	user.Password = Encrypt(newPassword)
-	return repo.db.Updates(&user).Error
+	return repo.GetContextDB(ctx).Updates(&user).Error
 }
 
-func (repo *daoRepo) RestPassword(userID int64, newPassword string) error {
+func (repo *daoRepo) RestPassword(ctx core.Context, userID int64, newPassword string) error {
 	var user User
-	err := repo.db.Where("user_id = ?", userID).First(&user).Error
+	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return core.Error(code.UserNotExistsError, "user does not exists")
 	} else if err != nil {
@@ -219,10 +218,10 @@ func (repo *daoRepo) RestPassword(userID int64, newPassword string) error {
 	}
 
 	user.Password = Encrypt(newPassword)
-	return repo.db.Updates(&user).Error
+	return repo.GetContextDB(ctx).Updates(&user).Error
 }
 
-func (repo *daoRepo) UpdateUserInfo(ctx context.Context, userID int64, phone string, email string, corporation string) error {
+func (repo *daoRepo) UpdateUserInfo(ctx core.Context, userID int64, phone string, email string, corporation string) error {
 	var user User
 	err := repo.GetContextDB(ctx).Where("user_id = ?", userID).First(&user).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -237,9 +236,9 @@ func (repo *daoRepo) UpdateUserInfo(ctx context.Context, userID int64, phone str
 	return repo.GetContextDB(ctx).Updates(&user).Error
 }
 
-func (repo *daoRepo) GetUserInfo(userID int64) (User, error) {
+func (repo *daoRepo) GetUserInfo(ctx core.Context, userID int64) (User, error) {
 	var user User
-	err := repo.db.
+	err := repo.GetContextDB(ctx).
 		Select(userFieldSql).
 		Preload("RoleList").
 		Preload("TeamList").
@@ -248,31 +247,31 @@ func (repo *daoRepo) GetUserInfo(userID int64) (User, error) {
 	return user, err
 }
 
-func (repo *daoRepo) GetAnonymousUser() (User, error) {
+func (repo *daoRepo) GetAnonymousUser(ctx core.Context) (User, error) {
 	var user User
-	err := repo.db.Select(userFieldSql).Where("username = ?", AnonymousUsername).Find(&user).Error
+	err := repo.GetContextDB(ctx).Select(userFieldSql).Where("username = ?", AnonymousUsername).Find(&user).Error
 	return user, err
 }
 
-func (repo *daoRepo) GetUserList(req *request.GetUserListRequest) ([]User, int64, error) {
+func (repo *daoRepo) GetUserList(ctx core.Context, req *request.GetUserListRequest) ([]User, int64, error) {
 	var users []User
 	var count int64
 
-	query := repo.db.Model(&User{}).Preload("RoleList").Preload("TeamList")
+	query := repo.GetContextDB(ctx).Model(&User{}).Preload("RoleList").Preload("TeamList")
 
 	if len(req.Username) > 0 {
 		query = query.Where("username LIKE ?", fmt.Sprintf("%%%s%%", req.Username))
 	}
 
 	if len(req.RoleList) > 0 {
-		subQuery := repo.db.Table("user_role").
+		subQuery := repo.GetContextDB(ctx).Table("user_role").
 			Select("user_id").
 			Where("role_id IN ?", req.RoleList)
 		query = query.Where("user_id IN (?)", subQuery)
 	}
 
 	if len(req.TeamList) > 0 {
-		subQuery := repo.db.Table("user_team").
+		subQuery := repo.GetContextDB(ctx).Table("user_team").
 			Select("user_id").
 			Where("team_id IN ?", req.TeamList)
 		query = query.Where("user_id IN (?)", subQuery)
@@ -299,7 +298,7 @@ func (repo *daoRepo) GetUserList(req *request.GetUserListRequest) ([]User, int64
 	return users, count, nil
 }
 
-func (repo *daoRepo) RemoveUser(ctx context.Context, userID int64) error {
+func (repo *daoRepo) RemoveUser(ctx core.Context, userID int64) error {
 	err := repo.GetContextDB(ctx).Model(&User{}).Where("user_id = ?", userID).Delete(nil).Error
 	if err != nil {
 		return err
@@ -322,9 +321,9 @@ func (repo *daoRepo) RemoveUser(ctx context.Context, userID int64) error {
 		Error
 }
 
-func (repo *daoRepo) UserExists(userIDs ...int64) (bool, error) {
+func (repo *daoRepo) UserExists(ctx core.Context, userIDs ...int64) (bool, error) {
 	var count int64
-	if err := repo.db.Model(&User{}).Where("user_id IN ?", userIDs).Count(&count).Error; err != nil {
+	if err := repo.GetContextDB(ctx).Model(&User{}).Where("user_id IN ?", userIDs).Count(&count).Error; err != nil {
 		return false, err
 	}
 

--- a/backend/pkg/repository/database/driver/db.go
+++ b/backend/pkg/repository/database/driver/db.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package driver
 
 import (

--- a/backend/pkg/repository/database/driver/db.go
+++ b/backend/pkg/repository/database/driver/db.go
@@ -1,0 +1,35 @@
+package driver
+
+import (
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"gorm.io/gorm"
+)
+
+const (
+	_transactionCtxKey = "__transaction__"
+)
+
+type DB struct {
+	*gorm.DB
+}
+
+func (d *DB) GetContextDB(ctx core.Context) *gorm.DB {
+	if ctx == nil {
+		return d.DB
+	}
+
+	ctxDB, exist := ctx.Get(_transactionCtxKey)
+	if exist && ctxDB != nil {
+		tx, ok := ctxDB.(*gorm.DB)
+		if !ok {
+			return nil
+		}
+		return tx
+	}
+	return d.WithContext(ctx.GetContext())
+}
+
+func (d *DB) WithTransaction(ctx core.Context, tx *gorm.DB) core.Context {
+	ctx.Set(_transactionCtxKey, tx)
+	return ctx
+}

--- a/backend/pkg/repository/database/init_api.go
+++ b/backend/pkg/repository/database/init_api.go
@@ -4,11 +4,12 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/spf13/viper"
 	"gorm.io/gorm/clause"
 )
 
-func (repo *daoRepo) initApi() error {
+func (repo *daoRepo) initApi(ctx core.Context) error {
 	var apis []API
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile("./sqlscripts/api.yml")
@@ -19,7 +20,7 @@ func (repo *daoRepo) initApi() error {
 		return err
 	}
 
-	return repo.db.Clauses(clause.OnConflict{
+	return repo.GetContextDB(ctx).Clauses(clause.OnConflict{
 		Columns:   []clause.Column{{Name: "path"}, {Name: "method"}},
 		UpdateAll: true,
 	}).Create(&apis).Error

--- a/backend/pkg/repository/database/init_feature.go
+++ b/backend/pkg/repository/database/init_feature.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -23,8 +24,8 @@ var validFeatures = []Feature{
 	{FeatureName: "数据组管理"}, {FeatureName: "团队管理"}, {FeatureName: "角色管理"},
 }
 
-func (repo *daoRepo) initFeature() error {
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+func (repo *daoRepo) initFeature(ctx core.Context) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var existingFeatures []Feature
 		if err := tx.Where("custom = ?", false).Find(&existingFeatures).Error; err != nil {
 			return err

--- a/backend/pkg/repository/database/init_feature_mapping.go
+++ b/backend/pkg/repository/database/init_feature_mapping.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
@@ -23,7 +24,7 @@ func isValidMenuItem(menuItem string) bool {
 	return false
 }
 
-func (repo *daoRepo) initFeatureMenuItems() error {
+func (repo *daoRepo) initFeatureMenuItems(ctx core.Context) error {
 	featureMenuMapping := []struct {
 		FeatureName string
 		MenuKey     string
@@ -52,7 +53,7 @@ func (repo *daoRepo) initFeatureMenuItems() error {
 		{"角色管理", "role"},
 	}
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var featureIDs, menuItemIDs []int
 		if err := tx.Model(&Feature{}).Select("feature_id").Find(&featureIDs).Error; err != nil {
 			return err
@@ -126,7 +127,7 @@ func (repo *daoRepo) initFeatureMenuItems() error {
 
 // TODO add mapping of feature and api
 
-func (repo *daoRepo) initFeatureRouter() error {
+func (repo *daoRepo) initFeatureRouter(ctx core.Context) error {
 	featureRoutes := map[string][]string{
 		"服务概览": {"/service/info", "/service/overview"},
 		"数据接入": {"/integration/data/settings", "/data/ingestion"},
@@ -134,7 +135,7 @@ func (repo *daoRepo) initFeatureRouter() error {
 		"告警事件": {"/alerts/events/detail/:alertID/:eventID"},
 	}
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var featureIDs, routerIDs []int
 		if err := tx.Model(&Feature{}).Select("feature_id").Find(&featureIDs).Error; err != nil {
 			return err
@@ -221,7 +222,7 @@ func isValidPath(path string) bool {
 	return len(path) > 0 && path[0] == '/' && !strings.ContainsAny(path, ";&'=")
 }
 
-func (repo *daoRepo) initFeatureAPI() error {
+func (repo *daoRepo) initFeatureAPI(ctx core.Context) error {
 	featureAPI := map[string][]API{}
 	viper.SetConfigType("yaml")
 	viper.SetConfigFile("./sqlscripts/feature_api.yml")
@@ -232,7 +233,7 @@ func (repo *daoRepo) initFeatureAPI() error {
 		return err
 	}
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.AutoMigrate(&FeatureMapping{}); err != nil {
 			return err
 		}

--- a/backend/pkg/repository/database/init_i18n.go
+++ b/backend/pkg/repository/database/init_i18n.go
@@ -6,12 +6,13 @@ package database
 import (
 	"fmt"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/spf13/viper"
 	"gorm.io/gorm"
 )
 
-func (repo *daoRepo) initI18nTranslation() error {
+func (repo *daoRepo) initI18nTranslation(ctx core.Context) error {
 	type transConfig struct {
 		Key  string            `mapstructure:"key"`
 		I18n []I18nTranslation `mapstructure:"i18n"`
@@ -26,7 +27,7 @@ func (repo *daoRepo) initI18nTranslation() error {
 		return err
 	}
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var existingTranslations []I18nTranslation
 		var toInsert, toDelete, toUpdate []I18nTranslation
 		if err := tx.Find(&existingTranslations).Error; err != nil {

--- a/backend/pkg/repository/database/init_insert_page.go
+++ b/backend/pkg/repository/database/init_insert_page.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -19,8 +20,8 @@ var validPages = []InsertPage{
 	{Url: "grafana/d/3ab420aae391a1/originx-polaris-metrics", Type: "grafana"},
 }
 
-func (repo *daoRepo) initInsertPages() error {
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+func (repo *daoRepo) initInsertPages(ctx core.Context) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var existingPage, toAdd []InsertPage
 		var toDelete []int
 		var toUpdate []InsertPage

--- a/backend/pkg/repository/database/init_menu_item.go
+++ b/backend/pkg/repository/database/init_menu_item.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -41,9 +42,9 @@ var validMenuItemMappings = []struct {
 	{MenuItem: MenuItem{Key: "role", Order: 52}, RouterKey: "/system/role-manage"},
 }
 
-func (repo *daoRepo) initMenuItems() error {
+func (repo *daoRepo) initMenuItems(ctx core.Context) error {
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		// Menu item might include item which not support to existing
 		// but the mapping between item and feature will be deleted
 		// because once a menu was deleted, the feature should also be deleted.

--- a/backend/pkg/repository/database/init_permission.go
+++ b/backend/pkg/repository/database/init_permission.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"gorm.io/gorm"
 )
@@ -18,7 +19,7 @@ func isValidRoleName(roleName string) bool {
 	return false
 }
 
-func (repo *daoRepo) initPermissions() error {
+func (repo *daoRepo) initPermissions(ctx core.Context) error {
 	roleFeatures := map[string][]string{
 		model.ROLE_ADMIN: {
 			"服务概览", "工作流", "日志检索", "故障现场日志", "全量日志", "链路追踪",
@@ -44,7 +45,7 @@ func (repo *daoRepo) initPermissions() error {
 		},
 	}
 
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var featureIDs []int
 		if err := tx.Model(&Feature{}).Select("feature_id").Find(&featureIDs).Error; err != nil {
 			return err

--- a/backend/pkg/repository/database/init_role.go
+++ b/backend/pkg/repository/database/init_role.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -15,8 +16,8 @@ var validRoles = []Role{
 	{RoleName: model.ROLE_ANONYMOS},
 }
 
-func (repo *daoRepo) initRole() error {
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+func (repo *daoRepo) initRole(ctx core.Context) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		return tx.Clauses(clause.OnConflict{
 			Columns:   []clause.Column{{Name: "role_name"}},
 			DoNothing: true,

--- a/backend/pkg/repository/database/init_router.go
+++ b/backend/pkg/repository/database/init_router.go
@@ -4,6 +4,7 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -37,8 +38,8 @@ var validRouters = []Router{
 }
 
 // initRouterData TODO Add mapping of router to feature when permission control is required
-func (repo *daoRepo) initRouterData() error {
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+func (repo *daoRepo) initRouterData(ctx core.Context) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		if err := tx.AutoMigrate(&Router{}); err != nil {
 			return err
 		}

--- a/backend/pkg/repository/database/init_router_page.go
+++ b/backend/pkg/repository/database/init_router_page.go
@@ -6,6 +6,7 @@ package database
 import (
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"gorm.io/gorm"
 )
 
@@ -30,7 +31,7 @@ func isValidPageURL(url string) bool {
 }
 
 // initRouterPage init router-insertPage mapping records.
-func (repo *daoRepo) initRouterPage() error {
+func (repo *daoRepo) initRouterPage(ctx core.Context) error {
 	type page struct {
 		url      string
 		language string
@@ -59,7 +60,7 @@ func (repo *daoRepo) initRouterPage() error {
 			{url: "jaeger/search", language: "en"},
 		},
 	}
-	return repo.db.Transaction(func(tx *gorm.DB) error {
+	return repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		var routerIDs, pageIDs []int
 		if err := tx.Model(&Router{}).Select("router_id").Find(&routerIDs).Error; err != nil {
 			return err

--- a/backend/pkg/repository/database/integration/alert/dao.go
+++ b/backend/pkg/repository/database/integration/alert/dao.go
@@ -5,66 +5,70 @@ package alert
 
 import (
 	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
+	"github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
 	dbdriver "github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
 
 	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"gorm.io/gorm"
 )
 
 type AlertInput interface {
 	// Manage AlertSource
-	CreateAlertSource(*alert.AlertSource) error
-	GetAlertSource(sourceId string) (*alert.AlertSource, error)
-	UpdateAlertSource(alertSource *alert.AlertSource) error
-	DeleteAlertSource(alertSource alert.SourceFrom) (*alert.AlertSource, error)
-	ListAlertSource() ([]alert.AlertSource, error)
+	CreateAlertSource(ctx core.Context, source *alert.AlertSource) error
+	GetAlertSource(ctx core.Context, sourceId string) (*alert.AlertSource, error)
+	UpdateAlertSource(ctx core.Context, alertSource *alert.AlertSource) error
+	DeleteAlertSource(ctx core.Context, alertSource alert.SourceFrom) (*alert.AlertSource, error)
+	ListAlertSource(ctx core.Context) ([]alert.AlertSource, error)
 
 	// Manage AlertEnrichRule
-	AddAlertEnrichRule(enrichRule []alert.AlertEnrichRule) error
-	AddAlertEnrichConditions(enrichConditions []alert.AlertEnrichCondition) error
-	AddAlertEnrichSchemaTarget(enrichSchemaTarget []alert.AlertEnrichSchemaTarget) error
-	GetAlertEnrichRule(sourceId string) ([]alert.AlertEnrichRule, error)
-	GetAlertEnrichConditions(sourceId string) ([]alert.AlertEnrichCondition, error)
-	GetAlertEnrichSchemaTarget(sourceId string) ([]alert.AlertEnrichSchemaTarget, error)
-	DeleteAlertEnrichRule(ruleIds []string) error
-	DeleteAlertEnrichRuleBySourceId(sourceId string) error
-	DeleteAlertEnrichConditions(ruleIds []string) error
-	DeleteAlertEnrichConditionsBySourceId(sourceId string) error
-	DeleteAlertEnrichSchemaTarget(ruleIds []string) error
-	DeleteAlertEnrichSchemaTargetBySourceId(sourceId string) error
+	AddAlertEnrichRule(ctx core.Context, enrichRule []alert.AlertEnrichRule) error
+	AddAlertEnrichConditions(ctx core.Context, enrichConditions []alert.AlertEnrichCondition) error
+	AddAlertEnrichSchemaTarget(ctx core.Context, enrichSchemaTarget []alert.AlertEnrichSchemaTarget) error
+	GetAlertEnrichRule(ctx core.Context, sourceId string) ([]alert.AlertEnrichRule, error)
+	GetAlertEnrichConditions(ctx core.Context, sourceId string) ([]alert.AlertEnrichCondition, error)
+	GetAlertEnrichSchemaTarget(ctx core.Context, sourceId string) ([]alert.AlertEnrichSchemaTarget, error)
+	DeleteAlertEnrichRule(ctx core.Context, ruleIds []string) error
+	DeleteAlertEnrichRuleBySourceId(ctx core.Context, sourceId string) error
+	DeleteAlertEnrichConditions(ctx core.Context, ruleIds []string) error
+	DeleteAlertEnrichConditionsBySourceId(ctx core.Context, sourceId string) error
+	DeleteAlertEnrichSchemaTarget(ctx core.Context, ruleIds []string) error
+	DeleteAlertEnrichSchemaTargetBySourceId(ctx core.Context, sourceId string) error
 
 	// Manage schema
-	CreateSchema(schema string, columns []string) error
-	DeleteSchema(string) error
-	CheckSchemaIsUsed(schema string) ([]string, error)
-	ListSchema() ([]string, error)
-	ListSchemaColumns(schema string) ([]string, error)
-	InsertSchemaData(schema string, columns []string, fullRows [][]string) error
-	GetSchemaData(schema string) ([]string, map[int64][]string, error)
-	UpdateSchemaData(schema string, columns []string, rows map[int][]string) error
-	ClearSchemaData(schema string) error
-	SearchSchemaTarget(schema string, sourceField string, sourceValue string, targets []alert.AlertEnrichSchemaTarget) ([]string, error)
+	CreateSchema(ctx core.Context, schema string, columns []string) error
+	DeleteSchema(ctx core.Context, schema string) error
+	CheckSchemaIsUsed(ctx core.Context, schema string) ([]string, error)
+	ListSchema(ctx core.Context) ([]string, error)
+	ListSchemaColumns(ctx core.Context, schema string) ([]string, error)
+	InsertSchemaData(ctx core.Context, schema string, columns []string, fullRows [][]string) error
+	GetSchemaData(ctx core.Context, schema string) ([]string, map[int64][]string, error)
+	UpdateSchemaData(ctx core.Context, schema string, columns []string, rows map[int][]string) error
+	ClearSchemaData(ctx core.Context, schema string) error
+	SearchSchemaTarget(ctx core.Context, schema string, sourceField string, sourceValue string, targets []alert.AlertEnrichSchemaTarget) ([]string, error)
 
-	ListAlertTargetTags(lang string) ([]alert.TargetTag, error)
+	ListAlertTargetTags(ctx core.Context) ([]alert.TargetTag, error)
 
 	// Load complate alertEnrichRule
-	LoadAlertEnrichRule() ([]alert.AlertSource, map[alert.SourceFrom][]alert.AlertEnrichRuleVO, error)
+	LoadAlertEnrichRule(ctx core.Context) ([]alert.AlertSource, map[alert.SourceFrom][]alert.AlertEnrichRuleVO, error)
 
-	GetAlertSlience() ([]sc.AlertSlienceConfig, error)
-	AddAlertSlience(slience *sc.AlertSlienceConfig) error
-	UpdateAlertSlience(slience *sc.AlertSlienceConfig) error
-	DeleteAlertSlience(id int) error
+	GetAlertSlience(ctx core.Context) ([]sc.AlertSlienceConfig, error)
+	AddAlertSlience(ctx core.Context, slience *sc.AlertSlienceConfig) error
+	UpdateAlertSlience(ctx core.Context, slience *sc.AlertSlienceConfig) error
+	DeleteAlertSlience(ctx core.Context, id int) error
 }
 
 type subRepo struct {
-	db *gorm.DB
+	*driver.DB
 }
 
 func NewAlertInputRepo(db *gorm.DB, cfg *config.Config) (*subRepo, error) {
-	repo := &subRepo{db}
+	repo := &subRepo{
+		DB: &driver.DB{DB: db},
+	}
 
-	if err := repo.db.AutoMigrate(
+	if err := repo.GetContextDB(nil).AutoMigrate(
 		&alert.AlertSource{},
 		&alert.TargetTag{},
 		&alert.AlertEnrichRule{},

--- a/backend/pkg/repository/database/integration/alert/dao_list_alert_target_tags.go
+++ b/backend/pkg/repository/database/integration/alert/dao_list_alert_target_tags.go
@@ -6,12 +6,14 @@ package alert
 import (
 	"strings"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
-func (repo *subRepo) ListAlertTargetTags(lang string) ([]alert.TargetTag, error) {
+func (repo *subRepo) ListAlertTargetTags(ctx core.Context) ([]alert.TargetTag, error) {
+	lang := ctx.LANG()
 	var targetTags []alert.TargetTag
-	err := repo.db.Model(&alert.TargetTag{}).
+	err := repo.GetContextDB(ctx).Model(&alert.TargetTag{}).
 		Select("id", "field", getTargetTag(lang), getTargetTagDescribe(lang)).
 		Order("id ASC").
 		Scan(&targetTags).Error

--- a/backend/pkg/repository/database/integration/alert/dao_load_alert_enrich_rule.go
+++ b/backend/pkg/repository/database/integration/alert/dao_load_alert_enrich_rule.go
@@ -3,29 +3,32 @@
 
 package alert
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
 
-func (repo *subRepo) LoadAlertEnrichRule() ([]alert.AlertSource, map[alert.SourceFrom][]alert.AlertEnrichRuleVO, error) {
+func (repo *subRepo) LoadAlertEnrichRule(ctx core.Context) ([]alert.AlertSource, map[alert.SourceFrom][]alert.AlertEnrichRuleVO, error) {
 	var sources []alert.AlertSource
-	err := repo.db.Find(&sources).Error
+	err := repo.GetContextDB(ctx).Find(&sources).Error
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var enrichRules []alert.AlertEnrichRule
-	err = repo.db.Find(&enrichRules).Error
+	err = repo.GetContextDB(ctx).Find(&enrichRules).Error
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var enrichConditions []alert.AlertEnrichCondition
-	err = repo.db.Find(&enrichConditions).Error
+	err = repo.GetContextDB(ctx).Find(&enrichConditions).Error
 	if err != nil {
 		return nil, nil, err
 	}
 
 	var enrichSchemaTarget []alert.AlertEnrichSchemaTarget
-	err = repo.db.Find(&enrichSchemaTarget).Error
+	err = repo.GetContextDB(ctx).Find(&enrichSchemaTarget).Error
 	if err != nil {
 		return nil, nil, err
 	}

--- a/backend/pkg/repository/database/integration/alert/dao_manage_enrich_conditions.go
+++ b/backend/pkg/repository/database/integration/alert/dao_manage_enrich_conditions.go
@@ -3,28 +3,31 @@
 
 package alert
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
 
-func (repo *subRepo) AddAlertEnrichConditions(enrichConditions []alert.AlertEnrichCondition) error {
+func (repo *subRepo) AddAlertEnrichConditions(ctx core.Context, enrichConditions []alert.AlertEnrichCondition) error {
 	if len(enrichConditions) == 0 {
 		return nil
 	}
-	return repo.db.Create(&enrichConditions).Error
+	return repo.GetContextDB(ctx).Create(&enrichConditions).Error
 }
 
-func (repo *subRepo) GetAlertEnrichConditions(sourceId string) ([]alert.AlertEnrichCondition, error) {
+func (repo *subRepo) GetAlertEnrichConditions(ctx core.Context, sourceId string) ([]alert.AlertEnrichCondition, error) {
 	var enrichConditions []alert.AlertEnrichCondition
-	err := repo.db.Find(&enrichConditions, "source_id = ?", sourceId).Error
+	err := repo.GetContextDB(ctx).Find(&enrichConditions, "source_id = ?", sourceId).Error
 	return enrichConditions, err
 }
 
-func (repo *subRepo) DeleteAlertEnrichConditions(ruleIds []string) error {
+func (repo *subRepo) DeleteAlertEnrichConditions(ctx core.Context, ruleIds []string) error {
 	if len(ruleIds) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&alert.AlertEnrichCondition{}, "enrich_rule_id in ?", ruleIds).Error
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichCondition{}, "enrich_rule_id in ?", ruleIds).Error
 }
 
-func (repo *subRepo) DeleteAlertEnrichConditionsBySourceId(sourceId string) error {
-	return repo.db.Delete(&alert.AlertEnrichCondition{}, "source_id = ?", sourceId).Error
+func (repo *subRepo) DeleteAlertEnrichConditionsBySourceId(ctx core.Context, sourceId string) error {
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichCondition{}, "source_id = ?", sourceId).Error
 }

--- a/backend/pkg/repository/database/integration/alert/dao_manage_enrich_rule.go
+++ b/backend/pkg/repository/database/integration/alert/dao_manage_enrich_rule.go
@@ -3,28 +3,31 @@
 
 package alert
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
 
-func (repo *subRepo) AddAlertEnrichRule(enrichRule []alert.AlertEnrichRule) error {
+func (repo *subRepo) AddAlertEnrichRule(ctx core.Context, enrichRule []alert.AlertEnrichRule) error {
 	if len(enrichRule) == 0 {
 		return nil
 	}
-	return repo.db.Create(&enrichRule).Error
+	return repo.GetContextDB(ctx).Create(&enrichRule).Error
 }
 
-func (repo *subRepo) GetAlertEnrichRule(sourceId string) ([]alert.AlertEnrichRule, error) {
+func (repo *subRepo) GetAlertEnrichRule(ctx core.Context, sourceId string) ([]alert.AlertEnrichRule, error) {
 	var enrichRules []alert.AlertEnrichRule
-	err := repo.db.Find(&enrichRules, "source_id = ?", sourceId).Error
+	err := repo.GetContextDB(ctx).Find(&enrichRules, "source_id = ?", sourceId).Error
 	return enrichRules, err
 }
 
-func (repo *subRepo) DeleteAlertEnrichRule(ruleIds []string) error {
+func (repo *subRepo) DeleteAlertEnrichRule(ctx core.Context, ruleIds []string) error {
 	if len(ruleIds) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&alert.AlertEnrichRule{}, "enrich_rule_id in ?", ruleIds).Error
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichRule{}, "enrich_rule_id in ?", ruleIds).Error
 }
 
-func (repo *subRepo) DeleteAlertEnrichRuleBySourceId(sourceId string) error {
-	return repo.db.Delete(&alert.AlertEnrichRule{}, "source_id = ?", sourceId).Error
+func (repo *subRepo) DeleteAlertEnrichRuleBySourceId(ctx core.Context, sourceId string) error {
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichRule{}, "source_id = ?", sourceId).Error
 }

--- a/backend/pkg/repository/database/integration/alert/dao_manage_enrich_schema_target.go
+++ b/backend/pkg/repository/database/integration/alert/dao_manage_enrich_schema_target.go
@@ -3,16 +3,19 @@
 
 package alert
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
 
-func (repo *subRepo) CheckSchemaIsUsed(schema string) ([]string, error) {
+func (repo *subRepo) CheckSchemaIsUsed(ctx core.Context, schema string) ([]string, error) {
 	var alertSource = make([]string, 0)
 	if !AllowSchema.MatchString(schema) {
 		return nil, alert.ErrNotAllowSchema{Table: schema}
 	}
 
 	sql := `SELECT source_name,schema FROM alert_enrich_rules st left join alert_sources s on s.source_id = st.source_id WHERE st.schema = ?`
-	rows, err := repo.db.Raw(sql, schema).Rows()
+	rows, err := repo.GetContextDB(ctx).Raw(sql, schema).Rows()
 	if err != nil {
 		return nil, err
 	}
@@ -34,26 +37,26 @@ func (repo *subRepo) CheckSchemaIsUsed(schema string) ([]string, error) {
 	return alertSource, err
 }
 
-func (repo *subRepo) AddAlertEnrichSchemaTarget(enrichSchemaTarget []alert.AlertEnrichSchemaTarget) error {
+func (repo *subRepo) AddAlertEnrichSchemaTarget(ctx core.Context, enrichSchemaTarget []alert.AlertEnrichSchemaTarget) error {
 	if len(enrichSchemaTarget) == 0 {
 		return nil
 	}
-	return repo.db.Create(&enrichSchemaTarget).Error
+	return repo.GetContextDB(ctx).Create(&enrichSchemaTarget).Error
 }
 
-func (repo *subRepo) GetAlertEnrichSchemaTarget(sourceId string) ([]alert.AlertEnrichSchemaTarget, error) {
+func (repo *subRepo) GetAlertEnrichSchemaTarget(ctx core.Context, sourceId string) ([]alert.AlertEnrichSchemaTarget, error) {
 	var enrichSchemaTarget []alert.AlertEnrichSchemaTarget
-	err := repo.db.Find(&enrichSchemaTarget, "source_id = ?", sourceId).Error
+	err := repo.GetContextDB(ctx).Find(&enrichSchemaTarget, "source_id = ?", sourceId).Error
 	return enrichSchemaTarget, err
 }
 
-func (repo *subRepo) DeleteAlertEnrichSchemaTarget(ruleIds []string) error {
+func (repo *subRepo) DeleteAlertEnrichSchemaTarget(ctx core.Context, ruleIds []string) error {
 	if len(ruleIds) == 0 {
 		return nil
 	}
-	return repo.db.Delete(&alert.AlertEnrichSchemaTarget{}, "enrich_rule_id in ?", ruleIds).Error
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichSchemaTarget{}, "enrich_rule_id in ?", ruleIds).Error
 }
 
-func (repo *subRepo) DeleteAlertEnrichSchemaTargetBySourceId(sourceId string) error {
-	return repo.db.Delete(&alert.AlertEnrichSchemaTarget{}, "source_id = ?", sourceId).Error
+func (repo *subRepo) DeleteAlertEnrichSchemaTargetBySourceId(ctx core.Context, sourceId string) error {
+	return repo.GetContextDB(ctx).Delete(&alert.AlertEnrichSchemaTarget{}, "source_id = ?", sourceId).Error
 }

--- a/backend/pkg/repository/database/integration/alert/dao_search_schema_target.go
+++ b/backend/pkg/repository/database/integration/alert/dao_search_schema_target.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"regexp"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
 var AllowField = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]{0,63}$`)
 
-func (repo *subRepo) SearchSchemaTarget(
+func (repo *subRepo) SearchSchemaTarget(ctx core.Context,
 	schema string,
 	sourceField string, sourceValue string,
 	targets []alert.AlertEnrichSchemaTarget,
@@ -25,8 +26,8 @@ func (repo *subRepo) SearchSchemaTarget(
 	if !AllowField.MatchString(sourceField) {
 		return nil, fmt.Errorf("invalid source field: %s", sourceField)
 	}
-	
-	rows, err := repo.db.Table(schema).Where(fmt.Sprintf("%s = ?", sourceField), sourceValue).Limit(1).Rows()
+
+	rows, err := repo.GetContextDB(ctx).Table(schema).Where(fmt.Sprintf("%s = ?", sourceField), sourceValue).Limit(1).Rows()
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/database/integration/alert/dao_slient.go
+++ b/backend/pkg/repository/database/integration/alert/dao_slient.go
@@ -3,25 +3,28 @@
 
 package alert
 
-import sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
+)
 
-func (repo *subRepo) GetAlertSlience() ([]sc.AlertSlienceConfig, error) {
+func (repo *subRepo) GetAlertSlience(ctx core.Context) ([]sc.AlertSlienceConfig, error) {
 	var result []sc.AlertSlienceConfig
-	err := repo.db.Find(&result).Error
+	err := repo.GetContextDB(ctx).Find(&result).Error
 	if err != nil {
 		return nil, err
 	}
 	return result, nil
 }
 
-func (repo *subRepo) AddAlertSlience(SlienceConfig *sc.AlertSlienceConfig) error {
-	return repo.db.Create(SlienceConfig).Error
+func (repo *subRepo) AddAlertSlience(ctx core.Context, SlienceConfig *sc.AlertSlienceConfig) error {
+	return repo.GetContextDB(ctx).Create(SlienceConfig).Error
 }
 
-func (repo *subRepo) UpdateAlertSlience(SlienceConfig *sc.AlertSlienceConfig) error {
-	return repo.db.Where("id = ?", SlienceConfig.ID).Updates(SlienceConfig).Error
+func (repo *subRepo) UpdateAlertSlience(ctx core.Context, SlienceConfig *sc.AlertSlienceConfig) error {
+	return repo.GetContextDB(ctx).Where("id = ?", SlienceConfig.ID).Updates(SlienceConfig).Error
 }
 
-func (repo *subRepo) DeleteAlertSlience(id int) error {
-	return repo.db.Delete(&sc.AlertSlienceConfig{}, "id = ? ", id).Error
+func (repo *subRepo) DeleteAlertSlience(ctx core.Context, id int) error {
+	return repo.GetContextDB(ctx).Delete(&sc.AlertSlienceConfig{}, "id = ? ", id).Error
 }

--- a/backend/pkg/repository/database/integration/dao_integration_config.go
+++ b/backend/pkg/repository/database/integration/dao_integration_config.go
@@ -7,29 +7,30 @@ import (
 	"encoding/json"
 	"errors"
 
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"go.uber.org/multierr"
 	"gorm.io/gorm"
 )
 
-func (repo *subRepos) updateTraceIntegration(t *integration.TraceIntegration) error {
+func (repo *subRepos) updateTraceIntegration(ctx core.Context, t *integration.TraceIntegration) error {
 	var updateError error
 
 	if t.Mode == "sidecar" {
 		oldAPI := integration.TraceIntegration{}
-		err := repo.db.First(&oldAPI, "apm_type = ? and mode = 'sidecar'", t.ApmType).
+		err := repo.GetContextDB(ctx).First(&oldAPI, "apm_type = ? and mode = 'sidecar'", t.ApmType).
 			Order("updated_at DESC").Error
 		if err == nil {
 			t.TraceAPI.AcceptExistedSecret(oldAPI.TraceAPI.Obj)
 		}
 	}
 
-	updateError = repo.db.Save(t).Error
+	updateError = repo.GetContextDB(ctx).Save(t).Error
 
 	if !IndependentTraceAPI && t.Mode == "sidecar" {
 		// since traceAPI is not independent now
 		// Any change will affect all sidecar trace integrations
-		err := repo.db.Model(&integration.TraceIntegration{}).
+		err := repo.GetContextDB(ctx).Model(&integration.TraceIntegration{}).
 			Where("apm_type = ? and mode = 'sidecar'", t.ApmType).
 			Update("trace_api", t.TraceAPI).Error
 
@@ -40,27 +41,27 @@ func (repo *subRepos) updateTraceIntegration(t *integration.TraceIntegration) er
 }
 
 // save basic datasource for the platform, usually come from configmap
-func (repo *subRepos) UpdateAllMetricIntegration(m *integration.MetricIntegration) error {
+func (repo *subRepos) UpdateAllMetricIntegration(ctx core.Context, m *integration.MetricIntegration) error {
 	m.ClusterID = integration.PlatformClusterID.String()
-	return repo.updateMetricIntegration(m)
+	return repo.updateMetricIntegration(ctx, m)
 }
 
-func (repo *subRepos) updateMetricIntegration(m *integration.MetricIntegration) error {
+func (repo *subRepos) updateMetricIntegration(ctx core.Context, m *integration.MetricIntegration) error {
 	var updateError error
 
 	// oldAPI := integration.MetricIntegration{}
-	// err := repo.db.First(&oldAPI, "ds_type = ? ", m.DSType).
+	// err := repo.GetContextDB(ctx).First(&oldAPI, "ds_type = ? ", m.DSType).
 	// 	Order("updated_at DESC").Error
 	// if err == nil {
 	// 	m.MetricAPI.AcceptExistedSecret(oldAPI.MetricAPI.Obj)
 	// }
 
-	updateError = repo.db.Save(m).Error
+	updateError = repo.GetContextDB(ctx).Save(m).Error
 
 	if !IndependentMetricDatasource {
 		// Since Metric integration is not independent now
 		// Any change will affect all metric integrations
-		err := repo.db.Model(&integration.MetricIntegration{}).Omit("cluster_id").
+		err := repo.GetContextDB(ctx).Model(&integration.MetricIntegration{}).Omit("cluster_id").
 			Where("ds_type = ?", m.DSType).
 			Updates(m).Error
 		updateError = multierr.Append(updateError, err)
@@ -70,26 +71,26 @@ func (repo *subRepos) updateMetricIntegration(m *integration.MetricIntegration) 
 }
 
 // same as UpdateAllMetricIntegration
-func (repo *subRepos) UpdateAllLogIntegration(l *integration.LogIntegration) error {
+func (repo *subRepos) UpdateAllLogIntegration(ctx core.Context, l *integration.LogIntegration) error {
 	l.ClusterID = integration.PlatformClusterID.String()
-	return repo.updateLogIntegration(l)
+	return repo.updateLogIntegration(ctx, l)
 }
 
-func (repo *subRepos) updateLogIntegration(l *integration.LogIntegration) error {
+func (repo *subRepos) updateLogIntegration(ctx core.Context, l *integration.LogIntegration) error {
 	var updateError error
 
 	// oldAPI := integration.LogIntegration{}
-	// err := repo.db.First(&oldAPI, "db_type = ? ", l.DBType).
+	// err := repo.GetContextDB(ctx).First(&oldAPI, "db_type = ? ", l.DBType).
 	// 	Order("updated_at DESC").Error
 	// if err == nil {
 	// 	l.LogAPI.AcceptExistedSecret(oldAPI.LogAPI.Obj)
 	// }
 
-	updateError = repo.db.Save(l).Error
+	updateError = repo.GetContextDB(ctx).Save(l).Error
 
 	if !IndependentLogDatabase {
 		// same as updateMetricIntegration
-		err := repo.db.Model(&integration.LogIntegration{}).Omit("cluster_id").
+		err := repo.GetContextDB(ctx).Model(&integration.LogIntegration{}).Omit("cluster_id").
 			Where("db_type = ?", l.DBType).
 			Updates(l).Error
 		updateError = multierr.Append(updateError, err)
@@ -98,27 +99,27 @@ func (repo *subRepos) updateLogIntegration(l *integration.LogIntegration) error 
 	return updateError
 }
 
-func (repo *subRepos) SaveIntegrationConfig(iConfig integration.ClusterIntegration) error {
+func (repo *subRepos) SaveIntegrationConfig(ctx core.Context, iConfig integration.ClusterIntegration) error {
 	iConfig.Trace.ClusterID = iConfig.ID
 	iConfig.Metric.ClusterID = iConfig.ID
 	iConfig.Log.ClusterID = iConfig.ID
 
 	var storeErr error
 
-	storeErr = repo.updateTraceIntegration(&iConfig.Trace)
+	storeErr = repo.updateTraceIntegration(ctx, &iConfig.Trace)
 
-	err := repo.updateMetricIntegration(&iConfig.Metric)
+	err := repo.updateMetricIntegration(ctx, &iConfig.Metric)
 	storeErr = multierr.Append(storeErr, err)
 
-	err = repo.updateLogIntegration(&iConfig.Log)
+	err = repo.updateLogIntegration(ctx, &iConfig.Log)
 	storeErr = multierr.Append(storeErr, err)
 
 	return storeErr
 }
 
 // get integration config for the cluster
-func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.ClusterIntegration, error) {
-	cluster, err := repo.GetCluster(clusterID)
+func (repo *subRepos) GetIntegrationConfig(ctx core.Context, clusterID string) (*integration.ClusterIntegration, error) {
+	cluster, err := repo.GetCluster(ctx, clusterID)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +129,7 @@ func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.Clust
 	}
 
 	var traceIntegration integration.TraceIntegration
-	err = repo.db.
+	err = repo.GetContextDB(ctx).
 		Where("cluster_id = ?", clusterID).
 		Where("is_deleted = ?", false).
 		First(&traceIntegration).Error
@@ -138,7 +139,7 @@ func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.Clust
 	res.Trace = traceIntegration
 
 	var metricIntegration integration.MetricIntegration
-	err = repo.db.
+	err = repo.GetContextDB(ctx).
 		Where("cluster_id = ?", clusterID).
 		Where("is_deleted = ?", false).
 		First(&metricIntegration).Error
@@ -148,7 +149,7 @@ func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.Clust
 	res.Metric = metricIntegration
 
 	var logIntegration integration.LogIntegration
-	err = repo.db.
+	err = repo.GetContextDB(ctx).
 		Where("cluster_id = ?", clusterID).
 		Where("is_deleted = ?", false).
 		First(&logIntegration).Error
@@ -160,18 +161,18 @@ func (repo *subRepos) GetIntegrationConfig(clusterID string) (*integration.Clust
 	return res, err
 }
 
-func (repo *subRepos) DeleteIntegrationConfig(clusterID string) error {
-	err := repo.db.Model(&integration.TraceIntegration{}).
+func (repo *subRepos) DeleteIntegrationConfig(ctx core.Context, clusterID string) error {
+	err := repo.GetContextDB(ctx).Model(&integration.TraceIntegration{}).
 		Where("cluster_id = ?", clusterID).
 		Update("is_deleted", true).Error
 
-	err2 := repo.db.Model(&integration.MetricIntegration{}).
+	err2 := repo.GetContextDB(ctx).Model(&integration.MetricIntegration{}).
 		Where("cluster_id = ?", clusterID).
 		Update("is_deleted", true).Error
 
 	err = multierr.Append(err, err2)
 
-	err3 := repo.db.Model(&integration.LogIntegration{}).
+	err3 := repo.GetContextDB(ctx).Model(&integration.LogIntegration{}).
 		Where("cluster_id = ?", clusterID).
 		Update("is_deleted", true).Error
 
@@ -187,9 +188,9 @@ type traceAPI struct {
 	UpdatedAt int64 `gorm:"autoUpdateTime"`
 }
 
-func (repo *subRepos) GetLatestTraceAPIs(lastUpdateTS int64) (*integration.AdapterAPIConfig, error) {
+func (repo *subRepos) GetLatestTraceAPIs(ctx core.Context, lastUpdateTS int64) (*integration.AdapterAPIConfig, error) {
 	var latestUpdateTraceAPI integration.TraceIntegration
-	err := repo.db.First(&latestUpdateTraceAPI, "updated_at > ?", lastUpdateTS).
+	err := repo.GetContextDB(ctx).First(&latestUpdateTraceAPI, "updated_at > ?", lastUpdateTS).
 		Order("updated_at DESC").Error
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
@@ -205,7 +206,7 @@ func (repo *subRepos) GetLatestTraceAPIs(lastUpdateTS int64) (*integration.Adapt
   FROM trace_integrations WHERE is_deleted = false)
   SELECT apm_type, trace_api, updated_at FROM latestAPI WHERE rn = 1`
 
-	err = repo.db.Raw(sql).Scan(&latestTraceAPIs).Error
+	err = repo.GetContextDB(ctx).Raw(sql).Scan(&latestTraceAPIs).Error
 
 	if err != nil {
 		return nil, err

--- a/backend/pkg/repository/database/integration/dao_manage_cluster.go
+++ b/backend/pkg/repository/database/integration/dao_manage_cluster.go
@@ -4,43 +4,44 @@
 package integration
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
-func (repo *subRepos) CheckClusterNameExisted(clusterName string) (bool, error) {
+func (repo *subRepos) CheckClusterNameExisted(ctx core.Context, clusterName string) (bool, error) {
 	var count int64
-	err := repo.db.Model(&integration.Cluster{}).Where("name = ?", clusterName).Count(&count).Error
+	err := repo.GetContextDB(ctx).Model(&integration.Cluster{}).Where("name = ?", clusterName).Count(&count).Error
 	return count > 0, err
 }
 
-func (repo *subRepos) CreateCluster(cluster *integration.Cluster) error {
-	return repo.db.Create(&cluster).Error
+func (repo *subRepos) CreateCluster(ctx core.Context, cluster *integration.Cluster) error {
+	return repo.GetContextDB(ctx).Create(&cluster).Error
 }
 
-func (repo *subRepos) UpdateCluster(cluster *integration.Cluster) error {
-	return repo.db.Model(&integration.Cluster{}).
+func (repo *subRepos) UpdateCluster(ctx core.Context, cluster *integration.Cluster) error {
+	return repo.GetContextDB(ctx).Model(&integration.Cluster{}).
 		Where("id = ?", cluster.ID).
 		Updates(cluster).Error
 }
 
-func (repo *subRepos) DeleteCluster(cluster *integration.Cluster) error {
-	err := repo.db.Delete(&alert.AlertSource2Cluster{}, "cluster_id = ?", cluster.ID).Error
+func (repo *subRepos) DeleteCluster(ctx core.Context, cluster *integration.Cluster) error {
+	err := repo.GetContextDB(ctx).Delete(&alert.AlertSource2Cluster{}, "cluster_id = ?", cluster.ID).Error
 	if err != nil {
 		return err
 	}
 
-	return repo.db.Delete(&integration.Cluster{}, "id = ?", cluster.ID).Error
+	return repo.GetContextDB(ctx).Delete(&integration.Cluster{}, "id = ?", cluster.ID).Error
 }
 
-func (repo *subRepos) ListCluster() ([]integration.Cluster, error) {
+func (repo *subRepos) ListCluster(ctx core.Context) ([]integration.Cluster, error) {
 	var clusters []integration.Cluster
-	err := repo.db.Find(&clusters).Error
+	err := repo.GetContextDB(ctx).Find(&clusters).Error
 	return clusters, err
 }
 
-func (repo *subRepos) GetCluster(clusterID string) (integration.Cluster, error) {
+func (repo *subRepos) GetCluster(ctx core.Context, clusterID string) (integration.Cluster, error) {
 	var cluster integration.Cluster
-	err := repo.db.First(&cluster, "id = ?", clusterID).Error
+	err := repo.GetContextDB(ctx).First(&cluster, "id = ?", clusterID).Error
 	return cluster, err
 }

--- a/backend/pkg/repository/database/migrate_receiver.go
+++ b/backend/pkg/repository/database/migrate_receiver.go
@@ -4,22 +4,23 @@
 package database
 
 import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"gorm.io/gorm"
 )
 
-func (repo *daoRepo) CheckAMReceiverCount() int64 {
+func (repo *daoRepo) CheckAMReceiverCount(ctx core.Context) int64 {
 	var count int64
-	err := repo.db.Model(&amconfig.Receiver{}).Count(&count).Error
+	err := repo.GetContextDB(ctx).Model(&amconfig.Receiver{}).Count(&count).Error
 	if err != nil {
 		return -1
 	}
 	return count
 }
 
-func (repo *daoRepo) MigrateAMReceiver(receivers []amconfig.Receiver) ([]amconfig.Receiver, error) {
+func (repo *daoRepo) MigrateAMReceiver(ctx core.Context, receivers []amconfig.Receiver) ([]amconfig.Receiver, error) {
 	extraReceiver := skipAPOReceiver(receivers)
-	err := repo.db.Transaction(func(tx *gorm.DB) error {
+	err := repo.GetContextDB(ctx).Transaction(func(tx *gorm.DB) error {
 		// TODO Read Dingtalk config from Database, transform into xxx
 		if err := tx.AutoMigrate(&amconfig.Receiver{}); err != nil {
 			return err

--- a/backend/pkg/repository/database/transaction.go
+++ b/backend/pkg/repository/database/transaction.go
@@ -4,32 +4,11 @@
 package database
 
 import (
-	"context"
-	"gorm.io/gorm"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
 )
 
-func (repo *daoRepo) GetContextDB(ctx context.Context) *gorm.DB {
-	ctxDB := ctx.Value(repo.transactionCtx)
-
-	if ctxDB != nil {
-		tx, ok := ctxDB.(*gorm.DB)
-		if !ok {
-			return nil
-		}
-		return tx
-	}
-	return repo.db.WithContext(ctx)
-}
-
-func (repo *daoRepo) WithTransaction(ctx context.Context, tx *gorm.DB) context.Context {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	return context.WithValue(ctx, repo.transactionCtx, tx)
-}
-
-func (repo *daoRepo) Transaction(ctx context.Context, funcs ...func(txCtx context.Context) error) (err error) {
-	tx := repo.db.Begin()
+func (repo *daoRepo) Transaction(ctx core.Context, funcs ...func(txCtx core.Context) error) (err error) {
+	tx := repo.GetContextDB(ctx).Begin()
 	defer func() {
 		if r := recover(); r != nil {
 			tx.Rollback()

--- a/backend/pkg/repository/database/transaction_test.go
+++ b/backend/pkg/repository/database/transaction_test.go
@@ -4,13 +4,14 @@
 package database
 
 import (
-	"context"
 	"errors"
-	"github.com/CloudDetail/apo/backend/config"
-	"github.com/CloudDetail/apo/backend/pkg/logger"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"testing"
+
+	"github.com/CloudDetail/apo/backend/config"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/logger"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTransaction(t *testing.T) {
@@ -28,16 +29,16 @@ func TestTransaction(t *testing.T) {
 		return
 	}
 
-	var grantFunc = func(ctx context.Context) error {
-		return repo.GrantRoleWithUser(ctx, 239077004960, []int{2})
+	var grantFunc = func(ctx core.Context) error {
+		return repo.GrantRoleWithUser(nil, 239077004960, []int{2})
 	}
 
-	var boomFunc = func(ctx context.Context) error {
+	var boomFunc = func(ctx core.Context) error {
 		return errors.New("boom")
 	}
 
-	err = repo.Transaction(context.Background(), grantFunc, boomFunc)
-	exists, checkErr := repo.RoleGrantedToUser(239077004960, 2)
+	err = repo.Transaction(nil, grantFunc, boomFunc)
+	exists, checkErr := repo.RoleGrantedToUser(nil, 239077004960, 2)
 	if checkErr != nil {
 		t.Error(err)
 	}

--- a/backend/pkg/repository/dify/handle.go
+++ b/backend/pkg/repository/dify/handle.go
@@ -5,27 +5,21 @@ package dify
 
 import (
 	"context"
-	"time"
 
+	"github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"go.uber.org/zap"
 )
 
-type Handle func(ctx context.Context, record *model.WorkflowRecord) error
+type Handle func(ctx core.Context, record *model.WorkflowRecord) error
 
 func HandleRecords(ctx context.Context, logger *zap.Logger, records <-chan *model.WorkflowRecord, handlers ...Handle) {
 	for record := range records {
 		for _, handler := range handlers {
-			err := handleRecord(ctx, handler, record)
+			err := handler(nil, record)
 			if err != nil {
 				logger.Error("handle workflow records failed", zap.Error(err))
 			}
 		}
 	}
-}
-
-func handleRecord(ctx context.Context, handler Handle, record *model.WorkflowRecord) error {
-	ctx, cancel := context.WithTimeout(ctx, time.Minute)
-	defer cancel()
-	return handler(ctx, record)
 }

--- a/backend/pkg/router/router.go
+++ b/backend/pkg/router/router.go
@@ -118,10 +118,10 @@ func NewHTTPServer(logger *zap.Logger) (*Server, error) {
 
 	if config.Get().AlertReceiver.Enabled {
 		// migrate AMReceiver from ConfigMap to database
-		if r.pkg_db.CheckAMReceiverCount() <= 0 {
+		if r.pkg_db.CheckAMReceiverCount(nil) <= 0 {
 			receivers, total := r.k8sApi.GetAMConfigReceiver("", nil, nil, true)
 			if total > 0 {
-				migratedReceivers, err := r.pkg_db.MigrateAMReceiver(receivers)
+				migratedReceivers, err := r.pkg_db.MigrateAMReceiver(nil, receivers)
 				if err != nil {
 					logger.Fatal("failed to migrate amconfig ", zap.Error(err))
 				}

--- a/backend/pkg/services/alerts/inputs_alertmanager.go
+++ b/backend/pkg/services/alerts/inputs_alertmanager.go
@@ -4,7 +4,6 @@
 package alerts
 
 import (
-	"context"
 	"encoding/json"
 	"log"
 	"time"
@@ -76,7 +75,7 @@ func convertStatus(status string) model.Status {
 
 func (s *service) InputAlertManager(ctx core.Context, req *request.InputAlertManagerRequest) error {
 	events := transferAlertManager(req)
-	err := s.chRepo.InsertBatchAlertEvents(context.Background(), events)
+	err := s.chRepo.InsertBatchAlertEvents(ctx, events)
 	if err != nil {
 		log.Println("[AlertManager] Error inserting data: ", err)
 		return err

--- a/backend/pkg/services/alerts/service_alert_event_detail.go
+++ b/backend/pkg/services/alerts/service_alert_event_detail.go
@@ -14,7 +14,7 @@ import (
 )
 
 func (s *service) AlertDetail(ctx core.Context, req *request.GetAlertDetailRequest) (*response.GetAlertDetailResponse, error) {
-	eventDetail, err := s.chRepo.GetAlertDetail(req, s.difyRepo.GetCacheMinutes())
+	eventDetail, err := s.chRepo.GetAlertDetail(ctx, req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err
 	}
@@ -27,7 +27,7 @@ func (s *service) AlertDetail(ctx core.Context, req *request.GetAlertDetailReque
 
 	s.fillWorkflowParams(eventDetail)
 
-	releatedEvents, total, err := s.chRepo.GetRelatedAlertEvents(req, s.difyRepo.GetCacheMinutes())
+	releatedEvents, total, err := s.chRepo.GetRelatedAlertEvents(ctx, req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err
 	}
@@ -123,5 +123,5 @@ func (s *service) fillSimilarEventWorkflowParams(records []alert.AEventWithWReco
 
 func (s *service) ManualResolveLatestAlertEventByAlertID(ctx core.Context, alertID string) error {
 	// TODO valid alertID
-	return s.chRepo.ManualResolveLatestAlertEventByAlertID(alertID)
+	return s.chRepo.ManualResolveLatestAlertEventByAlertID(ctx, alertID)
 }

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -17,12 +17,12 @@ import (
 )
 
 func (s *service) AlertEventList(ctx core.Context, req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
-	events, count, err := s.chRepo.GetAlertEventWithWorkflowRecord(req, s.difyRepo.GetCacheMinutes())
+	events, count, err := s.chRepo.GetAlertEventWithWorkflowRecord(ctx, req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err
 	}
 
-	counts, err := s.chRepo.GetAlertEventCounts(req, s.difyRepo.GetCacheMinutes())
+	counts, err := s.chRepo.GetAlertEventCounts(ctx, req, s.difyRepo.GetCacheMinutes())
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/alerts/service_amconfig_receiver.go
+++ b/backend/pkg/services/alerts/service_amconfig_receiver.go
@@ -63,7 +63,7 @@ func (s *service) GetAMReceiversFromExternalAM(ctx core.Context, req *request.Ge
 	if req.AMConfigReceiverFilter != nil {
 		name = req.AMConfigReceiverFilter.Name
 	}
-	dingTalkReceivers, dingTalkCount, err := s.dbRepo.GetDingTalkReceiverByAlertName(req.AMConfigFile, name, page, pageSize)
+	dingTalkReceivers, dingTalkCount, err := s.dbRepo.GetDingTalkReceiverByAlertName(ctx, req.AMConfigFile, name, page, pageSize)
 	if err != nil {
 		return resp
 	}
@@ -104,7 +104,7 @@ func (s *service) AddAMReceiversForExternalAM(ctx core.Context, req *request.Add
 		req.AMConfigReceiver.DingTalkConfigs[i].UUID = uuid
 		req.AMConfigReceiver.DingTalkConfigs[i].AlertName = req.AMConfigReceiver.Name
 		req.AMConfigReceiver.DingTalkConfigs[i].ConfigFile = req.AMConfigFile
-		err = s.dbRepo.CreateDingTalkReceiver(req.AMConfigReceiver.DingTalkConfigs[i])
+		err = s.dbRepo.CreateDingTalkReceiver(ctx, req.AMConfigReceiver.DingTalkConfigs[i])
 		if err != nil {
 			s.k8sApi.DeleteAMConfigReceiver(req.AMConfigFile, req.AMConfigReceiver.Name)
 			return err
@@ -137,7 +137,7 @@ func (s *service) UpdateAMReceiverForExternalAM(ctx core.Context, req *request.U
 		req.AMConfigReceiver.DingTalkConfigs[i].AlertName = req.AMConfigReceiver.Name
 		req.AMConfigReceiver.DingTalkConfigs[i].ConfigFile = req.AMConfigFile
 
-		err = s.dbRepo.UpdateDingTalkReceiver(req.AMConfigReceiver.DingTalkConfigs[i], req.OldName)
+		err = s.dbRepo.UpdateDingTalkReceiver(ctx, req.AMConfigReceiver.DingTalkConfigs[i], req.OldName)
 		if err != nil {
 			// redo
 			s.k8sApi.DeleteAMConfigReceiver(req.AMConfigFile, req.AMConfigReceiver.Name)
@@ -165,7 +165,7 @@ func (s *service) DeleteAMReceiverForExternalAM(ctx core.Context, req *request.D
 	if req.Type != "dingtalk" {
 		return nil
 	}
-	return s.dbRepo.DeleteDingTalkReceiver(req.AMConfigFile, req.Name)
+	return s.dbRepo.DeleteDingTalkReceiver(ctx, req.AMConfigFile, req.Name)
 }
 
 func (s *service) addDingTalkWebhook(name string) (string, error) {

--- a/backend/pkg/services/alerts/service_forward_to_dingtalk.go
+++ b/backend/pkg/services/alerts/service_forward_to_dingtalk.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *service) ForwardToDingTalk(ctx core.Context, req *request.ForwardToDingTalkRequest, uuid string) error {
-	config, err := s.dbRepo.GetDingTalkReceiver(uuid)
+	config, err := s.dbRepo.GetDingTalkReceiver(ctx, uuid)
 	if err != nil {
 		log.Println("get dingtalk receiver err:", err)
 		return err

--- a/backend/pkg/services/alerts/service_get_metric_pql.go
+++ b/backend/pkg/services/alerts/service_get_metric_pql.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) GetMetricPQL(ctx core.Context) (*response.GetMetricPQLResponse, error) {
-	alertMetrics, err := s.dbRepo.ListQuickAlertRuleMetric(ctx.LANG())
+	alertMetrics, err := s.dbRepo.ListQuickAlertRuleMetric(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/config/service_getttl.go
+++ b/backend/pkg/services/config/service_getttl.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *service) GetTTL(ctx core.Context) (*response.GetTTLResponse, error) {
-	tables, err := s.chRepo.GetTables(model.GetAllTables())
+	tables, err := s.chRepo.GetTables(ctx, model.GetAllTables())
 	if err != nil {
 		log.Println("[GetTTL] Error getting tables: ", err)
 		return nil, err

--- a/backend/pkg/services/config/service_setttl.go
+++ b/backend/pkg/services/config/service_setttl.go
@@ -4,7 +4,6 @@
 package config
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -49,7 +48,7 @@ func prepareTTLInfo(tables []model.TablesQuery) []model.ModifyTableTTLMap {
 }
 
 func (s *service) SetTableTTL(ctx core.Context, tableNames []model.Table, day int) error {
-	tables, err := s.chRepo.GetTables(tableNames)
+	tables, err := s.chRepo.GetTables(ctx, tableNames)
 	if err != nil {
 		log.Println("[SetSingleTableTTL] Error getting tables: ", err)
 		return err
@@ -59,7 +58,7 @@ func (s *service) SetTableTTL(ctx core.Context, tableNames []model.Table, day in
 		log.Println("[SetSingleTableTTL] Error convertModifyTableTTLMap: ", err)
 		return err
 	}
-	err = s.chRepo.ModifyTableTTL(context.Background(), mapResult)
+	err = s.chRepo.ModifyTableTTL(ctx, mapResult)
 	if err != nil {
 		log.Println("[SetSingleTableTTL] Error ModifyTableTTL: ", err)
 		return err

--- a/backend/pkg/services/data/datasource_permission_test.go
+++ b/backend/pkg/services/data/datasource_permission_test.go
@@ -59,7 +59,7 @@ func TestDataSourcePermission(t *testing.T) {
 
 	namespaceList := []string{}
 
-	anonymousUser, err := s.dbRepo.GetAnonymousUser()
+	anonymousUser, err := s.dbRepo.GetAnonymousUser(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/backend/pkg/services/data/service_check_datasource_permission.go
+++ b/backend/pkg/services/data/service_check_datasource_permission.go
@@ -31,7 +31,7 @@ func (s *service) CheckDatasourcePermission(ctx core.Context, userID, groupID in
 
 	// Get user's data group
 	if groupID != 0 {
-		has, err := s.dbRepo.CheckGroupPermission(userID, groupID, "view")
+		has, err := s.dbRepo.CheckGroupPermission(ctx, userID, groupID, "view")
 		if err != nil {
 			return err
 		}
@@ -42,7 +42,7 @@ func (s *service) CheckDatasourcePermission(ctx core.Context, userID, groupID in
 		filter := model.DataGroupFilter{
 			ID: groupID,
 		}
-		groups, _, err = s.dbRepo.GetDataGroup(filter)
+		groups, _, err = s.dbRepo.GetDataGroup(ctx, filter)
 		if err != nil {
 			return err
 		}

--- a/backend/pkg/services/data/service_data_group.go
+++ b/backend/pkg/services/data/service_data_group.go
@@ -4,8 +4,6 @@
 package data
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -19,7 +17,7 @@ func (s *service) CreateDataGroup(ctx core.Context, req *request.CreateDataGroup
 	filter := model.DataGroupFilter{
 		Name: req.GroupName,
 	}
-	exists, err := s.dbRepo.DataGroupExist(filter)
+	exists, err := s.dbRepo.DataGroupExist(ctx, filter)
 	if err != nil {
 		return err
 	}
@@ -33,22 +31,22 @@ func (s *service) CreateDataGroup(ctx core.Context, req *request.CreateDataGroup
 		GroupID:     util.Generator.GenerateID(),
 	}
 
-	var createGroupFunc = func(ctx context.Context) error {
+	var createGroupFunc = func(ctx core.Context) error {
 		return s.dbRepo.CreateDataGroup(ctx, &group)
 	}
 
-	var createDSGroupFunc = func(ctx context.Context) error {
+	var createDSGroupFunc = func(ctx core.Context) error {
 		return s.dbRepo.CreateDatasourceGroup(ctx, req.DatasourceList, group.GroupID)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), createGroupFunc, createDSGroupFunc)
+	return s.dbRepo.Transaction(ctx, createGroupFunc, createDSGroupFunc)
 }
 
 func (s *service) DeleteDataGroup(ctx core.Context, req *request.DeleteDataGroupRequest) error {
 	filter := model.DataGroupFilter{
 		ID: req.GroupID,
 	}
-	exists, err := s.dbRepo.DataGroupExist(filter)
+	exists, err := s.dbRepo.DataGroupExist(ctx, filter)
 	if err != nil {
 		return err
 	}
@@ -57,22 +55,22 @@ func (s *service) DeleteDataGroup(ctx core.Context, req *request.DeleteDataGroup
 		return core.Error(code.DataGroupNotExistError, "data group does not exist")
 	}
 
-	var deleteGroupFunc = func(ctx context.Context) error {
+	var deleteGroupFunc = func(ctx core.Context) error {
 		return s.dbRepo.DeleteDataGroup(ctx, req.GroupID)
 	}
 
-	var deleteDSGroupFunc = func(ctx context.Context) error {
+	var deleteDSGroupFunc = func(ctx core.Context) error {
 		return s.dbRepo.DeleteDSGroup(ctx, req.GroupID)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), deleteDSGroupFunc, deleteGroupFunc)
+	return s.dbRepo.Transaction(ctx, deleteDSGroupFunc, deleteGroupFunc)
 }
 
 func (s *service) UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroupRequest) error {
 	idFilter := model.DataGroupFilter{
 		ID: req.GroupID,
 	}
-	groups, _, err := s.dbRepo.GetDataGroup(idFilter)
+	groups, _, err := s.dbRepo.GetDataGroup(ctx, idFilter)
 	if err != nil {
 		return err
 	}
@@ -87,7 +85,7 @@ func (s *service) UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroup
 	}
 
 	if group.GroupName != req.GroupName {
-		exists, err := s.dbRepo.DataGroupExist(nameFilter)
+		exists, err := s.dbRepo.DataGroupExist(ctx, nameFilter)
 		if err != nil {
 			return err
 		}
@@ -98,7 +96,7 @@ func (s *service) UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroup
 	}
 
 	// 1. Get data group's datasource
-	dsGroups, err := s.dbRepo.GetGroupDatasource(req.GroupID)
+	dsGroups, err := s.dbRepo.GetGroupDatasource(ctx, req.GroupID)
 	if err != nil {
 		return err
 	}
@@ -141,19 +139,19 @@ func (s *service) UpdateDataGroup(ctx core.Context, req *request.UpdateDataGroup
 		deleteData = append(deleteData, ds)
 	}
 
-	var updateNameFunc = func(ctx context.Context) error {
+	var updateNameFunc = func(ctx core.Context) error {
 		return s.dbRepo.UpdateDataGroup(ctx, req.GroupID, req.GroupName, req.Description)
 	}
 
-	var assignFunc = func(ctx context.Context) error {
+	var assignFunc = func(ctx core.Context) error {
 		return s.dbRepo.CreateDatasourceGroup(ctx, addData, req.GroupID)
 	}
 
-	var retrieveFunc = func(ctx context.Context) error {
+	var retrieveFunc = func(ctx core.Context) error {
 		return s.dbRepo.RetrieveDataFromGroup(ctx, req.GroupID, deleteData)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), updateNameFunc, assignFunc, retrieveFunc)
+	return s.dbRepo.Transaction(ctx, updateNameFunc, assignFunc, retrieveFunc)
 }
 
 func (s *service) GetDataGroup(ctx core.Context, req *request.GetDataGroupRequest) (resp response.GetDataGroupResponse, err error) {
@@ -164,7 +162,7 @@ func (s *service) GetDataGroup(ctx core.Context, req *request.GetDataGroupReques
 		DatasourceList: req.DataSourceList,
 	}
 
-	dataGroups, count, err := s.dbRepo.GetDataGroup(filter)
+	dataGroups, count, err := s.dbRepo.GetDataGroup(ctx, filter)
 	if err != nil {
 		return
 	}

--- a/backend/pkg/services/data/service_datasource.go
+++ b/backend/pkg/services/data/service_datasource.go
@@ -199,7 +199,7 @@ func (s *service) getDataGroup(ctx core.Context, groupID int64, category string)
 		ID: groupID,
 	}
 
-	dataGroups, _, err := s.dbRepo.GetDataGroup(filter)
+	dataGroups, _, err := s.dbRepo.GetDataGroup(ctx, filter)
 	if err != nil {
 		return dataGroups, err
 	}

--- a/backend/pkg/services/data/service_get_group_subs.go
+++ b/backend/pkg/services/data/service_get_group_subs.go
@@ -18,15 +18,15 @@ func (s *service) GetGroupSubs(ctx core.Context, req *request.GetGroupSubsReques
 
 	switch req.SubjectType {
 	case model.DATA_GROUP_SUB_TYP_USER:
-		resp, err = s.dbRepo.GetDataGroupUsers(req.DataGroupID)
+		resp, err = s.dbRepo.GetDataGroupUsers(ctx, req.DataGroupID)
 	case model.DATA_GROUP_SUB_TYP_TEAM:
-		resp, err = s.dbRepo.GetDataGroupTeams(req.DataGroupID)
+		resp, err = s.dbRepo.GetDataGroupTeams(ctx, req.DataGroupID)
 	case "":
-		resp, err = s.dbRepo.GetDataGroupUsers(req.DataGroupID)
+		resp, err = s.dbRepo.GetDataGroupUsers(ctx, req.DataGroupID)
 		if err != nil {
 			return nil, err
 		}
-		authTeam, err := s.dbRepo.GetDataGroupTeams(req.DataGroupID)
+		authTeam, err := s.dbRepo.GetDataGroupTeams(ctx, req.DataGroupID)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/pkg/services/data/service_get_subject_data_group.go
+++ b/backend/pkg/services/data/service_get_subject_data_group.go
@@ -13,7 +13,7 @@ import (
 
 func (s *service) GetSubjectDataGroup(ctx core.Context, req *request.GetSubjectDataGroupRequest) (response.GetSubjectDataGroupResponse, error) {
 	if req.SubjectType == model.DATA_GROUP_SUB_TYP_TEAM {
-		return s.dbRepo.GetSubjectDataGroupList(req.SubjectID, req.SubjectType, req.Category)
+		return s.dbRepo.GetSubjectDataGroupList(ctx, req.SubjectID, req.SubjectType, req.Category)
 	}
 
 	return s.getUserDataGroup(ctx, req.SubjectID, req.Category)
@@ -21,7 +21,7 @@ func (s *service) GetSubjectDataGroup(ctx core.Context, req *request.GetSubjectD
 
 // getUserDataGroup Get user's data group or default data group.
 func (s *service) getUserDataGroup(ctx core.Context, userID int64, category string) ([]database.DataGroup, error) {
-	teamIDs, err := s.dbRepo.GetUserTeams(userID)
+	teamIDs, err := s.dbRepo.GetUserTeams(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (s *service) getUserDataGroup(ctx core.Context, userID int64, category stri
 	// Get user's teams.
 	var groups []database.DataGroup
 	for _, teamID := range teamIDs {
-		gs, err := s.dbRepo.GetSubjectDataGroupList(teamID, model.DATA_GROUP_SUB_TYP_TEAM, category)
+		gs, err := s.dbRepo.GetSubjectDataGroupList(ctx, teamID, model.DATA_GROUP_SUB_TYP_TEAM, category)
 		if err != nil {
 			return nil, err
 		}
@@ -49,7 +49,7 @@ func (s *service) getUserDataGroup(ctx core.Context, userID int64, category stri
 		groups[i].Source = model.DATA_GROUP_SUB_TYP_TEAM
 	}
 
-	gs, err := s.dbRepo.GetSubjectDataGroupList(userID, model.DATA_GROUP_SUB_TYP_USER, category)
+	gs, err := s.dbRepo.GetSubjectDataGroupList(ctx, userID, model.DATA_GROUP_SUB_TYP_USER, category)
 	for i := range gs {
 		gs[i].Source = model.DATA_GROUP_SUB_TYP_USER
 	}

--- a/backend/pkg/services/integration/alert/enrich/tag_enricher.go
+++ b/backend/pkg/services/integration/alert/enrich/tag_enricher.go
@@ -69,7 +69,7 @@ func NewTagEnricher(
 		}
 	}
 
-	targetTags, err := dbRepo.ListAlertTargetTags("")
+	targetTags, err := dbRepo.ListAlertTargetTags(nil)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +119,7 @@ func (e *TagEnricher) Enrich(alertEvent *alert.AlertEvent) {
 	case "tagMapping":
 		alertEvent.EnrichTags[e.targetTag] = value
 	case "schemaMapping":
-		targets, err := e.DBRepo.SearchSchemaTarget(e.Schema, e.SchemaSource, value, e.SchemaTarget)
+		targets, err := e.DBRepo.SearchSchemaTarget(nil, e.Schema, e.SchemaSource, value, e.SchemaTarget)
 		if err != nil {
 			return
 		}

--- a/backend/pkg/services/integration/alert/service.go
+++ b/backend/pkg/services/integration/alert/service.go
@@ -76,7 +76,7 @@ func New(
 		ckRepo:   chRepo,
 	}
 
-	_, enrichMaps, err := service.dbRepo.LoadAlertEnrichRule()
+	_, enrichMaps, err := service.dbRepo.LoadAlertEnrichRule(nil)
 	if err != nil {
 		log.Printf("failed to init alertinput module,err: %v", err)
 		return service

--- a/backend/pkg/services/integration/alert/service_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_alert_source.go
@@ -16,7 +16,7 @@ import (
 
 func (s *service) GetAlertSource(ctx core.Context, source *alert.SourceFrom) (*alert.AlertSource, error) {
 	// TODO support search by sourceName
-	alertSource, err := s.dbRepo.GetAlertSource(source.SourceID)
+	alertSource, err := s.dbRepo.GetAlertSource(ctx, source.SourceID)
 
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, alert.ErrAlertSourceNotExist{}
@@ -39,16 +39,16 @@ func (s *service) UpdateAlertSource(ctx core.Context, source *alert.AlertSource)
 		return nil, alert.ErrAlertSourceNotExist{}
 	}
 
-	err := s.dbRepo.UpdateAlertSource(source)
+	err := s.dbRepo.UpdateAlertSource(ctx, source)
 	return source, err
 }
 
 func (s *service) ListAlertSource(ctx core.Context) ([]alert.AlertSource, error) {
-	return s.dbRepo.ListAlertSource()
+	return s.dbRepo.ListAlertSource(ctx)
 }
 
 func (s *service) DeleteAlertSource(ctx core.Context, source alert.SourceFrom) (*alert.AlertSource, error) {
-	deletedSource, err := s.dbRepo.DeleteAlertSource(source)
+	deletedSource, err := s.dbRepo.DeleteAlertSource(ctx, source)
 	if err != nil {
 		return nil, err
 	}
@@ -56,11 +56,11 @@ func (s *service) DeleteAlertSource(ctx core.Context, source alert.SourceFrom) (
 	s.dispatcher.DeleteAlertSource(ctx, deletedSource)
 
 	var storeError error
-	err = s.dbRepo.DeleteAlertEnrichRuleBySourceId(source.SourceID)
+	err = s.dbRepo.DeleteAlertEnrichRuleBySourceId(ctx, source.SourceID)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichConditionsBySourceId(source.SourceID)
+	err = s.dbRepo.DeleteAlertEnrichConditionsBySourceId(ctx, source.SourceID)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichSchemaTargetBySourceId(source.SourceID)
+	err = s.dbRepo.DeleteAlertEnrichSchemaTargetBySourceId(ctx, source.SourceID)
 	storeError = multierr.Append(storeError, err)
 
 	return deletedSource, storeError

--- a/backend/pkg/services/integration/alert/service_clusters.go
+++ b/backend/pkg/services/integration/alert/service_clusters.go
@@ -11,17 +11,17 @@ import (
 
 func (s *service) CreateCluster(ctx core.Context, cluster *input.Cluster) error {
 	cluster.ID = uuid.NewString()
-	return s.dbRepo.CreateCluster(cluster)
+	return s.dbRepo.CreateCluster(ctx, cluster)
 }
 
 func (s *service) ListCluster(ctx core.Context) ([]input.Cluster, error) {
-	return s.dbRepo.ListCluster()
+	return s.dbRepo.ListCluster(ctx)
 }
 
 func (s *service) UpdateCluster(ctx core.Context, cluster *input.Cluster) error {
-	return s.dbRepo.UpdateCluster(cluster)
+	return s.dbRepo.UpdateCluster(ctx, cluster)
 }
 
 func (s *service) DeleteCluster(ctx core.Context, cluster *input.Cluster) error {
-	return s.dbRepo.DeleteCluster(cluster)
+	return s.dbRepo.DeleteCluster(ctx, cluster)
 }

--- a/backend/pkg/services/integration/alert/service_create_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_create_alert_source.go
@@ -30,7 +30,7 @@ func (s *service) CreateAlertSource(ctx core.Context, source *alertin.AlertSourc
 		}
 	}
 
-	err := s.dbRepo.CreateAlertSource(source)
+	err := s.dbRepo.CreateAlertSource(ctx, source)
 	if err != nil {
 		return nil, err
 	}
@@ -76,11 +76,11 @@ func (s *service) initDefaultAlertSource(source *alertin.SourceFrom) (*enrich.Al
 	}
 
 	var storeError error
-	err = s.dbRepo.AddAlertEnrichRule(newR)
+	err = s.dbRepo.AddAlertEnrichRule(nil, newR)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichConditions(newC)
+	err = s.dbRepo.AddAlertEnrichConditions(nil, newC)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichSchemaTarget(newS)
+	err = s.dbRepo.AddAlertEnrichSchemaTarget(nil, newS)
 	storeError = multierr.Append(storeError, err)
 
 	s.dispatcher.AddAlertSource(*source, enricher)

--- a/backend/pkg/services/integration/alert/service_default_alert_source.go
+++ b/backend/pkg/services/integration/alert/service_default_alert_source.go
@@ -25,11 +25,11 @@ func (s *service) ClearDefaultAlertEnrichRule(ctx core.Context, sourceType strin
 	sourceUUID := uuid.NewMD5(uuidZero, []byte(sourceType)).String()
 
 	var storeError error
-	err := s.dbRepo.DeleteAlertEnrichRuleBySourceId(sourceUUID)
+	err := s.dbRepo.DeleteAlertEnrichRuleBySourceId(ctx, sourceUUID)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichConditionsBySourceId(sourceUUID)
+	err = s.dbRepo.DeleteAlertEnrichConditionsBySourceId(ctx, sourceUUID)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichSchemaTargetBySourceId(sourceUUID)
+	err = s.dbRepo.DeleteAlertEnrichSchemaTargetBySourceId(ctx, sourceUUID)
 	storeError = multierr.Append(storeError, err)
 	return find, storeError
 }
@@ -67,15 +67,15 @@ func (s *service) SetDefaultAlertEnrichRule(ctx core.Context, sourceType string,
 
 	var storeError error
 	if !existed {
-		err := s.dbRepo.CreateAlertSource(&alert.AlertSource{SourceFrom: *sourceFrom})
+		err := s.dbRepo.CreateAlertSource(ctx, &alert.AlertSource{SourceFrom: *sourceFrom})
 		storeError = multierr.Append(storeError, err)
 	}
 
-	err = s.dbRepo.AddAlertEnrichRule(newR)
+	err = s.dbRepo.AddAlertEnrichRule(ctx, newR)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichConditions(newC)
+	err = s.dbRepo.AddAlertEnrichConditions(ctx, newC)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichSchemaTarget(newS)
+	err = s.dbRepo.AddAlertEnrichSchemaTarget(ctx, newS)
 	storeError = multierr.Append(storeError, err)
 	return storeError
 }

--- a/backend/pkg/services/integration/alert/service_get_alert_enrich_rule.go
+++ b/backend/pkg/services/integration/alert/service_get_alert_enrich_rule.go
@@ -11,17 +11,17 @@ import (
 func (s *service) GetAlertEnrichRule(ctx core.Context,
 	sourceID string,
 ) ([]alert.AlertEnrichRuleVO, error) {
-	enrichRules, err := s.dbRepo.GetAlertEnrichRule(sourceID)
+	enrichRules, err := s.dbRepo.GetAlertEnrichRule(ctx, sourceID)
 	if err != nil {
 		return nil, err
 	}
 
-	conditions, err := s.dbRepo.GetAlertEnrichConditions(sourceID)
+	conditions, err := s.dbRepo.GetAlertEnrichConditions(ctx, sourceID)
 	if err != nil {
 		return nil, err
 	}
 
-	schemaTargets, err := s.dbRepo.GetAlertEnrichSchemaTarget(sourceID)
+	schemaTargets, err := s.dbRepo.GetAlertEnrichSchemaTarget(ctx, sourceID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/integration/alert/service_get_alert_enrich_rule_tags.go
+++ b/backend/pkg/services/integration/alert/service_get_alert_enrich_rule_tags.go
@@ -9,5 +9,5 @@ import (
 )
 
 func (s *service) GetAlertEnrichRuleTags(ctx core.Context) ([]alert.TargetTag, error) {
-	return s.dbRepo.ListAlertTargetTags(ctx.LANG())
+	return s.dbRepo.ListAlertTargetTags(ctx)
 }

--- a/backend/pkg/services/integration/alert/service_process_alert_events.go
+++ b/backend/pkg/services/integration/alert/service_process_alert_events.go
@@ -4,7 +4,6 @@
 package alert
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log"
@@ -35,5 +34,5 @@ func (s *service) ProcessAlertEvents(ctx core.Context, source alert.SourceFrom, 
 	}
 
 	s.difyRepo.SubmitAlertEvents(events)
-	return s.ckRepo.InsertAlertEvent(context.Background(), events, source)
+	return s.ckRepo.InsertAlertEvent(ctx, events, source)
 }

--- a/backend/pkg/services/integration/alert/service_schema.go
+++ b/backend/pkg/services/integration/alert/service_schema.go
@@ -10,26 +10,26 @@ import (
 )
 
 func (s *service) CreateSchema(ctx core.Context, req *alert.CreateSchemaRequest) error {
-	err := s.dbRepo.CreateSchema(req.Schema, req.Columns)
+	err := s.dbRepo.CreateSchema(ctx, req.Schema, req.Columns)
 	if err != nil {
 		return err
 	}
 	if len(req.FullRows) > 0 {
-		return s.dbRepo.InsertSchemaData(req.Schema, req.Columns, req.FullRows)
+		return s.dbRepo.InsertSchemaData(ctx, req.Schema, req.Columns, req.FullRows)
 	}
 	return nil
 }
 
 func (s *service) ListSchema(ctx core.Context) ([]string, error) {
-	return s.dbRepo.ListSchema()
+	return s.dbRepo.ListSchema(ctx)
 }
 
 func (s *service) GetSchemaData(ctx core.Context, schema string) ([]string, map[int64][]string, error) {
-	return s.dbRepo.GetSchemaData(schema)
+	return s.dbRepo.GetSchemaData(ctx, schema)
 }
 
 func (s *service) CheckSchemaIsUsed(ctx core.Context, schema string) ([]string, error) {
-	return s.dbRepo.CheckSchemaIsUsed(schema)
+	return s.dbRepo.CheckSchemaIsUsed(ctx, schema)
 }
 
 func (s *service) DeleteSchema(ctx core.Context, schema string) error {
@@ -39,24 +39,24 @@ func (s *service) DeleteSchema(ctx core.Context, schema string) error {
 		return true
 	})
 
-	return s.dbRepo.DeleteSchema(schema)
+	return s.dbRepo.DeleteSchema(ctx, schema)
 }
 
 func (s *service) ListSchemaColumns(ctx core.Context, schema string) ([]string, error) {
-	return s.dbRepo.ListSchemaColumns(schema)
+	return s.dbRepo.ListSchemaColumns(ctx, schema)
 }
 
 func (s *service) UpdateSchemaData(ctx core.Context, req *alert.UpdateSchemaDataRequest) error {
 	if req.ClearAll {
-		err := s.dbRepo.ClearSchemaData(req.Schema)
+		err := s.dbRepo.ClearSchemaData(ctx, req.Schema)
 		if err != nil {
 			return err
 		}
 	}
 	if len(req.NewRows) > 0 {
-		return s.dbRepo.InsertSchemaData(req.Schema, req.Columns, req.NewRows)
+		return s.dbRepo.InsertSchemaData(ctx, req.Schema, req.Columns, req.NewRows)
 	} else if len(req.UpdateRows) > 0 {
-		return s.dbRepo.UpdateSchemaData(req.Schema, req.Columns, req.UpdateRows)
+		return s.dbRepo.UpdateSchemaData(ctx, req.Schema, req.Columns, req.UpdateRows)
 	}
 
 	return nil

--- a/backend/pkg/services/integration/alert/service_update_alert_enrich_rule.go
+++ b/backend/pkg/services/integration/alert/service_update_alert_enrich_rule.go
@@ -108,26 +108,26 @@ func (s *service) UpdateAlertEnrichRule(ctx core.Context, req *alert.AlertEnrich
 		}
 	}
 
-	err = s.dbRepo.DeleteAlertEnrichRule(deletedRules)
+	err = s.dbRepo.DeleteAlertEnrichRule(ctx, deletedRules)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichConditions(deletedRules)
+	err = s.dbRepo.DeleteAlertEnrichConditions(ctx, deletedRules)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.DeleteAlertEnrichSchemaTarget(deletedRules)
-	storeError = multierr.Append(storeError, err)
-
-	err = s.dbRepo.DeleteAlertEnrichConditions(conditionsModifiedRules)
-	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichConditions(newConditions)
+	err = s.dbRepo.DeleteAlertEnrichSchemaTarget(ctx, deletedRules)
 	storeError = multierr.Append(storeError, err)
 
-	err = s.dbRepo.DeleteAlertEnrichSchemaTarget(schemaTargetModifiedRules)
+	err = s.dbRepo.DeleteAlertEnrichConditions(ctx, conditionsModifiedRules)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichSchemaTarget(newSchemaTargets)
+	err = s.dbRepo.AddAlertEnrichConditions(ctx, newConditions)
 	storeError = multierr.Append(storeError, err)
 
-	err = s.dbRepo.DeleteAlertEnrichRule(modifiedAlertEnrichRules)
+	err = s.dbRepo.DeleteAlertEnrichSchemaTarget(ctx, schemaTargetModifiedRules)
 	storeError = multierr.Append(storeError, err)
-	err = s.dbRepo.AddAlertEnrichRule(newAlertEnrichRules)
+	err = s.dbRepo.AddAlertEnrichSchemaTarget(ctx, newSchemaTargets)
+	storeError = multierr.Append(storeError, err)
+
+	err = s.dbRepo.DeleteAlertEnrichRule(ctx, modifiedAlertEnrichRules)
+	storeError = multierr.Append(storeError, err)
+	err = s.dbRepo.AddAlertEnrichRule(ctx, newAlertEnrichRules)
 	storeError = multierr.Append(storeError, err)
 
 	return storeError

--- a/backend/pkg/services/integration/service_clusters.go
+++ b/backend/pkg/services/integration/service_clusters.go
@@ -9,14 +9,14 @@ import (
 )
 
 func (s *service) ListCluster(ctx core.Context) ([]integration.Cluster, error) {
-	return s.dbRepo.ListCluster()
+	return s.dbRepo.ListCluster(ctx)
 }
 
 func (s *service) DeleteCluster(ctx core.Context, cluster *integration.Cluster) error {
-	err := s.dbRepo.DeleteCluster(cluster)
+	err := s.dbRepo.DeleteCluster(ctx, cluster)
 	if err != nil {
 		return err
 	}
 
-	return s.dbRepo.DeleteIntegrationConfig(cluster.ID)
+	return s.dbRepo.DeleteIntegrationConfig(ctx, cluster.ID)
 }

--- a/backend/pkg/services/integration/service_create_cluster.go
+++ b/backend/pkg/services/integration/service_create_cluster.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *service) CreateCluster(ctx core.Context, cluster *integration.ClusterIntegration) (*integration.Cluster, error) {
-	isExist, err := s.dbRepo.CheckClusterNameExisted(cluster.Name)
+	isExist, err := s.dbRepo.CheckClusterNameExisted(ctx, cluster.Name)
 	if err != nil {
 		return nil, err
 	}
@@ -23,7 +23,7 @@ func (s *service) CreateCluster(ctx core.Context, cluster *integration.ClusterIn
 
 	cluster.ID = uuid.NewString()
 	cluster.APOCollector.RemoveHttpPrefix()
-	err = s.dbRepo.CreateCluster(&cluster.Cluster)
+	err = s.dbRepo.CreateCluster(ctx, &cluster.Cluster)
 	if err != nil {
 		return nil, err
 	}
@@ -31,7 +31,7 @@ func (s *service) CreateCluster(ctx core.Context, cluster *integration.ClusterIn
 	// HACK 当前强制指定VM和CK配置
 	forceSetupMetricLogAPI(cluster)
 
-	err = s.dbRepo.SaveIntegrationConfig(*cluster)
+	err = s.dbRepo.SaveIntegrationConfig(ctx, *cluster)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/integration/service_get_cluster_integration.go
+++ b/backend/pkg/services/integration/service_get_cluster_integration.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) GetClusterIntegration(ctx core.Context, clusterID string) (*integration.ClusterIntegrationVO, error) {
-	config, err := s.dbRepo.GetIntegrationConfig(clusterID)
+	config, err := s.dbRepo.GetIntegrationConfig(ctx, clusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/integration/service_integration_config.go
+++ b/backend/pkg/services/integration/service_integration_config.go
@@ -79,7 +79,7 @@ func defaultValue(v any, def any) string {
 }
 
 func (s *service) GetIntegrationInstallConfigFile(ctx core.Context, req *integration.GetCInstallRequest) (*integration.GetCInstallConfigResponse, error) {
-	clusterConfig, err := s.dbRepo.GetIntegrationConfig(req.ClusterID)
+	clusterConfig, err := s.dbRepo.GetIntegrationConfig(ctx, req.ClusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/integration/service_integration_doc.go
+++ b/backend/pkg/services/integration/service_integration_doc.go
@@ -13,12 +13,12 @@ import (
 
 // Deprecated
 func (s *service) GetIntegrationInstallDoc(ctx core.Context, req *integration.GetCInstallRequest) ([]byte, error) {
-	cluster, err := s.dbRepo.GetCluster(req.ClusterID)
+	cluster, err := s.dbRepo.GetCluster(ctx, req.ClusterID)
 	if err != nil {
 		return nil, err
 	}
 
-	clusterConfig, err := s.dbRepo.GetIntegrationConfig(req.ClusterID)
+	clusterConfig, err := s.dbRepo.GetIntegrationConfig(ctx, req.ClusterID)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/integration/service_static_integration.go
+++ b/backend/pkg/services/integration/service_static_integration.go
@@ -53,7 +53,7 @@ func (s *service) GetStaticIntegration(ctx core.Context) map[string]any {
 	ds.MetricAPI.ReplaceSecret()
 	resp["datasource"] = ds
 
-	if latestTraceAPI, err := s.dbRepo.GetLatestTraceAPIs(-1); err == nil {
+	if latestTraceAPI, err := s.dbRepo.GetLatestTraceAPIs(ctx, -1); err == nil {
 		if latestTraceAPI == nil {
 			resp["traceAPI"] = integration.TraceAPI{}
 		} else {

--- a/backend/pkg/services/integration/service_trigger_adapter_update.go
+++ b/backend/pkg/services/integration/service_trigger_adapter_update.go
@@ -31,7 +31,7 @@ const adapterUpdateAPI = "/trace/api/update"
 var adapterServiceAddress = "http://apo-apm-adapter-svc:8079"
 
 func (s *service) TriggerAdapterUpdate(ctx core.Context, req *integration.TriggerAdapterUpdateRequest) {
-	traceAPI, err := s.dbRepo.GetLatestTraceAPIs(req.LastUpdateTS)
+	traceAPI, err := s.dbRepo.GetLatestTraceAPIs(ctx, req.LastUpdateTS)
 	if err != nil {
 		log.Println("get latest trace api error: ", err)
 	}

--- a/backend/pkg/services/integration/service_update_cluster_integration.go
+++ b/backend/pkg/services/integration/service_update_cluster_integration.go
@@ -35,10 +35,10 @@ func (s *service) UpdateClusterIntegration(ctx core.Context, cluster *integratio
 	}
 
 	cluster.APOCollector.RemoveHttpPrefix()
-	err := s.dbRepo.UpdateCluster(&cluster.Cluster)
+	err := s.dbRepo.UpdateCluster(ctx, &cluster.Cluster)
 	if err != nil {
 		return err
 	}
 
-	return s.dbRepo.SaveIntegrationConfig(*cluster)
+	return s.dbRepo.SaveIntegrationConfig(ctx, *cluster)
 }

--- a/backend/pkg/services/log/service_add_log_parse_rule.go
+++ b/backend/pkg/services/log/service_add_log_parse_rule.go
@@ -69,7 +69,7 @@ func (s *service) AddLogParseRule(ctx core.Context, req *request.AddLogParseRequ
 	logReq.Buffer = req.LogTable.Buffer
 	logReq.IsStructured = req.IsStructured
 	logReq.FillerValue()
-	_, err := s.chRepo.CreateLogTable(logReq)
+	_, err := s.chRepo.CreateLogTable(ctx, logReq)
 	if err != nil {
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (s *service) AddLogParseRule(ctx core.Context, req *request.AddLogParseRequ
 		ParseRule:    req.ParseRule,
 	}
 
-	err = s.dbRepo.OperateLogTableInfo(&log, database.INSERT)
+	err = s.dbRepo.OperateLogTableInfo(ctx, &log, database.INSERT)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_add_other_table.go
+++ b/backend/pkg/services/log/service_add_other_table.go
@@ -20,12 +20,12 @@ func (s *service) AddOtherTable(ctx core.Context, req *request.AddOtherTableRequ
 		Table:     req.Table,
 		TimeField: req.TimeField,
 	}
-	err := s.dbRepo.OperatorOtherLogTable(model, database.QUERY)
+	err := s.dbRepo.OperatorOtherLogTable(ctx, model, database.QUERY)
 	if err == nil {
 		res.Err = "table already exists"
 		return res, nil
 	} else {
-		err = s.dbRepo.OperatorOtherLogTable(model, database.INSERT)
+		err = s.dbRepo.OperatorOtherLogTable(ctx, model, database.INSERT)
 	}
 	if err != nil {
 		res.Err = err.Error()

--- a/backend/pkg/services/log/service_delete_log_parse_rule.go
+++ b/backend/pkg/services/log/service_delete_log_parse_rule.go
@@ -44,7 +44,7 @@ func (s *service) DeleteLogParseRule(ctx core.Context, req *request.DeleteLogPar
 	if err != nil {
 		return nil, err
 	}
-	_, err = s.chRepo.DropLogTable(logReq)
+	_, err = s.chRepo.DropLogTable(ctx, logReq)
 	if err != nil {
 		return nil, err
 	}
@@ -56,7 +56,7 @@ func (s *service) DeleteLogParseRule(ctx core.Context, req *request.DeleteLogPar
 		DataBase:  logReq.DataBase,
 		Cluster:   logReq.Cluster,
 	}
-	err = s.dbRepo.OperateLogTableInfo(&log, database.DELETE)
+	err = s.dbRepo.OperateLogTableInfo(ctx, &log, database.DELETE)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_delete_other_table.go
+++ b/backend/pkg/services/log/service_delete_other_table.go
@@ -17,7 +17,7 @@ func (s *service) DeleteOtherTable(ctx core.Context, req *request.DeleteOtherTab
 		Instance: req.Instance,
 		Table:    req.TableName,
 	}
-	err := s.dbRepo.OperatorOtherLogTable(model, database.DELETE)
+	err := s.dbRepo.OperatorOtherLogTable(ctx, model, database.DELETE)
 	if err != nil {
 		res.Err = err.Error()
 	}

--- a/backend/pkg/services/log/service_get_fault_log_contents.go
+++ b/backend/pkg/services/log/service_get_fault_log_contents.go
@@ -11,7 +11,7 @@ import (
 
 // GetFaultLogContent implements Service.
 func (s *service) GetFaultLogContent(ctx core.Context, req *request.GetFaultLogContentRequest) (*response.GetFaultLogContentResponse, error) {
-	logContest, sources, err := s.chRepo.QueryApplicationLogs(req)
+	logContest, sources, err := s.chRepo.QueryApplicationLogs(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_get_fault_log_page_list.go
+++ b/backend/pkg/services/log/service_get_fault_log_page_list.go
@@ -28,7 +28,7 @@ func (s *service) GetFaultLogPageList(ctx core.Context, req *request.GetFaultLog
 		PageSize:       req.PageSize,
 		Pod:            req.Pod,
 	}
-	list, total, err := s.chRepo.GetFaultLogPageList(query)
+	list, total, err := s.chRepo.GetFaultLogPageList(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_get_log_chart.go
+++ b/backend/pkg/services/log/service_get_log_chart.go
@@ -16,7 +16,7 @@ const SecondToMirco = 1000000
 
 func (s *service) getChart(ctx core.Context, req *request.LogQueryRequest) (*response.LogChartResponse, error) {
 	res := &response.LogChartResponse{}
-	rows, interval, err := s.chRepo.GetLogChart(req)
+	rows, interval, err := s.chRepo.GetLogChart(ctx, req)
 	if err != nil {
 		res.Err = err.Error()
 		return res, nil

--- a/backend/pkg/services/log/service_get_log_parse_rule.go
+++ b/backend/pkg/services/log/service_get_log_parse_rule.go
@@ -48,7 +48,7 @@ func (s *service) GetLogParseRule(ctx core.Context, req *request.QueryLogParseRe
 		DataBase: req.DataBase,
 		Table:    req.TableName,
 	}
-	err := s.dbRepo.OperateLogTableInfo(model, database.QUERY)
+	err := s.dbRepo.OperateLogTableInfo(ctx, model, database.QUERY)
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return &response.LogParseResponse{
 			ParseName: defaultParseName,

--- a/backend/pkg/services/log/service_get_log_table_info.go
+++ b/backend/pkg/services/log/service_get_log_table_info.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *service) GetLogTableInfo(ctx core.Context, req *request.LogTableInfoRequest) (*response.LogTableInfoResponse, error) {
-	rows, err := s.dbRepo.GetAllLogTable()
+	rows, err := s.dbRepo.GetAllLogTable(ctx)
 	res := &response.LogTableInfoResponse{}
 	if err != nil {
 		return nil, err
@@ -25,7 +25,7 @@ func (s *service) GetLogTableInfo(ctx core.Context, req *request.LogTableInfoReq
 		})
 	}
 
-	others, err := s.dbRepo.GetAllOtherLogTable()
+	others, err := s.dbRepo.GetAllOtherLogTable(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_log_index.go
+++ b/backend/pkg/services/log/service_log_index.go
@@ -13,7 +13,7 @@ import (
 
 func (s *service) GetLogIndex(ctx core.Context, req *request.LogIndexRequest) (*response.LogIndexResponse, error) {
 	res := &response.LogIndexResponse{}
-	list, sum, err := s.chRepo.GetLogIndex(req)
+	list, sum, err := s.chRepo.GetLogIndex(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_log_table.go
+++ b/backend/pkg/services/log/service_log_table.go
@@ -29,7 +29,7 @@ var defaultRouteRuleMap = map[string]string{
 }
 
 func (s *service) InitParseLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error) {
-	sqls, err := s.chRepo.CreateLogTable(req)
+	sqls, err := s.chRepo.CreateLogTable(ctx, req)
 	res := &response.LogTableResponse{Sqls: sqls}
 	if err != nil {
 		res.Err = err.Error()
@@ -51,9 +51,9 @@ func (s *service) InitParseLogTable(ctx core.Context, req *request.LogTableReque
 		ParseInfo: defaultParseInfo,
 	}
 	// does not exist to insert logtableinfo
-	err = s.dbRepo.OperateLogTableInfo(logtable, database.QUERY)
+	err = s.dbRepo.OperateLogTableInfo(ctx, logtable, database.QUERY)
 	if err != nil {
-		err = s.dbRepo.OperateLogTableInfo(logtable, database.INSERT)
+		err = s.dbRepo.OperateLogTableInfo(ctx, logtable, database.INSERT)
 		if err != nil {
 			res.Err = err.Error()
 			return res, nil
@@ -65,7 +65,7 @@ func (s *service) InitParseLogTable(ctx core.Context, req *request.LogTableReque
 
 func (s *service) DropLogTable(ctx core.Context, req *request.LogTableRequest) (*response.LogTableResponse, error) {
 
-	sqls, err := s.chRepo.DropLogTable(req)
+	sqls, err := s.chRepo.DropLogTable(ctx, req)
 	res := &response.LogTableResponse{Sqls: sqls}
 	if err != nil {
 		res.Err = err.Error()
@@ -76,7 +76,7 @@ func (s *service) DropLogTable(ctx core.Context, req *request.LogTableRequest) (
 		DataBase: req.DataBase,
 		Table:    req.TableName,
 	}
-	err = s.dbRepo.OperateLogTableInfo(logtable, database.DELETE)
+	err = s.dbRepo.OperateLogTableInfo(ctx, logtable, database.DELETE)
 	if err != nil {
 		res.Err = err.Error()
 	}
@@ -90,7 +90,7 @@ func (s *service) UpdateLogTable(ctx core.Context, req *request.LogTableRequest)
 		DataBase: req.DataBase,
 		Table:    req.TableName,
 	}
-	err := s.dbRepo.OperateLogTableInfo(logtable, database.QUERY)
+	err := s.dbRepo.OperateLogTableInfo(ctx, logtable, database.QUERY)
 	if err != nil {
 		return nil, err
 	}
@@ -100,7 +100,7 @@ func (s *service) UpdateLogTable(ctx core.Context, req *request.LogTableRequest)
 		return nil, err
 	}
 
-	sqls, err := s.chRepo.UpdateLogTable(req, oldFields)
+	sqls, err := s.chRepo.UpdateLogTable(ctx, req, oldFields)
 	res.Sqls = sqls
 	if err != nil {
 		return nil, err

--- a/backend/pkg/services/log/service_other_log.go
+++ b/backend/pkg/services/log/service_other_log.go
@@ -11,7 +11,7 @@ import (
 
 func (s *service) OtherTable(ctx core.Context, req *request.OtherTableRequest) (*response.OtherTableResponse, error) {
 	res := &response.OtherTableResponse{}
-	rows, err := s.chRepo.OtherLogTable()
+	rows, err := s.chRepo.OtherLogTable(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/log/service_other_log_info.go
+++ b/backend/pkg/services/log/service_other_log_info.go
@@ -11,7 +11,7 @@ import (
 
 func (s *service) OtherTableInfo(ctx core.Context, req *request.OtherTableInfoRequest) (*response.OtherTableInfoResponse, error) {
 	res := &response.OtherTableInfoResponse{}
-	rows, err := s.chRepo.OtherLogTableInfo(req)
+	rows, err := s.chRepo.OtherLogTableInfo(ctx, req)
 	if err != nil {
 		res.Err = err.Error()
 		return res, nil

--- a/backend/pkg/services/log/service_query_log.go
+++ b/backend/pkg/services/log/service_query_log.go
@@ -31,7 +31,7 @@ func (s *service) QueryLog(ctx core.Context, req *request.LogQueryRequest) (*res
 	}
 
 	req.PageNum = offset
-	logs, sql, err := s.chRepo.QueryAllLogs(req)
+	logs, sql, err := s.chRepo.QueryAllLogs(ctx, req)
 	res := &response.LogQueryResponse{Query: sql}
 	if err != nil {
 		res.Err = err.Error()
@@ -39,7 +39,7 @@ func (s *service) QueryLog(ctx core.Context, req *request.LogQueryRequest) (*res
 	}
 
 	// query column name and type
-	rows, err := s.chRepo.OtherLogTableInfo(&request.OtherTableInfoRequest{
+	rows, err := s.chRepo.OtherLogTableInfo(ctx, &request.OtherTableInfoRequest{
 		DataBase:  req.DataBase,
 		TableName: req.TableName,
 	})
@@ -63,7 +63,7 @@ func (s *service) QueryLog(ctx core.Context, req *request.LogQueryRequest) (*res
 			Table:    req.TableName,
 		}
 		// query log field json
-		s.dbRepo.OperateLogTableInfo(model, database.QUERY)
+		s.dbRepo.OperateLogTableInfo(ctx, model, database.QUERY)
 		var fields []request.Field
 		_ = json.Unmarshal([]byte(model.Fields), &fields)
 

--- a/backend/pkg/services/log/service_query_log_context.go
+++ b/backend/pkg/services/log/service_query_log_context.go
@@ -63,7 +63,7 @@ func (s *service) QueryLogContext(ctx core.Context, req *request.LogQueryContext
 		Table:    req.TableName,
 	}
 	// query log field json
-	s.dbRepo.OperateLogTableInfo(model, database.QUERY)
+	s.dbRepo.OperateLogTableInfo(ctx, model, database.QUERY)
 	var fields []request.Field
 	_ = json.Unmarshal([]byte(model.Fields), &fields)
 
@@ -71,7 +71,7 @@ func (s *service) QueryLogContext(ctx core.Context, req *request.LogQueryContext
 		logFields[field.Name] = struct{}{}
 	}
 
-	front, end, _ := s.chRepo.QueryLogContext(req)
+	front, end, _ := s.chRepo.QueryLogContext(ctx, req)
 
 	frontItem, err := log2item(front, logFields)
 	if err != nil {

--- a/backend/pkg/services/log/service_update_log_parse_rule.go
+++ b/backend/pkg/services/log/service_update_log_parse_rule.go
@@ -99,7 +99,7 @@ func (s *service) UpdateLogParseRule(ctx core.Context, req *request.UpdateLogPar
 		ParseRule:    req.ParseRule,
 	}
 
-	err = s.dbRepo.UpdateLogParseRule(&log)
+	err = s.dbRepo.UpdateLogParseRule(ctx, &log)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/network/service_get_segments_network.go
+++ b/backend/pkg/services/network/service_get_segments_network.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *service) GetSpanSegmentsMetrics(ctx core.Context, req *request.SpanSegmentMetricsRequest) (response.SpanSegmentMetricsResponse, error) {
-	netSegments, err := s.chRepo.GetNetworkSpanSegments(req.TraceId, req.SpanId)
+	netSegments, err := s.chRepo.GetNetworkSpanSegments(ctx, req.TraceId, req.SpanId)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/permission/service_check_api_permission.go
+++ b/backend/pkg/services/permission/service_check_api_permission.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *service) CheckApiPermission(ctx core.Context, userID int64, method string, path string) (ok bool, err error) {
-	exists, err := s.dbRepo.UserExists(userID)
+	exists, err := s.dbRepo.UserExists(ctx, userID)
 	if err != nil {
 		return false, err
 	}
@@ -23,7 +23,7 @@ func (s *service) CheckApiPermission(ctx core.Context, userID int64, method stri
 	if err != nil {
 		return false, err
 	}
-	api, err := s.dbRepo.GetAPIByPath(path, method)
+	api, err := s.dbRepo.GetAPIByPath(ctx, path, method)
 	if err != nil {
 		return false, err
 	}
@@ -32,7 +32,7 @@ func (s *service) CheckApiPermission(ctx core.Context, userID int64, method stri
 		return false, core.Error(code.APINotExist, "api does not exist")
 	}
 
-	fm, err := s.dbRepo.GetFeatureMappingByMapped(api.ID, model.MAPPED_TYP_API)
+	fm, err := s.dbRepo.GetFeatureMappingByMapped(ctx, api.ID, model.MAPPED_TYP_API)
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/services/permission/service_check_router.go
+++ b/backend/pkg/services/permission/service_check_router.go
@@ -16,12 +16,12 @@ func (s *service) CheckRouterPermission(ctx core.Context, userID int64, routerTo
 		return false, err
 	}
 
-	menuMappings, err := s.dbRepo.GetFeatureMappingByFeature(features, model.MAPPED_TYP_MENU)
+	menuMappings, err := s.dbRepo.GetFeatureMappingByFeature(ctx, features, model.MAPPED_TYP_MENU)
 	if err != nil {
 		return false, err
 	}
 
-	routerMappings, err := s.dbRepo.GetFeatureMappingByFeature(features, model.MAPPED_TYP_ROUTER)
+	routerMappings, err := s.dbRepo.GetFeatureMappingByFeature(ctx, features, model.MAPPED_TYP_ROUTER)
 	if err != nil {
 		return false, err
 	}
@@ -36,12 +36,12 @@ func (s *service) CheckRouterPermission(ctx core.Context, userID int64, routerTo
 		routerIDs = append(routerIDs, mapping.MappedID)
 	}
 
-	routers, err := s.dbRepo.GetRouterByIDs(routerIDs)
+	routers, err := s.dbRepo.GetRouterByIDs(ctx, routerIDs)
 	if err != nil {
 		return false, err
 	}
 
-	itemRouters, err := s.dbRepo.GetItemsRouter(menuIDs)
+	itemRouters, err := s.dbRepo.GetItemsRouter(ctx, menuIDs)
 	if err != nil {
 		return false, err
 	}

--- a/backend/pkg/services/permission/service_get_user_permission.go
+++ b/backend/pkg/services/permission/service_get_user_permission.go
@@ -10,12 +10,12 @@ import (
 
 func (s *service) getUserFeatureIDs(ctx core.Context, userID int64) ([]int, error) {
 	// 1. Get user's role
-	roles, err := s.dbRepo.GetUserRole(userID)
+	roles, err := s.dbRepo.GetUserRole(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 	// 2. Get user's team
-	teamIDs, err := s.dbRepo.GetUserTeams(userID)
+	teamIDs, err := s.dbRepo.GetUserTeams(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -25,17 +25,17 @@ func (s *service) getUserFeatureIDs(ctx core.Context, userID int64) ([]int, erro
 	for i := range roleIDs {
 		roleIDs[i] = int64(roles[i].RoleID)
 	}
-	rolesFeatures, err := s.dbRepo.GetSubjectsPermission(roleIDs, model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE)
+	rolesFeatures, err := s.dbRepo.GetSubjectsPermission(ctx, roleIDs, model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
 
-	uFeatureIDs, err := s.dbRepo.GetSubjectPermission(userID, model.PERMISSION_SUB_TYP_USER, model.PERMISSION_TYP_FEATURE)
+	uFeatureIDs, err := s.dbRepo.GetSubjectPermission(ctx, userID, model.PERMISSION_SUB_TYP_USER, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
 
-	teamFeatures, err := s.dbRepo.GetSubjectsPermission(teamIDs, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE)
+	teamFeatures, err := s.dbRepo.GetSubjectsPermission(ctx, teamIDs, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/permission/service_permission.go
+++ b/backend/pkg/services/permission/service_permission.go
@@ -4,8 +4,6 @@
 package permission
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -15,12 +13,12 @@ import (
 )
 
 func (s *service) GetFeature(ctx core.Context, req *request.GetFeatureRequest) (response.GetFeatureResponse, error) {
-	features, err := s.dbRepo.GetFeature(nil)
+	features, err := s.dbRepo.GetFeature(ctx, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	err = s.dbRepo.GetFeatureTans(&features, req.Language)
+	err = s.dbRepo.GetFeatureTans(ctx, &features, req.Language)
 	if err != nil {
 		return nil, err
 	}
@@ -51,22 +49,22 @@ func (s *service) GetSubjectFeature(ctx core.Context, req *request.GetSubjectFea
 		return s.getUserFeatureWithSource(ctx, req.SubjectID, req.Language)
 	}
 
-	featureIDs, err := s.dbRepo.GetSubjectPermission(req.SubjectID, req.SubjectType, model.PERMISSION_TYP_FEATURE)
+	featureIDs, err := s.dbRepo.GetSubjectPermission(ctx, req.SubjectID, req.SubjectType, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
 
-	featureList, err := s.dbRepo.GetFeature(featureIDs)
+	featureList, err := s.dbRepo.GetFeature(ctx, featureIDs)
 	if err != nil {
 		return nil, err
 	}
-	err = s.dbRepo.GetFeatureTans(&featureList, req.Language)
+	err = s.dbRepo.GetFeatureTans(ctx, &featureList, req.Language)
 	return featureList, nil
 }
 
 func (s *service) getUserFeatureWithSource(ctx core.Context, userID int64, language string) (response.GetSubjectFeatureResponse, error) {
 	// Get user's roles and teams
-	roles, err := s.dbRepo.GetUserRole(userID)
+	roles, err := s.dbRepo.GetUserRole(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -75,26 +73,26 @@ func (s *service) getUserFeatureWithSource(ctx core.Context, userID int64, langu
 		roleIDs[i] = int64(roles[i].RoleID)
 	}
 
-	teamIDs, err := s.dbRepo.GetUserTeams(userID)
+	teamIDs, err := s.dbRepo.GetUserTeams(ctx, userID)
 	if err != nil {
 		return nil, err
 	}
 
 	// Get feature sources
-	roleFeatures, err := s.dbRepo.GetSubjectsPermission(roleIDs, model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE)
+	roleFeatures, err := s.dbRepo.GetSubjectsPermission(ctx, roleIDs, model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
-	teamFeatures, err := s.dbRepo.GetSubjectsPermission(teamIDs, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE)
+	teamFeatures, err := s.dbRepo.GetSubjectsPermission(ctx, teamIDs, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
-	userFeatures, err := s.dbRepo.GetSubjectPermission(userID, model.PERMISSION_SUB_TYP_USER, model.PERMISSION_TYP_FEATURE)
+	userFeatures, err := s.dbRepo.GetSubjectPermission(ctx, userID, model.PERMISSION_SUB_TYP_USER, model.PERMISSION_TYP_FEATURE)
 	if err != nil {
 		return nil, err
 	}
 
-	features, err := s.dbRepo.GetFeature(nil)
+	features, err := s.dbRepo.GetFeature(ctx, nil)
 	featureMap := make(map[int]database.Feature)
 	for _, f := range features {
 		featureMap[f.FeatureID] = f
@@ -125,7 +123,7 @@ func (s *service) getUserFeatureWithSource(ctx core.Context, userID int64, langu
 		}
 	}
 
-	err = s.dbRepo.GetFeatureTans(&features, language)
+	err = s.dbRepo.GetFeatureTans(ctx, &features, language)
 	return resp, err
 }
 
@@ -134,14 +132,14 @@ func (s *service) PermissionOperation(ctx core.Context, req *request.PermissionO
 	var err error
 	switch req.SubjectType {
 	case model.PERMISSION_SUB_TYP_ROLE:
-		exists, err = s.dbRepo.RoleExists(int(req.SubjectID))
+		exists, err = s.dbRepo.RoleExists(ctx, int(req.SubjectID))
 	case model.PERMISSION_SUB_TYP_USER:
-		exists, err = s.dbRepo.UserExists(req.SubjectID)
+		exists, err = s.dbRepo.UserExists(ctx, req.SubjectID)
 	case model.PERMISSION_SUB_TYP_TEAM:
 		filter := model.TeamFilter{
 			ID: req.SubjectID,
 		}
-		exists, err = s.dbRepo.TeamExist(filter)
+		exists, err = s.dbRepo.TeamExist(ctx, filter)
 	default:
 		return nil
 	}
@@ -152,23 +150,23 @@ func (s *service) PermissionOperation(ctx core.Context, req *request.PermissionO
 		return core.Error(code.AuthSubjectNotExistError, "subject of authorisation does not exist")
 	}
 
-	addPermissions, deletePermissions, err := s.dbRepo.GetAddAndDeletePermissions(req.SubjectID, req.SubjectType, req.Type, req.PermissionList)
+	addPermissions, deletePermissions, err := s.dbRepo.GetAddAndDeletePermissions(ctx, req.SubjectID, req.SubjectType, req.Type, req.PermissionList)
 	if err != nil {
 		return err
 	}
-	var grantFunc = func(ctx context.Context) error {
+	var grantFunc = func(ctx core.Context) error {
 		if len(addPermissions) == 0 {
 			return nil
 		}
 		return s.dbRepo.GrantPermission(ctx, req.SubjectID, req.SubjectType, req.Type, addPermissions)
 	}
 
-	var revokeFunc = func(ctx context.Context) error {
+	var revokeFunc = func(ctx core.Context) error {
 		if len(deletePermissions) == 0 {
 			return nil
 		}
 		return s.dbRepo.RevokePermission(ctx, req.SubjectID, req.SubjectType, req.Type, deletePermissions)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), grantFunc, revokeFunc)
+	return s.dbRepo.Transaction(ctx, grantFunc, revokeFunc)
 }

--- a/backend/pkg/services/permission/service_user_configs.go
+++ b/backend/pkg/services/permission/service_user_configs.go
@@ -21,7 +21,7 @@ func (s *service) GetUserConfig(ctx core.Context, req *request.GetUserConfigRequ
 		return resp, err
 	}
 
-	res, err := s.dbRepo.GetFeatureMappingByFeature(featureIDs, model.MAPPED_TYP_MENU)
+	res, err := s.dbRepo.GetFeatureMappingByFeature(ctx, featureIDs, model.MAPPED_TYP_MENU)
 	itemIDs := make([]int, len(res))
 	for i := range res {
 		itemIDs[i] = res[i].MappedID
@@ -30,12 +30,12 @@ func (s *service) GetUserConfig(ctx core.Context, req *request.GetUserConfigRequ
 		return resp, err
 	}
 
-	items, err := s.dbRepo.GetMenuItems()
+	items, err := s.dbRepo.GetMenuItems(ctx)
 	if err != nil {
 		return resp, err
 	}
 
-	err = s.dbRepo.FillItemRouter(&items)
+	err = s.dbRepo.FillItemRouter(ctx, &items)
 	if err != nil {
 		return resp, err
 	}
@@ -46,12 +46,12 @@ func (s *service) GetUserConfig(ctx core.Context, req *request.GetUserConfigRequ
 		}
 	}
 
-	err = s.dbRepo.GetRouterInsertedPage(routers, req.Language)
+	err = s.dbRepo.GetRouterInsertedPage(ctx, routers, req.Language)
 	if err != nil {
 		return resp, err
 	}
 
-	err = s.dbRepo.GetMenuItemTans(&items, req.Language)
+	err = s.dbRepo.GetMenuItemTans(ctx, &items, req.Language)
 	if err != nil {
 		return resp, err
 	}

--- a/backend/pkg/services/role/service_delete_role.go
+++ b/backend/pkg/services/role/service_delete_role.go
@@ -4,15 +4,13 @@
 package role
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
 func (s *service) DeleteRole(ctx core.Context, req *request.DeleteRoleRequest) error {
-	exists, err := s.dbRepo.RoleExists(req.RoleID)
+	exists, err := s.dbRepo.RoleExists(ctx, req.RoleID)
 	if err != nil {
 		return err
 	}
@@ -21,7 +19,7 @@ func (s *service) DeleteRole(ctx core.Context, req *request.DeleteRoleRequest) e
 		return core.Error(code.RoleNotExistsError, "role does not exist")
 	}
 
-	granted, err := s.dbRepo.RoleGranted(req.RoleID)
+	granted, err := s.dbRepo.RoleGranted(ctx, req.RoleID)
 	if err != nil {
 		return err
 	}
@@ -30,13 +28,13 @@ func (s *service) DeleteRole(ctx core.Context, req *request.DeleteRoleRequest) e
 		return core.Error(code.RoleGrantedError, "role has been granted")
 	}
 
-	var revokeRoleFunc = func(ctx context.Context) error {
+	var revokeRoleFunc = func(ctx core.Context) error {
 		return s.dbRepo.RevokeRoleWithRole(ctx, req.RoleID)
 	}
 
-	var deleteFunc = func(ctx context.Context) error {
+	var deleteFunc = func(ctx core.Context) error {
 		return s.dbRepo.DeleteRole(ctx, req.RoleID)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), revokeRoleFunc, deleteFunc)
+	return s.dbRepo.Transaction(ctx, revokeRoleFunc, deleteFunc)
 }

--- a/backend/pkg/services/role/service_update_role.go
+++ b/backend/pkg/services/role/service_update_role.go
@@ -4,8 +4,6 @@
 package role
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -17,7 +15,7 @@ func (s *service) UpdateRole(ctx core.Context, req *request.UpdateRoleRequest) e
 		ID: req.RoleID,
 	}
 
-	role, err := s.dbRepo.GetRoles(idFilter)
+	role, err := s.dbRepo.GetRoles(ctx, idFilter)
 	if err != nil {
 		return err
 	}
@@ -31,7 +29,7 @@ func (s *service) UpdateRole(ctx core.Context, req *request.UpdateRoleRequest) e
 			Name: req.RoleName,
 		}
 
-		existRole, err := s.dbRepo.GetRoles(nameFilter)
+		existRole, err := s.dbRepo.GetRoles(ctx, nameFilter)
 		if err != nil {
 			return err
 		}
@@ -41,22 +39,22 @@ func (s *service) UpdateRole(ctx core.Context, req *request.UpdateRoleRequest) e
 		}
 	}
 
-	toAdd, toDelete, err := s.dbRepo.GetAddAndDeletePermissions(int64(req.RoleID), model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE, req.PermissionList)
+	toAdd, toDelete, err := s.dbRepo.GetAddAndDeletePermissions(ctx, int64(req.RoleID), model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE, req.PermissionList)
 	if err != nil {
 		return err
 	}
 
-	var updateRoleFunc = func(ctx context.Context) error {
+	var updateRoleFunc = func(ctx core.Context) error {
 		return s.dbRepo.UpdateRole(ctx, req.RoleID, req.RoleName, req.Description)
 	}
 
-	var grantPermissionFunc = func(ctx context.Context) error {
+	var grantPermissionFunc = func(ctx core.Context) error {
 		return s.dbRepo.GrantPermission(ctx, int64(req.RoleID), model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE, toAdd)
 	}
 
-	var revokePermissionFunc = func(ctx context.Context) error {
+	var revokePermissionFunc = func(ctx core.Context) error {
 		return s.dbRepo.RevokePermission(ctx, int64(req.RoleID), model.PERMISSION_SUB_TYP_ROLE, model.PERMISSION_TYP_FEATURE, toDelete)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), updateRoleFunc, grantPermissionFunc, revokePermissionFunc)
+	return s.dbRepo.Transaction(ctx, updateRoleFunc, grantPermissionFunc, revokePermissionFunc)
 }

--- a/backend/pkg/services/role/service_user_role.go
+++ b/backend/pkg/services/role/service_user_role.go
@@ -4,8 +4,6 @@
 package role
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -15,7 +13,7 @@ import (
 )
 
 func (s *service) GetRoles(ctx core.Context) (response.GetRoleResponse, error) {
-	roles, err := s.dbRepo.GetRoles(model.RoleFilter{})
+	roles, err := s.dbRepo.GetRoles(ctx, model.RoleFilter{})
 	var resp response.GetRoleResponse
 	if err != nil {
 		return resp, err
@@ -26,7 +24,7 @@ func (s *service) GetRoles(ctx core.Context) (response.GetRoleResponse, error) {
 }
 
 func (s *service) GetUserRole(ctx core.Context, req *request.GetUserRoleRequest) (response.GetUserRoleResponse, error) {
-	userRole, err := s.dbRepo.GetUserRole(req.UserID)
+	userRole, err := s.dbRepo.GetUserRole(ctx, req.UserID)
 	if err != nil {
 		return nil, err
 	}
@@ -36,7 +34,7 @@ func (s *service) GetUserRole(ctx core.Context, req *request.GetUserRoleRequest)
 		roleIDs[i] = roleID.RoleID
 	}
 	filter := model.RoleFilter{IDs: roleIDs}
-	roles, err := s.dbRepo.GetRoles(filter)
+	roles, err := s.dbRepo.GetRoles(ctx, filter)
 	if err != nil {
 		return nil, err
 	}
@@ -45,13 +43,13 @@ func (s *service) GetUserRole(ctx core.Context, req *request.GetUserRoleRequest)
 
 func (s *service) RoleOperation(ctx core.Context, req *request.RoleOperationRequest) error {
 	// 1. get user's role
-	userRole, err := s.dbRepo.GetUserRole(req.UserID)
+	userRole, err := s.dbRepo.GetUserRole(ctx, req.UserID)
 	if err != nil {
 		return err
 	}
 
 	// 2. get all roles
-	roles, err := s.dbRepo.GetRoles(model.RoleFilter{})
+	roles, err := s.dbRepo.GetRoles(ctx, model.RoleFilter{})
 	if err != nil {
 		return err
 	}
@@ -66,15 +64,15 @@ func (s *service) RoleOperation(ctx core.Context, req *request.RoleOperationRequ
 		return err
 	}
 
-	var grantFunc = func(txCtx context.Context) error {
-		return s.dbRepo.GrantRoleWithUser(txCtx, req.UserID, addRoles)
+	var grantFunc = func(txCtx core.Context) error {
+		return s.dbRepo.GrantRoleWithUser(ctx, req.UserID, addRoles)
 	}
 
-	var revokeFunc = func(txCtx context.Context) error {
-		return s.dbRepo.RevokeRole(txCtx, req.UserID, deleteRoles)
+	var revokeFunc = func(txCtx core.Context) error {
+		return s.dbRepo.RevokeRole(ctx, req.UserID, deleteRoles)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), grantFunc, revokeFunc)
+	return s.dbRepo.Transaction(ctx, grantFunc, revokeFunc)
 }
 
 // GetAddDeleteRoles Determine grant and revoke roles.

--- a/backend/pkg/services/service/service_count_k8s_events.go
+++ b/backend/pkg/services/service/service_count_k8s_events.go
@@ -29,7 +29,7 @@ func (s *service) CountK8sEvents(ctx core.Context, req *request.GetK8sEventsRequ
 		return resp, nil
 	}
 	// Use all pod instances as filter criteria to return a list of events related to the time period
-	counts, err := s.chRepo.CountK8sEvents(startTime, endTime, podInstances)
+	counts, err := s.chRepo.CountK8sEvents(ctx, startTime, endTime, podInstances)
 	if err != nil {
 		return resp, err
 	}

--- a/backend/pkg/services/service/service_get_alert_events.go
+++ b/backend/pkg/services/service/service_get_alert_events.go
@@ -36,6 +36,7 @@ func (s *service) GetAlertEventsSample(ctx core.Context, req *request.GetAlertEv
 
 	// Query the AlertEvent of the instance
 	events, err := s.chRepo.GetAlertEventsSample(
+		ctx,
 		req.SampleCount,
 		startTime, endTime,
 		req.AlertFilter,
@@ -80,6 +81,7 @@ func (s *service) GetAlertEvents(ctx core.Context, req *request.GetAlertEventsRe
 
 	// Query the AlertEvent of the instance
 	events, totalCount, err := s.chRepo.GetAlertEvents(
+		ctx,
 		startTime, endTime,
 		req.AlertFilter,
 		&model.RelatedInstances{

--- a/backend/pkg/services/service/service_get_descendant_metrics.go
+++ b/backend/pkg/services/service/service_get_descendant_metrics.go
@@ -13,7 +13,7 @@ import (
 
 func (s *service) GetDescendantMetrics(ctx core.Context, req *request.GetDescendantMetricsRequest) ([]response.GetDescendantMetricsResponse, error) {
 	// Query all descendant nodes
-	nodes, err := s.chRepo.ListDescendantNodes(req)
+	nodes, err := s.chRepo.ListDescendantNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_descendant_relevance.go
+++ b/backend/pkg/services/service/service_get_descendant_relevance.go
@@ -20,7 +20,7 @@ import (
 // GetDescendantRelevance implements Service.
 func (s *service) GetDescendantRelevance(ctx core.Context, req *request.GetDescendantRelevanceRequest) ([]response.GetDescendantRelevanceResponse, error) {
 	// Query all descendant nodes
-	nodes, err := s.chRepo.ListDescendantNodes(req)
+	nodes, err := s.chRepo.ListDescendantNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (s *service) GetDescendantRelevance(ctx core.Context, req *request.GetDesce
 	if err != nil {
 		// Failed to query RED metric when adding log to TODO
 	}
-	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
+	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 	if err != nil {
 		// Failed to query the threshold when adding logs to TODO
 	}

--- a/backend/pkg/services/service/service_get_error_instance.go
+++ b/backend/pkg/services/service/service_get_error_instance.go
@@ -35,7 +35,7 @@ func (s *service) GetErrorInstance(ctx core.Context, req *request.GetErrorInstan
 	}
 
 	// Get error propagation link
-	propagations, err := s.chRepo.ListErrorPropagation(req)
+	propagations, err := s.chRepo.ListErrorPropagation(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_errorinstance_logs.go
+++ b/backend/pkg/services/service/service_get_errorinstance_logs.go
@@ -21,7 +21,7 @@ func (s *service) GetErrorInstanceLogs(ctx core.Context, req *request.GetErrorIn
 		PageNum:   1,
 		PageSize:  5,
 	}
-	list, _, err := s.chRepo.GetFaultLogPageList(query)
+	list, _, err := s.chRepo.GetFaultLogPageList(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_log_logs.go
+++ b/backend/pkg/services/service/service_get_log_logs.go
@@ -24,7 +24,7 @@ func (s *service) GetLogLogs(ctx core.Context, req *request.GetLogLogsRequest) (
 		PageNum:     1,
 		PageSize:    5,
 	}
-	list, _, err := s.chRepo.GetFaultLogPageList(query)
+	list, _, err := s.chRepo.GetFaultLogPageList(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_service_endpoint_relation.go
+++ b/backend/pkg/services/service/service_get_service_endpoint_relation.go
@@ -12,13 +12,13 @@ import (
 
 func (s *service) GetServiceEndpointRelation(ctx core.Context, req *request.GetServiceEndpointRelationRequest) (*response.GetServiceEndpointRelationResponse, error) {
 	// Query all upstream nodes
-	parents, err := s.chRepo.ListParentNodes(req)
+	parents, err := s.chRepo.ListParentNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	// Query the calling relationship list of all downstream nodes
-	relations, err := s.chRepo.ListDescendantRelations(req)
+	relations, err := s.chRepo.ListDescendantRelations(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_service_endpoint_topology.go
+++ b/backend/pkg/services/service/service_get_service_endpoint_topology.go
@@ -12,13 +12,13 @@ import (
 
 func (s *service) GetServiceEndpointTopology(ctx core.Context, req *request.GetServiceEndpointTopologyRequest) (*response.GetServiceEndpointTopologyResponse, error) {
 	// Query all upstream nodes
-	parents, err := s.chRepo.ListParentNodes(req)
+	parents, err := s.chRepo.ListParentNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}
 
 	// Query all downstream nodes
-	children, err := s.chRepo.ListChildNodes(req)
+	children, err := s.chRepo.ListChildNodes(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_get_service_entry_endpoints.go
+++ b/backend/pkg/services/service/service_get_service_entry_endpoints.go
@@ -10,5 +10,5 @@ import (
 )
 
 func (s *service) GetServiceEntryEndpoints(ctx core.Context, req *request.GetServiceEntryEndpointsRequest) ([]clickhouse.EntryNode, error) {
-	return s.chRepo.ListEntryEndpoints(req)
+	return s.chRepo.ListEntryEndpoints(ctx, req)
 }

--- a/backend/pkg/services/service/service_get_trace_logs.go
+++ b/backend/pkg/services/service/service_get_trace_logs.go
@@ -24,7 +24,7 @@ func (s *service) GetTraceLogs(ctx core.Context, req *request.GetTraceLogsReques
 		PageNum:     1,
 		PageSize:    5,
 	}
-	list, _, err := s.chRepo.GetFaultLogPageList(query)
+	list, _, err := s.chRepo.GetFaultLogPageList(ctx, query)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/service/service_instance_new.go
+++ b/backend/pkg/services/service/service_instance_new.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (s *service) GetInstancesNew(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
-	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
+	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 	if err != nil {
 		return res, err
 	}

--- a/backend/pkg/services/service/service_instances.go
+++ b/backend/pkg/services/service/service_instances.go
@@ -18,7 +18,7 @@ import (
 )
 
 func (s *service) GetInstances(ctx core.Context, startTime time.Time, endTime time.Time, step time.Duration, serviceName string, endPoint string) (res response.InstancesRes, err error) {
-	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
+	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 	if err != nil {
 		return res, err
 	}

--- a/backend/pkg/services/serviceoverview/service_alert.go
+++ b/backend/pkg/services/serviceoverview/service_alert.go
@@ -269,6 +269,7 @@ func GetAlertStatusCH(ctx core.Context, chRepo clickhouse.Repo,
 
 		// Query the alarm information related to the instance
 		events, _ := chRepo.GetAlertEventsSample(
+			ctx,
 			1, startTime, endTime,
 			request.AlertFilter{Services: []string{serviceName}, Status: "firing"},
 			&model.RelatedInstances{
@@ -309,7 +310,7 @@ func GetAlertStatusCH(ctx core.Context, chRepo clickhouse.Repo,
 
 	if len(alertTypes) == 0 || contains(alertTypes, "k8sStatus") {
 		// Query K8s events of warning level and above
-		k8sEvents, _ := chRepo.GetK8sAlertEventsSample(startTime, endTime, instances)
+		k8sEvents, _ := chRepo.GetK8sAlertEventsSample(ctx, startTime, endTime, instances)
 		if len(k8sEvents) > 0 {
 			alertStatus.K8sStatus = model.STATUS_CRITICAL
 			for _, event := range k8sEvents {

--- a/backend/pkg/services/serviceoverview/service_get_endpoints_data.go
+++ b/backend/pkg/services/serviceoverview/service_get_endpoints_data.go
@@ -88,7 +88,7 @@ func (s *service) sortWithRule(ctx core.Context, sortRule request.SortType, endp
 	case request.SortByLatency, request.SortByErrorRate, request.SortByThroughput, request.SortByLogErrorCount:
 		slices.SortStableFunc(endpointsMap.MetricGroupList, prometheus.ReverseSortWithMetrics(sortRule))
 	case request.DODThreshold: //Sort by Day-to-Year Threshold
-		threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
+		threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 		if err != nil {
 			return err
 		}

--- a/backend/pkg/services/serviceoverview/service_get_threshold.go
+++ b/backend/pkg/services/serviceoverview/service_get_threshold.go
@@ -9,7 +9,7 @@ import (
 )
 
 func (s *service) GetThreshold(ctx core.Context, level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error) {
-	threshold, err := s.dbRepo.GetOrCreateThreshold(serviceName, endPoint, level)
+	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, serviceName, endPoint, level)
 	if err != nil {
 		return res, err
 	}

--- a/backend/pkg/services/serviceoverview/service_moreurl.go
+++ b/backend/pkg/services/serviceoverview/service_moreurl.go
@@ -35,7 +35,7 @@ func (s *service) GetServiceMoreUrl(ctx core.Context, startTime time.Time, endTi
 		return nil, nil
 	}
 
-	threshold, err := s.dbRepo.GetOrCreateThreshold("", "", database.GLOBAL)
+	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/serviceoverview/service_ryg_light.go
+++ b/backend/pkg/services/serviceoverview/service_ryg_light.go
@@ -63,7 +63,7 @@ func (s *service) GetServicesRYGLightStatus(ctx core.Context, startTime time.Tim
 		ServiceList: []*response.ServiceRYGResult{},
 	}
 
-	alertEventCount, _ := s.chRepo.GetAlertEventCountGroupByInstance(startTime,
+	alertEventCount, _ := s.chRepo.GetAlertEventCountGroupByInstance(ctx, startTime,
 		endTime,
 		request.AlertFilter{Status: "firing"},
 		nil,

--- a/backend/pkg/services/serviceoverview/service_set_threshold.go
+++ b/backend/pkg/services/serviceoverview/service_set_threshold.go
@@ -19,7 +19,7 @@ func (s *service) SetThreshold(ctx core.Context, level string, serviceName strin
 	if level == database.GLOBAL {
 		threshold.Level = database.GLOBAL
 	}
-	err = s.dbRepo.CreateOrUpdateThreshold(threshold)
+	err = s.dbRepo.CreateOrUpdateThreshold(ctx, threshold)
 	return res, err
 
 }

--- a/backend/pkg/services/team/service_get_team.go
+++ b/backend/pkg/services/team/service_get_team.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) GetTeamList(ctx core.Context, req *request.GetTeamRequest) (resp response.GetTeamResponse, err error) {
-	teams, count, err := s.dbRepo.GetTeamList(req)
+	teams, count, err := s.dbRepo.GetTeamList(ctx, req)
 	if err != nil {
 		return
 	}

--- a/backend/pkg/services/team/service_get_team_user.go
+++ b/backend/pkg/services/team/service_get_team_user.go
@@ -15,7 +15,7 @@ func (s *service) GetTeamUser(ctx core.Context, req *request.GetTeamUserRequest)
 	filter := model.TeamFilter{
 		ID: req.TeamID,
 	}
-	exists, err := s.dbRepo.TeamExist(filter)
+	exists, err := s.dbRepo.TeamExist(ctx, filter)
 	if err != nil {
 		return
 	}
@@ -25,7 +25,7 @@ func (s *service) GetTeamUser(ctx core.Context, req *request.GetTeamUserRequest)
 		return
 	}
 
-	users, err := s.dbRepo.GetTeamUserList(req.TeamID)
+	users, err := s.dbRepo.GetTeamUserList(ctx, req.TeamID)
 	if err != nil {
 		return
 	}

--- a/backend/pkg/services/team/service_team_opreation.go
+++ b/backend/pkg/services/team/service_team_opreation.go
@@ -4,20 +4,18 @@
 package team
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
 func (s *service) TeamOperation(ctx core.Context, req *request.TeamOperationRequest) error {
-	teamIDs, err := s.dbRepo.GetUserTeams(req.UserID)
+	teamIDs, err := s.dbRepo.GetUserTeams(ctx, req.UserID)
 	if err != nil {
 		return err
 	}
 
-	teams, _, err := s.dbRepo.GetTeamList(&request.GetTeamRequest{})
+	teams, _, err := s.dbRepo.GetTeamList(ctx, &request.GetTeamRequest{})
 	if err != nil {
 		return err
 	}
@@ -49,13 +47,13 @@ func (s *service) TeamOperation(ctx core.Context, req *request.TeamOperationRequ
 		toDelete = append(toDelete, id)
 	}
 
-	var assignFunc = func(ctx context.Context) error {
+	var assignFunc = func(ctx core.Context) error {
 		return s.dbRepo.AssignUserToTeam(ctx, req.UserID, toAdd)
 	}
 
-	var removeFunc = func(ctx context.Context) error {
+	var removeFunc = func(ctx core.Context) error {
 		return s.dbRepo.RemoveFromTeamByUser(ctx, req.UserID, toDelete)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), assignFunc, removeFunc)
+	return s.dbRepo.Transaction(ctx, assignFunc, removeFunc)
 }

--- a/backend/pkg/services/team/service_team_user_operation.go
+++ b/backend/pkg/services/team/service_team_user_operation.go
@@ -4,8 +4,6 @@
 package team
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -16,7 +14,7 @@ func (s *service) TeamUserOperation(ctx core.Context, req *request.AssignToTeamR
 	filter := model.TeamFilter{
 		ID: req.TeamID,
 	}
-	exists, err := s.dbRepo.TeamExist(filter)
+	exists, err := s.dbRepo.TeamExist(ctx, filter)
 	if err != nil {
 		return err
 	}
@@ -25,7 +23,7 @@ func (s *service) TeamUserOperation(ctx core.Context, req *request.AssignToTeamR
 		return core.Error(code.TeamNotExistError, "team does not exist")
 	}
 
-	exists, err = s.dbRepo.UserExists(req.UserList...)
+	exists, err = s.dbRepo.UserExists(ctx, req.UserList...)
 	if err != nil {
 		return err
 	}
@@ -34,7 +32,7 @@ func (s *service) TeamUserOperation(ctx core.Context, req *request.AssignToTeamR
 		return core.Error(code.UserNotExistsError, "user does not exist")
 	}
 
-	hasUsers, err := s.dbRepo.GetTeamUsers(req.TeamID)
+	hasUsers, err := s.dbRepo.GetTeamUsers(ctx, req.TeamID)
 	if err != nil {
 		return err
 	}
@@ -57,13 +55,13 @@ func (s *service) TeamUserOperation(ctx core.Context, req *request.AssignToTeamR
 		toDelete = append(toDelete, id)
 	}
 
-	var inviteFunc = func(ctx context.Context) error {
+	var inviteFunc = func(ctx core.Context) error {
 		return s.dbRepo.InviteUserToTeam(ctx, req.TeamID, toAdd)
 	}
 
-	var removeFunc = func(ctx context.Context) error {
+	var removeFunc = func(ctx core.Context) error {
 		return s.dbRepo.RemoveFromTeamByTeam(ctx, req.TeamID, toDelete)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), inviteFunc, removeFunc)
+	return s.dbRepo.Transaction(ctx, inviteFunc, removeFunc)
 }

--- a/backend/pkg/services/team/service_update_team.go
+++ b/backend/pkg/services/team/service_update_team.go
@@ -4,8 +4,6 @@
 package team
 
 import (
-	"context"
-
 	"github.com/CloudDetail/apo/backend/pkg/code"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -13,7 +11,7 @@ import (
 )
 
 func (s *service) UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) error {
-	team, err := s.dbRepo.GetTeam(req.TeamID)
+	team, err := s.dbRepo.GetTeam(ctx, req.TeamID)
 	if err != nil {
 		return err
 	}
@@ -27,7 +25,7 @@ func (s *service) UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) e
 			Name: req.TeamName,
 		}
 
-		exists, err := s.dbRepo.TeamExist(filter)
+		exists, err := s.dbRepo.TeamExist(ctx, filter)
 		if err != nil {
 			return err
 		}
@@ -51,7 +49,7 @@ func (s *service) UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) e
 	// }
 
 	// determine added or removed users
-	hasUsers, err := s.dbRepo.GetTeamUsers(req.TeamID)
+	hasUsers, err := s.dbRepo.GetTeamUsers(ctx, req.TeamID)
 	if err != nil {
 		return err
 	}
@@ -74,33 +72,33 @@ func (s *service) UpdateTeam(ctx core.Context, req *request.UpdateTeamRequest) e
 		toDelete = append(toDelete, id)
 	}
 
-	var inviteFunc = func(ctx context.Context) error {
+	var inviteFunc = func(ctx core.Context) error {
 		return s.dbRepo.InviteUserToTeam(ctx, req.TeamID, toAdd)
 	}
 
-	var removeFunc = func(ctx context.Context) error {
+	var removeFunc = func(ctx core.Context) error {
 		return s.dbRepo.RemoveFromTeamByTeam(ctx, req.TeamID, toDelete)
 	}
 
-	var updateTeamFunc = func(ctx context.Context) error {
+	var updateTeamFunc = func(ctx core.Context) error {
 		return s.dbRepo.UpdateTeam(ctx, team)
 	}
 
-	// var grantPermissionFunc = func(ctx context.Context) error {
+	// var grantPermissionFunc = func(ctx core.Context) error {
 	// 	return s.dbRepo.GrantPermission(ctx, req.TeamID, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE, toAddFeature)
 	// }
 
-	// var revokePermissionFunc = func(ctx context.Context) error {
+	// var revokePermissionFunc = func(ctx core.Context) error {
 	// 	return s.dbRepo.RevokePermission(ctx, req.TeamID, model.PERMISSION_SUB_TYP_TEAM, model.PERMISSION_TYP_FEATURE, toDeleteFeature)
 	// }
 
-	// var assignDataGroupFunc = func(ctx context.Context) error {
+	// var assignDataGroupFunc = func(ctx core.Context) error {
 	// 	return s.dbRepo.AssignDataGroup(ctx, toModifyDg)
 	// }
 
-	// var removeDataGroupFunc = func(ctx context.Context) error {
+	// var removeDataGroupFunc = func(ctx core.Context) error {
 	// 	return s.dbRepo.RevokeDataGroupByGroup(ctx, toDeleteDg, req.TeamID)
 	// }
 
-	return s.dbRepo.Transaction(context.Background(), updateTeamFunc, inviteFunc, removeFunc)
+	return s.dbRepo.Transaction(ctx, updateTeamFunc, inviteFunc, removeFunc)
 }

--- a/backend/pkg/services/trace/service_get_flame_data.go
+++ b/backend/pkg/services/trace/service_get_flame_data.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) GetFlameGraphData(ctx core.Context, req *request.GetFlameDataRequest) (resp response.GetFlameDataResponse, err error) {
-	flameData, err := s.chRepo.GetFlameGraphData(req.StartTime, req.EndTime, req.NodeName,
+	flameData, err := s.chRepo.GetFlameGraphData(ctx, req.StartTime, req.EndTime, req.NodeName,
 		req.PID, req.TID, req.SampleType, req.SpanID, req.TraceID)
 	if err != nil {
 		return

--- a/backend/pkg/services/trace/service_get_on_off_cpu.go
+++ b/backend/pkg/services/trace/service_get_on_off_cpu.go
@@ -10,7 +10,7 @@ import (
 )
 
 func (s *service) GetOnOffCPU(ctx core.Context, req *request.GetOnOffCPURequest) (*response.GetOnOffCPUResponse, error) {
-	result, err := s.chRepo.GetOnOffCPU(req.PID, req.NodeName, req.StartTime, req.EndTime)
+	result, err := s.chRepo.GetOnOffCPU(ctx, req.PID, req.NodeName, req.StartTime, req.EndTime)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/trace/service_get_process_flame_data.go
+++ b/backend/pkg/services/trace/service_get_process_flame_data.go
@@ -15,7 +15,7 @@ import (
 )
 
 func (s *service) GetProcessFlameGraphData(ctx core.Context, req *request.GetProcessFlameGraphRequest) (response.GetProcessFlameGraphResponse, error) {
-	data, err := s.chRepo.GetFlameGraphData(req.StartTime, req.EndTime, req.NodeName,
+	data, err := s.chRepo.GetFlameGraphData(ctx, req.StartTime, req.EndTime, req.NodeName,
 		req.PID, -1, req.SampleType, "", "")
 	if err != nil {
 		return response.GetProcessFlameGraphResponse{}, err

--- a/backend/pkg/services/trace/service_get_trace_filter_values.go
+++ b/backend/pkg/services/trace/service_get_trace_filter_values.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (s *service) GetTraceFilterValues(ctx core.Context, startTime, endTime time.Time, searchText string, filter request.SpanTraceFilter) (*response.GetTraceFilterValueResponse, error) {
-	option, err := s.chRepo.GetFieldValues(searchText, &filter, startTime, endTime)
+	option, err := s.chRepo.GetFieldValues(ctx, searchText, &filter, startTime, endTime)
 	if err != nil {
 		return &response.GetTraceFilterValueResponse{
 			TraceFilterOptions: clickhouse.SpanTraceOptions{

--- a/backend/pkg/services/trace/service_get_trace_filters.go
+++ b/backend/pkg/services/trace/service_get_trace_filters.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (s *service) GetTraceFilters(ctx core.Context, startTime, endTime time.Time, needUpdate bool) (*response.GetTraceFiltersResponse, error) {
-	filters, err := s.chRepo.GetAvailableFilterKey(startTime, endTime, needUpdate)
+	filters, err := s.chRepo.GetAvailableFilterKey(ctx, startTime, endTime, needUpdate)
 	if err != nil {
 		return &response.GetTraceFiltersResponse{
 			TraceFilters: []request.SpanTraceFilter{},

--- a/backend/pkg/services/trace/service_get_trace_page_list.go
+++ b/backend/pkg/services/trace/service_get_trace_page_list.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) GetTracePageList(ctx core.Context, req *request.GetTracePageListRequest) (*response.GetTracePageListResponse, error) {
-	list, total, err := s.chRepo.GetTracePageList(req)
+	list, total, err := s.chRepo.GetTracePageList(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/services/user/service_get_user_info.go
+++ b/backend/pkg/services/user/service_get_user_info.go
@@ -19,12 +19,12 @@ func (s *service) GetUserInfo(ctx core.Context, userID int64) (response.GetUserI
 	)
 
 	if userID == 0 {
-		user, err = s.dbRepo.GetAnonymousUser()
+		user, err = s.dbRepo.GetAnonymousUser(ctx)
 		resp.User = user
 		return resp, err
 	}
 
-	exists, err := s.dbRepo.UserExists(userID)
+	exists, err := s.dbRepo.UserExists(ctx, userID)
 	if err != nil {
 		return resp, err
 	}
@@ -33,7 +33,7 @@ func (s *service) GetUserInfo(ctx core.Context, userID int64) (response.GetUserI
 		return resp, core.Error(code.UserNotExistsError, "user does not exist")
 	}
 
-	user, err = s.dbRepo.GetUserInfo(userID)
+	user, err = s.dbRepo.GetUserInfo(ctx, userID)
 	if err != nil {
 		return resp, err
 	}
@@ -43,7 +43,7 @@ func (s *service) GetUserInfo(ctx core.Context, userID int64) (response.GetUserI
 }
 
 func (s *service) GetUserList(ctx core.Context, req *request.GetUserListRequest) (resp response.GetUserListResponse, err error) {
-	users, count, err := s.dbRepo.GetUserList(req)
+	users, count, err := s.dbRepo.GetUserList(ctx, req)
 	resp.Users = users
 	resp.PageSize = req.PageSize
 	resp.CurrentPage = req.CurrentPage

--- a/backend/pkg/services/user/service_get_user_team.go
+++ b/backend/pkg/services/user/service_get_user_team.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) GetUserTeam(ctx core.Context, req *request.GetUserTeamRequest) (response.GetUserTeamResponse, error) {
-	exists, err := s.dbRepo.UserExists(req.UserID)
+	exists, err := s.dbRepo.UserExists(ctx, req.UserID)
 	if err != nil {
 		return nil, err
 	}
@@ -20,5 +20,5 @@ func (s *service) GetUserTeam(ctx core.Context, req *request.GetUserTeamRequest)
 		return nil, core.Error(code.UserNotExistsError, "user does not exist")
 	}
 
-	return s.dbRepo.GetAssignedTeam(req.UserID)
+	return s.dbRepo.GetAssignedTeam(ctx, req.UserID)
 }

--- a/backend/pkg/services/user/service_login.go
+++ b/backend/pkg/services/user/service_login.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (s *service) Login(ctx core.Context, req *request.LoginRequest) (response.LoginResponse, error) {
-	user, err := s.dbRepo.Login(req.Username, req.Password)
+	user, err := s.dbRepo.Login(ctx, req.Username, req.Password)
 	if err != nil {
 		return response.LoginResponse{}, err
 	}

--- a/backend/pkg/services/user/service_logout.go
+++ b/backend/pkg/services/user/service_logout.go
@@ -9,12 +9,12 @@ import (
 )
 
 func (s *service) Logout(ctx core.Context, req *request.LogoutRequest) error {
-	err := s.cacheRepo.AddToken(req.AccessToken)
+	err := s.cacheRepo.AddToken(ctx, req.AccessToken)
 	if err != nil {
 		return err
 	}
 
-	err = s.cacheRepo.AddToken(req.RefreshToken)
+	err = s.cacheRepo.AddToken(ctx, req.RefreshToken)
 	if err != nil {
 		return err
 	}

--- a/backend/pkg/services/user/service_refresh_token.go
+++ b/backend/pkg/services/user/service_refresh_token.go
@@ -20,5 +20,5 @@ func (s *service) RefreshToken(ctx core.Context, token string) (response.Refresh
 }
 
 func (s *service) IsInBlacklist(ctx core.Context, token string) (bool, error) {
-	return s.cacheRepo.IsInBlacklist(token)
+	return s.cacheRepo.IsInBlacklist(ctx, token)
 }

--- a/backend/pkg/services/user/service_remove_user.go
+++ b/backend/pkg/services/user/service_remove_user.go
@@ -4,7 +4,6 @@
 package user
 
 import (
-	"context"
 	"errors"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
@@ -13,7 +12,7 @@ import (
 )
 
 func (s *service) RemoveUser(ctx core.Context, userID int64) error {
-	exists, err := s.dbRepo.UserExists(userID)
+	exists, err := s.dbRepo.UserExists(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -22,7 +21,7 @@ func (s *service) RemoveUser(ctx core.Context, userID int64) error {
 		return core.Error(code.UserNotExistsError, "user does not exist")
 	}
 
-	roles, err := s.dbRepo.GetUserRole(userID)
+	roles, err := s.dbRepo.GetUserRole(ctx, userID)
 	if err != nil {
 		return err
 	}
@@ -32,28 +31,28 @@ func (s *service) RemoveUser(ctx core.Context, userID int64) error {
 		roleIDs = append(roleIDs, role.RoleID)
 	}
 
-	user, err := s.dbRepo.GetUserInfo(userID)
+	user, err := s.dbRepo.GetUserInfo(ctx, userID)
 	if err != nil {
 		return err
 	}
 
-	var revokeRoleFunc = func(ctx context.Context) error {
+	var revokeRoleFunc = func(ctx core.Context) error {
 		return s.dbRepo.RevokeRole(ctx, userID, roleIDs)
 	}
 
-	var deleteAuthDataGroupFunc = func(ctx context.Context) error {
+	var deleteAuthDataGroupFunc = func(ctx core.Context) error {
 		return s.dbRepo.DeleteAuthDataGroup(ctx, userID, model.DATA_GROUP_SUB_TYP_USER)
 	}
 
-	var removeFromTeam = func(ctx context.Context) error {
+	var removeFromTeam = func(ctx core.Context) error {
 		return s.dbRepo.DeleteAllUserTeam(ctx, userID, "user")
 	}
 
-	var removeUserFunc = func(ctx context.Context) error {
+	var removeUserFunc = func(ctx core.Context) error {
 		return s.dbRepo.RemoveUser(ctx, userID)
 	}
 
-	var removeDifyUserFunc = func(ctx context.Context) error {
+	var removeDifyUserFunc = func(ctx core.Context) error {
 		resp, err := s.difyRepo.RemoveUser(user.Username)
 		if err != nil || resp.Result != "success" {
 			return errors.New("failed to remove user in dify")
@@ -61,9 +60,9 @@ func (s *service) RemoveUser(ctx core.Context, userID int64) error {
 		return nil
 	}
 
-	var revokeFeaturePermFunc = func(ctx context.Context) error {
+	var revokeFeaturePermFunc = func(ctx core.Context) error {
 		return s.dbRepo.RevokePermission(ctx, userID, model.PERMISSION_SUB_TYP_USER, model.PERMISSION_TYP_FEATURE, nil)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), revokeFeaturePermFunc, deleteAuthDataGroupFunc, revokeRoleFunc, removeFromTeam, removeUserFunc, removeDifyUserFunc)
+	return s.dbRepo.Transaction(ctx, revokeFeaturePermFunc, deleteAuthDataGroupFunc, revokeRoleFunc, removeFromTeam, removeUserFunc, removeDifyUserFunc)
 }

--- a/backend/pkg/services/user/service_update_info.go
+++ b/backend/pkg/services/user/service_update_info.go
@@ -4,7 +4,6 @@
 package user
 
 import (
-	"context"
 	"errors"
 	"unicode"
 
@@ -29,27 +28,27 @@ func (s *service) UpdateUserInfo(ctx core.Context, req *request.UpdateUserInfoRe
 	//	return err
 	//}
 	//
-	//var grantFunc = func(ctx context.Context) error {
+	//var grantFunc = func(ctx core.Context) error {
 	//	return s.dbRepo.GrantRoleWithUser(ctx, req.UserID, addRole)
 	//}
 	//
-	//var revokeFunc = func(ctx context.Context) error {
+	//var revokeFunc = func(ctx core.Context) error {
 	//	return s.dbRepo.RevokeRole(ctx, req.UserID, deleteRole)
 	//}
 
-	var updateInfoFunc = func(ctx context.Context) error {
+	var updateInfoFunc = func(ctx core.Context) error {
 		return s.dbRepo.UpdateUserInfo(ctx, req.UserID, req.Phone, req.Email, req.Corporation)
 	}
 
-	return s.dbRepo.Transaction(context.Background(), updateInfoFunc)
+	return s.dbRepo.Transaction(ctx, updateInfoFunc)
 }
 
 func (s *service) UpdateUserPhone(ctx core.Context, req *request.UpdateUserPhoneRequest) error {
-	return s.dbRepo.UpdateUserPhone(req.UserID, req.Phone)
+	return s.dbRepo.UpdateUserPhone(ctx, req.UserID, req.Phone)
 }
 
 func (s *service) UpdateUserEmail(ctx core.Context, req *request.UpdateUserEmailRequest) error {
-	return s.dbRepo.UpdateUserEmail(req.UserID, req.Email)
+	return s.dbRepo.UpdateUserEmail(ctx, req.UserID, req.Email)
 }
 
 func (s *service) UpdateUserPassword(ctx core.Context, req *request.UpdateUserPasswordRequest) error {
@@ -57,23 +56,23 @@ func (s *service) UpdateUserPassword(ctx core.Context, req *request.UpdateUserPa
 		return err
 	}
 
-	user, err := s.dbRepo.GetUserInfo(req.UserID)
+	user, err := s.dbRepo.GetUserInfo(ctx, req.UserID)
 	if err != nil {
 		return err
 	}
 
-	var updatePasswordFunc = func(ctx context.Context) error {
-		return s.dbRepo.UpdateUserPassword(req.UserID, req.OldPassword, req.NewPassword)
+	var updatePasswordFunc = func(ctx core.Context) error {
+		return s.dbRepo.UpdateUserPassword(ctx, req.UserID, req.OldPassword, req.NewPassword)
 	}
 
-	var updateDifyPasswordFunc = func(ctx context.Context) error {
+	var updateDifyPasswordFunc = func(ctx core.Context) error {
 		resp, err := s.difyRepo.UpdatePassword(user.Username, req.OldPassword, req.NewPassword)
 		if err != nil || resp.Result != "success" {
 			return errors.New("failed to update password in dify")
 		}
 		return nil
 	}
-	return s.dbRepo.Transaction(context.Background(), updatePasswordFunc, updateDifyPasswordFunc)
+	return s.dbRepo.Transaction(ctx, updatePasswordFunc, updateDifyPasswordFunc)
 }
 
 func checkPasswordComplexity(password string) error {
@@ -131,25 +130,25 @@ func (s *service) RestPassword(ctx core.Context, req *request.ResetPasswordReque
 		return err
 	}
 
-	user, err := s.dbRepo.GetUserInfo(req.UserID)
+	user, err := s.dbRepo.GetUserInfo(ctx, req.UserID)
 	if err != nil {
 		return err
 	}
 
-	var resetPasswordFunc = func(ctx context.Context) error {
-		return s.dbRepo.RestPassword(req.UserID, req.NewPassword)
+	var resetPasswordFunc = func(ctx core.Context) error {
+		return s.dbRepo.RestPassword(ctx, req.UserID, req.NewPassword)
 	}
 
-	var resetDifyPasswordFunc = func(ctx context.Context) error {
+	var resetDifyPasswordFunc = func(ctx core.Context) error {
 		resp, err := s.difyRepo.ResetPassword(user.Username, req.NewPassword)
 		if err != nil || resp.Result != "success" {
 			return errors.New("failed to reset password in dify")
 		}
 		return nil
 	}
-	return s.dbRepo.Transaction(context.Background(), resetPasswordFunc, resetDifyPasswordFunc)
+	return s.dbRepo.Transaction(ctx, resetPasswordFunc, resetDifyPasswordFunc)
 }
 
 func (s *service) UpdateSelfInfo(ctx core.Context, req *request.UpdateSelfInfoRequest) error {
-	return s.dbRepo.UpdateUserInfo(context.Background(), req.UserID, req.Phone, req.Email, req.Corporation)
+	return s.dbRepo.UpdateUserInfo(ctx, req.UserID, req.Phone, req.Email, req.Corporation)
 }


### PR DESCRIPTION
## Summary by Sourcery

Refactor repository and service layers to propagate a custom core.Context throughout, replacing direct use of context.Context and unwrapped DB connections with context-aware wrappers.

Enhancements:
- Update all database and clickhouse Repo interfaces and DAO implementations to accept core.Context as the first argument and use driver.DB/GetContextDB for queries and transactions
- Introduce factory.Conn and driver.DB wrappers to centralize context-based DB connection handling and simplify transaction propagation
- Revise service, receiver, and migration code to forward core.Context into repository calls and replace context.Context usage
- Adjust initialization scripts, migrations, and tests to work with the new context-aware repository abstraction