### PR TITLE
Fix/adjust alert group name

### DIFF
--- a/backend/pkg/model/alert_event_tags.go
+++ b/backend/pkg/model/alert_event_tags.go
@@ -115,6 +115,10 @@ var dbIPRegex = regexp.MustCompile(`tcp\((\d+\.\d+\.\d+\.\d+):.*\)`)
 var dbPortRegex = regexp.MustCompile(`tcp\(.*:(\d+)\)`)
 
 func (a *AlertEvent) GetDatabaseURL() string {
+	if dbURL, find := a.Tags["dbURL"]; find && len(dbURL) > 0 {
+		return dbURL
+	}
+
 	if dbURL, find := a.Tags["dbHost"]; find && len(dbURL) > 0 {
 		return dbURL
 	}

--- a/backend/pkg/model/alert_event_tags.go
+++ b/backend/pkg/model/alert_event_tags.go
@@ -119,7 +119,7 @@ func (a *AlertEvent) GetDatabaseURL() string {
 		return dbURL
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.RawTags["instance"]
 		return dbURLRegex.FindString(instance)
 	}
@@ -131,7 +131,7 @@ func (a *AlertEvent) GetDatabaseIP() string {
 		return dbIP
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.RawTags["instance"]
 		return dbIPRegex.FindString(instance)
 	}
@@ -143,7 +143,7 @@ func (a *AlertEvent) GetDatabasePort() string {
 		return dbPort
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.RawTags["instance"]
 		return dbPortRegex.FindString(instance)
 	}

--- a/backend/pkg/model/integration/alert/alert_event_tags.go
+++ b/backend/pkg/model/integration/alert/alert_event_tags.go
@@ -134,6 +134,10 @@ var dbIPRegex = regexp.MustCompile(`tcp\((\d+\.\d+\.\d+\.\d+):.*\)`)
 var dbPortRegex = regexp.MustCompile(`tcp\(.*:(\d+)\)`)
 
 func (a *Alert) GetDatabaseURL() string {
+	if dbURL, find := a.EnrichTags["dbURL"]; find && len(dbURL) > 0 {
+		return dbURL
+	}
+
 	if dbURL, find := a.EnrichTags["dbHost"]; find && len(dbURL) > 0 {
 		return dbURL
 	}

--- a/backend/pkg/model/integration/alert/alert_event_tags.go
+++ b/backend/pkg/model/integration/alert/alert_event_tags.go
@@ -138,7 +138,7 @@ func (a *Alert) GetDatabaseURL() string {
 		return dbURL
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.GetStringTagWithRaw("instance")
 		return dbURLRegex.FindString(instance)
 	}
@@ -150,7 +150,7 @@ func (a *Alert) GetDatabaseIP() string {
 		return dbIP
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.GetStringTagWithRaw("instance")
 		return dbIPRegex.FindString(instance)
 	}
@@ -162,7 +162,7 @@ func (a *Alert) GetDatabasePort() string {
 		return dbPort
 	}
 
-	if a.Group == "database" {
+	if a.Group == "middleware" {
 		instance := a.GetStringTagWithRaw("instance")
 		return dbPortRegex.FindString(instance)
 	}

--- a/backend/pkg/repository/prometheus/dao_db_instances.go
+++ b/backend/pkg/repository/prometheus/dao_db_instances.go
@@ -23,7 +23,7 @@ func (repo *promRepo) GetDescendantDatabase(ctx core.Context, startTime int64, e
 
 	pql := fmt.Sprintf(
 		TEMPLATE_GET_DESCENDANT_DATABASE_BY_SERVICE,
-		fmt.Sprintf("svc_name=\"%s\",content_key=\"%s\"", serviceName, endpoint),
+		fmt.Sprintf("svc_name=\"%s\"", serviceName),
 		vec, vec,
 	)
 


### PR DESCRIPTION
## Summary by Sourcery

Prioritize explicit dbURL tag and update group matching logic for database extraction in Alert and AlertEvent, and simplify Prometheus descendant database query by removing the content_key filter.

Bug Fixes:
- Prioritize explicit dbURL tag when extracting database URL in AlertEvent and Alert
- Change alert group check from "database" to "middleware" for database URL, IP, and port extraction in AlertEvent
- Prioritize explicit dbURL tag when extracting database URL in Alert
- Change alert group check from "database" to "middleware" for database URL, IP, and port extraction in Alert
- Remove redundant content_key filter from Prometheus descendant database query