### PR TITLE
Refactor/manage user2team by code

### DIFF
--- a/backend/pkg/core/static_ctx.go
+++ b/backend/pkg/core/static_ctx.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package core
 
 import "github.com/gin-gonic/gin"

--- a/backend/pkg/model/profile/team.go
+++ b/backend/pkg/model/profile/team.go
@@ -8,7 +8,7 @@ type Team struct {
 	TeamName    string `gorm:"column:team_name;type:varchar(20)" json:"teamName"`
 	Description string `gorm:"column:description;type:varchar(50)" json:"description"`
 
-	UserList    []User    `gorm:"many2many:user_team;foreignKey:TeamID;joinForeignKey:TeamID;References:UserID;joinReferences:UserID" json:"userList,omitempty"`
+	UserList    []User    `gorm:"-" json:"userList,omitempty"`
 	FeatureList []Feature `gorm:"-" json:"featureList,omitempty"`
 }
 

--- a/backend/pkg/model/profile/user.go
+++ b/backend/pkg/model/profile/user.go
@@ -11,8 +11,8 @@ type User struct {
 	Email       string `gorm:"column:email;type:varchar(50)" json:"email,omitempty"`
 	Corporation string `gorm:"column:corporation;type:varchar(50)" json:"corporation,omitempty"`
 
-	RoleList    []Role    `gorm:"many2many:user_role;joinForeignKey:UserID;joinReferences:RoleID" json:"roleList,omitempty"`
-	TeamList    []Team    `gorm:"many2many:user_team;joinForeignKey:UserID;joinReferences:TeamID" json:"teamList,omitempty"`
+	RoleList    []Role    `gorm:"-" json:"roleList,omitempty"`
+	TeamList    []Team    `gorm:"-" json:"teamList,omitempty"`
 	FeatureList []Feature `gorm:"-" json:"featureList,omitempty"`
 }
 

--- a/backend/pkg/repository/clickhouse/dao_query_rows.go
+++ b/backend/pkg/repository/clickhouse/dao_query_rows.go
@@ -3,7 +3,12 @@
 
 package clickhouse
 
-import core "github.com/CloudDetail/apo/backend/pkg/core"
+import (
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+)
 
 func (ch *chRepo) queryRowsData(ctx core.Context, sql string) ([]map[string]any, error) {
 	rows, err := ch.GetContextDB(ctx).Query(ctx.GetContext(), sql)
@@ -11,25 +16,71 @@ func (ch *chRepo) queryRowsData(ctx core.Context, sql string) ([]map[string]any,
 		return nil, err
 	}
 	defer rows.Close()
+	return rowsToMapSlice(rows)
+}
 
-	columns := rows.Columns()
-	results := make([]map[string]interface{}, 0)
-	for rows.Next() {
-		values := make([]interface{}, len(columns))
-		valuePtrs := make([]interface{}, len(columns))
-		for i := range values {
-			valuePtrs[i] = &values[i]
+func rowsToMapSlice(rows driver.Rows) ([]map[string]any, error) {
+	columnNames := rows.Columns()
+	columnTypes := rows.ColumnTypes()
+	var result []map[string]any
+
+	valuePtrs := make([]any, len(columnNames))
+	for i, colType := range columnTypes {
+		switch colType.DatabaseTypeName() {
+		case "DateTime64", "DateTime", "DateTime64(9)":
+			valuePtrs[i] = new(time.Time)
+		case "UInt64":
+			valuePtrs[i] = new(uint64)
+		case "Int64":
+			valuePtrs[i] = new(int64)
+		case "UInt32":
+			valuePtrs[i] = new(uint32)
+		case "Int32":
+			valuePtrs[i] = new(int32)
+		case "Float64":
+			valuePtrs[i] = new(float64)
+		case "Float32":
+			valuePtrs[i] = new(float32)
+		case "Nullable(String)", "String", "FixedString", "LowCardinality(String)":
+			valuePtrs[i] = new(string)
+		case "UUID":
+			valuePtrs[i] = new(string)
+		default:
+			valuePtrs[i] = new(string)
 		}
+	}
+
+	for rows.Next() {
 		if err := rows.Scan(valuePtrs...); err != nil {
 			return nil, err
 		}
 
-		entry := make(map[string]interface{})
-
-		for i, col := range columns {
-			entry[col] = values[i]
+		rowMap := make(map[string]any, len(columnNames))
+		for i, name := range columnNames {
+			switch val := valuePtrs[i].(type) {
+			case *time.Time:
+				rowMap[name] = *val
+			case *uint64:
+				rowMap[name] = *val
+			case *int64:
+				rowMap[name] = *val
+			case *uint32:
+				rowMap[name] = *val
+			case *int32:
+				rowMap[name] = *val
+			case *float64:
+				rowMap[name] = *val
+			case *float32:
+				rowMap[name] = *val
+			case *string:
+				rowMap[name] = *val
+			case *any:
+				rowMap[name] = *val
+			default:
+				rowMap[name] = ""
+			}
 		}
-		results = append(results, entry)
+		result = append(result, rowMap)
 	}
-	return results, nil
+	return result, nil
 }

--- a/backend/pkg/repository/clickhouse/dao_query_rows.go
+++ b/backend/pkg/repository/clickhouse/dao_query_rows.go
@@ -46,6 +46,7 @@ func rowsToMapSlice(rows driver.Rows) ([]map[string]any, error) {
 		case "UUID":
 			valuePtrs[i] = new(string)
 		default:
+			// TODO support clickhouse Map
 			valuePtrs[i] = new(string)
 		}
 	}
@@ -74,9 +75,8 @@ func rowsToMapSlice(rows driver.Rows) ([]map[string]any, error) {
 				rowMap[name] = *val
 			case *string:
 				rowMap[name] = *val
-			case *any:
-				rowMap[name] = *val
 			default:
+				// impossible branch,type must be handled above
 				rowMap[name] = ""
 			}
 		}

--- a/backend/pkg/repository/database/dao_role.go
+++ b/backend/pkg/repository/database/dao_role.go
@@ -172,10 +172,6 @@ type userRole struct {
 }
 
 func (repo *daoRepo) getRoleByUserID(ctx core.Context, userID ...int64) (userRoleMap, error) {
-	// var userRoles []profile.Role
-	// err := repo.GetContextDB(ctx).Where("user_id IN ?", userID).Order("user_id").Find(&userRoles).Error
-	// return userRoles, err
-
 	var userRoles []userRole
 	err := repo.GetContextDB(ctx).Model(&profile.UserRole{}).
 		Select("user_id", "role.role_id", "role_name", "description").

--- a/backend/pkg/repository/database/dao_role.go
+++ b/backend/pkg/repository/database/dao_role.go
@@ -152,3 +152,34 @@ func (repo *daoRepo) RoleGranted(ctx core.Context, roleID int) (bool, error) {
 
 	return count > 0, nil
 }
+
+// userID -> roles
+type userRoleMap = map[int64][]profile.Role
+type userRole struct {
+	UserID int64 `gorm:"column:user_id"`
+	profile.Role
+}
+
+func (repo *daoRepo) getRoleByUserID(ctx core.Context, userID ...int64) (userRoleMap, error) {
+	// var userRoles []profile.Role
+	// err := repo.GetContextDB(ctx).Where("user_id IN ?", userID).Order("user_id").Find(&userRoles).Error
+	// return userRoles, err
+
+	var userRoles []userRole
+	err := repo.GetContextDB(ctx).Model(&profile.UserRole{}).
+		Select("user_id", "role.role_id", "role_name", "description").
+		Where("user_id IN ?", userID).
+		Joins("LEFT JOIN role ON user_role.role_id = role.role_id").
+		Order("user_id").
+		Scan(&userRoles).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	userRoleMap := make(userRoleMap)
+	for _, userRole := range userRoles {
+		userRoleMap[userRole.UserID] = append(userRoleMap[userRole.UserID], userRole.Role)
+	}
+	return userRoleMap, nil
+}

--- a/backend/pkg/repository/database/dao_role.go
+++ b/backend/pkg/repository/database/dao_role.go
@@ -154,7 +154,18 @@ func (repo *daoRepo) RoleGranted(ctx core.Context, roleID int) (bool, error) {
 }
 
 // userID -> roles
-type userRoleMap = map[int64][]profile.Role
+type userRoleMap map[int64][]profile.Role
+
+func (m userRoleMap) Get(userID int64) []profile.Role {
+	if m == nil {
+		return []profile.Role{}
+	}
+	if v, find := m[userID]; find {
+		return v
+	}
+	return []profile.Role{}
+}
+
 type userRole struct {
 	UserID int64 `gorm:"column:user_id"`
 	profile.Role

--- a/backend/pkg/repository/database/dao_team.go
+++ b/backend/pkg/repository/database/dao_team.go
@@ -276,11 +276,15 @@ func (repo *daoRepo) getUsersIDNameByTeamIDs(ctx core.Context, teamIDs ...int64)
 		return nil, err
 	}
 
+	userIdSet := make(map[int64]struct{}, len(user2Teams))
 	userIds := make([]int64, 0, len(user2Teams))
 	for _, user2Team := range user2Teams {
-		userIds = append(userIds, user2Team.UserID)
+		if _, exists := userIdSet[user2Team.UserID]; !exists {
+			userIdSet[user2Team.UserID] = struct{}{}
+			userIds = append(userIds, user2Team.UserID)
+		}
 	}
-
+	
 	users, err := repo.GetUsersInfoWithoutTeamAndRole(ctx, userIds)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/repository/database/dao_team.go
+++ b/backend/pkg/repository/database/dao_team.go
@@ -214,7 +214,18 @@ func (repo *daoRepo) GetTeamUserList(ctx core.Context, teamID int64) ([]profile.
 	return users, err
 }
 
-type userTeamMap = map[int64][]profile.Team
+type userTeamMap map[int64][]profile.Team
+
+func (m userTeamMap) Get(userID int64) []profile.Team {
+	if m == nil {
+		return []profile.Team{}
+	}
+	if v, find := m[userID]; find {
+		return v
+	}
+	return []profile.Team{}
+}
+
 type userTeam struct {
 	UserID int64 `gorm:"column:user_id"`
 	profile.Team

--- a/backend/pkg/repository/database/dao_user.go
+++ b/backend/pkg/repository/database/dao_user.go
@@ -235,7 +235,7 @@ func (repo *daoRepo) GetUserInfo(ctx core.Context, userID int64) (profile.User, 
 	if err != nil {
 		return user, err
 	}
-	user.RoleList = roleList[userID]
+	user.RoleList = roleList.Get(userID)
 
 	teamList, err := repo.getTeamByUserID(ctx, userID)
 	if err != nil {
@@ -292,6 +292,25 @@ func (repo *daoRepo) GetUserList(ctx core.Context, req *request.GetUserListReque
 	err = query.Find(&users).Error
 	if err != nil {
 		return nil, 0, err
+	}
+
+	var userIDs []int64
+	for _, user := range users {
+		userIDs = append(userIDs, user.UserID)
+	}
+
+	rolesMap, err := repo.getRoleByUserID(ctx, userIDs...)
+	if err != nil {
+		return nil, 0, err
+	}
+	teamMap, err := repo.getTeamByUserID(ctx, userIDs...)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for i := 0; i < len(users); i++ {
+		users[i].RoleList = rolesMap.Get(users[i].UserID)
+		users[i].TeamList = teamMap.Get(users[i].UserID)
 	}
 
 	return users, count, nil

--- a/backend/pkg/repository/database/dao_user.go
+++ b/backend/pkg/repository/database/dao_user.go
@@ -241,7 +241,7 @@ func (repo *daoRepo) GetUserInfo(ctx core.Context, userID int64) (profile.User, 
 	if err != nil {
 		return user, err
 	}
-	user.TeamList = teamList[userID]
+	user.TeamList = teamList.Get(userID)
 
 	return user, err
 }

--- a/backend/pkg/repository/database/dao_user.go
+++ b/backend/pkg/repository/database/dao_user.go
@@ -246,6 +246,15 @@ func (repo *daoRepo) GetUserInfo(ctx core.Context, userID int64) (profile.User, 
 	return user, err
 }
 
+func (repo *daoRepo) GetUsersInfoWithoutTeamAndRole(ctx core.Context, userIDs []int64) ([]profile.User, error) {
+	var users []profile.User
+	err := repo.GetContextDB(ctx).
+		Select(userFieldSql).
+		Where("user_id IN ?", userIDs).
+		Find(&users).Error
+	return users, err
+}
+
 func (repo *daoRepo) GetAnonymousUser(ctx core.Context) (profile.User, error) {
 	var user profile.User
 	err := repo.GetContextDB(ctx).Select(userFieldSql).Where("username = ?", AnonymousUsername).Find(&user).Error


### PR DESCRIPTION
## Summary by Sourcery

Standardize loading of user-role and user-team relationships by replacing GORM preloads with explicit DAO methods, update models to remove many-to-many tags, and refactor ClickHouse query scanning with a dynamic rowsToMapSlice helper.

Enhancements:
- Replace GORM Preloads for RoleList, TeamList, and Team.UserList with explicit DAO methods (getRoleByUserID, getTeamByUserID, getUsersIDNameByTeamIDs).
- Remove many-to-many GORM tags from User and Team models and manually populate relationship fields in dao_user and dao_team.
- Introduce GetUsersInfoWithoutTeamAndRole helper to fetch base user data for relationship resolution.
- Refactor ClickHouse queryRowsData to use a new rowsToMapSlice function that dynamically scans columns by type into map[string]any.