### PR TITLE
fix: add correct interval for workflow search

### DIFF
--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -92,6 +92,7 @@ type Config struct {
 		APIKeys struct {
 			AlertCheck    string `mapstructure:"alert_check"`
 			AlertClassify string `mapstructure:"alert_classify"`
+			AlertAnalyze  string `mapstructure:"alert_analyze"`
 		} `mapstructure:"api_keys"`
 		FlowIDs struct {
 			AlertCheck        string `mapstructure:"alert_check"`

--- a/backend/pkg/model/integration/alert/alert_event_processed.go
+++ b/backend/pkg/model/integration/alert/alert_event_processed.go
@@ -36,6 +36,10 @@ type WorkflowDetail struct {
 
 	// Deprecated: use [Validity] instead, will remove after 1.7.x
 	IsValid string `json:"isValid" ch:"is_valid"`
+
+	AlertDirection string `json:"alertDirection" ch:"alert_direction"`
+	AnalyzeRunID   string `json:"analyzeRunId" ch:"analyze_run_id"`
+	AnalyzeErr     string `json:"analyzeErr" ch:"analyze_err"`
 }
 
 type NotifyDetail struct {

--- a/backend/pkg/model/workflow_records.go
+++ b/backend/pkg/model/workflow_records.go
@@ -17,6 +17,10 @@ type WorkflowRecord struct {
 	RoundedTime int64 `json:"-" ch:"rounded_time"`
 
 	InputRef any `json:"-" ch:"-"`
+
+	AlertDirection string `json:"alertDirection" ch:"alert_direction"`
+	AnalyzeRunID   string `json:"analyzeRunId" ch:"analyze_run_id"`
+	AnalyzeErr     string `json:"analyzeErr" ch:"analyze_err"`
 }
 
 type AlertNotifyRecord struct {

--- a/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
@@ -210,9 +210,10 @@ func (ch *chRepo) GetRelatedAlertEvents(ctx core.Context, req *request.GetAlertD
 		req.Pagination.CurrentPage = int(index)/req.Pagination.PageSize + 1
 	}
 
-	intervalMicro := int64(5*time.Minute) / 1e3
+	intervalMicro := int64(cacheMinutes) * int64(time.Minute) / 1e3
+	endTime := req.EndTime/1e6 + int64(5*time.Minute)/1e9
 	recordFilter := NewQueryBuilder().
-		Between("created_at", (req.StartTime-intervalMicro)/1e6, (req.EndTime+intervalMicro)/1e6).
+		Between("created_at", (req.StartTime-intervalMicro)/1e6, endTime).
 		Equals("ref", req.AlertID)
 
 	resultLimit := NewByLimitBuilder().
@@ -220,7 +221,7 @@ func (ch *chRepo) GetRelatedAlertEvents(ctx core.Context, req *request.GetAlertD
 		Limit(req.Pagination.PageSize).Offset(offSet)
 
 	notifyFilter := NewQueryBuilder().
-		Between("created_at", (req.StartTime-intervalMicro)/1e6, (req.EndTime+intervalMicro)/1e6).
+		Between("created_at", (req.StartTime-intervalMicro)/1e6, endTime).
 		Equals("alert_id", req.AlertID)
 
 	sql := fmt.Sprintf(SQL_GET_RELEATED_ALERT_EVENT,

--- a/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
@@ -60,6 +60,9 @@ SELECT ae.id as id,
   fw.importance as importance,
   fw.output as output,
   fw.created_at as last_check_at,
+  fw.alert_direction,
+  fw.analyze_run_id,
+  fw.analyze_err,
   le.status as last_status,
   CASE
     WHEN output = 'false' THEN 'true'
@@ -117,6 +120,9 @@ SELECT ae.id as id,
   fw.created_at as last_check_at,
   fw.importance as importance,
   fw.output as output,
+  fw.alert_direction,
+  fw.analyze_run_id,
+  fw.analyze_err,
   CASE
     WHEN output = 'false' THEN 'true'
     WHEN output = 'true' THEN 'false'

--- a/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_detail.go
@@ -60,9 +60,9 @@ SELECT ae.id as id,
   fw.importance as importance,
   fw.output as output,
   fw.created_at as last_check_at,
-  fw.alert_direction,
-  fw.analyze_run_id,
-  fw.analyze_err,
+  fw.alert_direction as alert_direction,
+  fw.analyze_run_id as analyze_run_id,
+  fw.analyze_err as analyze_err,
   le.status as last_status,
   CASE
     WHEN output = 'false' THEN 'true'
@@ -120,9 +120,9 @@ SELECT ae.id as id,
   fw.created_at as last_check_at,
   fw.importance as importance,
   fw.output as output,
-  fw.alert_direction,
-  fw.analyze_run_id,
-  fw.analyze_err,
+  fw.alert_direction as alert_direction,
+  fw.analyze_run_id as analyze_run_id,
+  fw.analyze_err as analyze_err,
   CASE
     WHEN output = 'false' THEN 'true'
     WHEN output = 'true' THEN 'false'

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -183,8 +183,9 @@ func (ch *chRepo) GetAlertEventWithWorkflowRecord(ctx core.Context, req *request
 	}
 
 	var count uint64
-	intervalMicro := int64(5*time.Minute) / 1e3
-	recordFilter := NewQueryBuilder().Between("created_at", (req.StartTime-intervalMicro)/1e6, (req.EndTime+intervalMicro)/1e6)
+	intervalMicro := int64(cacheMinutes) * int64(time.Minute) / 1e3
+	endTime := req.EndTime/1e6 + int64(5*time.Minute)/1e9
+	recordFilter := NewQueryBuilder().Between("created_at", (req.StartTime-intervalMicro)/1e6, endTime)
 
 	resultFilter := NewQueryBuilder()
 
@@ -261,9 +262,10 @@ func getSqlAndValueForSortedAlertEvent(req *request.AlertEventSearchRequest, cac
 			Limit(req.Pagination.PageSize)
 	}
 
-	intervalMicro := int64(5*time.Minute) / 1e3
+	intervalMicro := int64(cacheMinutes) * int64(time.Minute) / 1e3
+	endTime := req.EndTime/1e6 + int64(5*time.Minute)/1e9
 	recordFilter := NewQueryBuilder().
-		Between("created_at", (req.StartTime-intervalMicro)/1e6, (req.EndTime+intervalMicro)/1e6)
+		Between("created_at", (req.StartTime-intervalMicro)/1e6, endTime)
 
 	resultFilter := NewQueryBuilder()
 	// TODO remove in v1.9.x
@@ -302,9 +304,10 @@ func (ch *chRepo) GetAlertEventCounts(ctx core.Context, req *request.AlertEventS
 		NotGreaterThan("end_time", req.EndTime/1e6)
 
 	var counts []_alertEventCount
-	intervalMicro := int64(5*time.Minute) / 1e3
+	intervalMicro := int64(cacheMinutes) * int64(time.Minute) / 1e3
+	endTime := req.EndTime/1e6 + int64(5*time.Minute)/1e9
 	recordFilter := NewQueryBuilder().
-		Between("created_at", (req.StartTime-intervalMicro)/1e6, (req.EndTime+intervalMicro)/1e6)
+		Between("created_at", (req.StartTime-intervalMicro)/1e6, endTime)
 	countSql := fmt.Sprintf(SQL_GET_ALERTEVENT_COUNTS,
 		alertFilter.String(),
 		recordFilter.String(),

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -117,6 +117,9 @@ SELECT
   fw.importance,
   fw.created_at as last_check_at,
   fw.output,
+  fw.alert_direction,
+  fw.analyze_run_id,
+  fw.analyze_err,
   CASE
     WHEN output = 'false' THEN 'true'
     WHEN output = 'true' THEN 'false'

--- a/backend/pkg/repository/clickhouse/dao_workflow_records.go
+++ b/backend/pkg/repository/clickhouse/dao_workflow_records.go
@@ -12,7 +12,7 @@ import (
 
 func (ch *chRepo) AddWorkflowRecord(ctx core.Context, record *model.WorkflowRecord) error {
 	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
-		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at, rounded_time)
+		INSERT INTO workflow_records (workflow_run_id, workflow_id, workflow_name, ref, input, output, created_at, rounded_time, alert_direction,analyze_run_id,analyze_err)
 		VALUES
 	`)
 	if err != nil {
@@ -27,6 +27,9 @@ func (ch *chRepo) AddWorkflowRecord(ctx core.Context, record *model.WorkflowReco
 		record.Output,
 		time.UnixMicro(record.CreatedAt),
 		time.UnixMicro(record.RoundedTime),
+		record.AlertDirection,
+		record.AnalyzeRunID,
+		record.AnalyzeErr,
 	); err != nil {
 		return err
 	}

--- a/backend/pkg/repository/dify/async_alert_check.go
+++ b/backend/pkg/repository/dify/async_alert_check.go
@@ -32,7 +32,9 @@ type AlertCheckConfig struct {
 	FlowName      string
 	APIKey        string
 	Authorization string
-	User          string
+	AnalyzeAuth   string
+
+	User string
 
 	Sampling       string
 	CacheMinutes   int

--- a/backend/pkg/repository/dify/async_alert_check.go
+++ b/backend/pkg/repository/dify/async_alert_check.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/model"
@@ -82,7 +83,7 @@ func (c *checkWorkers) Run(ctx context.Context, client *DifyClient) (<-chan *mod
 		go worker.run(client, c.eventInput.Ch, rChan, &wg)
 	}
 
-	go waitForShutDown(ctx, c.eventInput, rChan, &wg)
+	go waitForShutDown(ctx, c.eventInput, rChan, &wg, c.logger)
 	return rChan, nil
 }
 
@@ -140,7 +141,7 @@ func (s *sampleWithFirstRecord) Run(
 		return nil, err
 	}
 	cronTab.Start()
-	go waitForShutDown(ctx, s.eventInput, rChan, &wg)
+	go waitForShutDown(ctx, s.eventInput, rChan, &wg, s.logger)
 	return rChan, nil
 }
 
@@ -216,7 +217,7 @@ func (s *sampleWithLastRecord) Run(
 		return nil, err
 	}
 	cronTab.Start()
-	go waitForShutDown(ctx, s.eventInput, rChan, &wg)
+	go waitForShutDown(ctx, s.eventInput, rChan, &wg, s.logger)
 	return rChan, nil
 }
 
@@ -260,15 +261,26 @@ func (s *sampleWithLastRecord) submit() {
 	}()
 }
 
+var runner atomic.Int32
+
 func waitForShutDown(
 	ctx context.Context,
 	eventInput *inputChan,
 	rChan chan *model.WorkflowRecord,
 	wg *sync.WaitGroup,
+	logger *zap.Logger,
 ) {
-	<-ctx.Done()
-	eventInput.IsShutDown = true
-	close(eventInput.Ch)
-	wg.Wait()
-	close(rChan)
+	ticker := time.NewTicker(30 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			eventInput.IsShutDown = true
+			close(eventInput.Ch)
+			wg.Wait()
+			close(rChan)
+		case <-ticker.C:
+			logger.Debug("alert waiting for check in dify workflow", zap.Int32("runningWorker", runner.Load()), zap.Int("remainCount", len(eventInput.Ch)))
+		}
+	}
 }

--- a/backend/pkg/repository/dify/async_alert_check.go
+++ b/backend/pkg/repository/dify/async_alert_check.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	"github.com/robfig/cron/v3"
 	"go.uber.org/zap"
 )
@@ -36,6 +37,8 @@ type AlertCheckConfig struct {
 	Sampling       string
 	CacheMinutes   int
 	MaxConcurrency int
+
+	Prom prometheus.Repo
 }
 
 func newAsyncAlertCheck(cfg *AlertCheckConfig, logger *zap.Logger) asyncAlertCheck {

--- a/backend/pkg/repository/dify/async_workflow.go
+++ b/backend/pkg/repository/dify/async_workflow.go
@@ -26,8 +26,8 @@ func (r *difyRepo) PrepareAsyncAlertCheckWorkflow(cfg *AlertCheckConfig, logger 
 	if cfg.MaxConcurrency <= 0 {
 		cfg.MaxConcurrency = 1
 	}
-	r.AlertCheckCFG = *cfg
-	r.asyncAlertCheck = newAsyncAlertCheck(&r.AlertCheckCFG, logger)
+	r.AlertCheckCFG = cfg
+	r.asyncAlertCheck = newAsyncAlertCheck(r.AlertCheckCFG, logger)
 	records, err = r.asyncAlertCheck.Run(context.Background(), r.cli)
 	if err != nil {
 		r.asyncAlertCheck = nil
@@ -42,8 +42,8 @@ func (r *difyRepo) SubmitAlertEvents(events []alert.AlertEvent) {
 	r.asyncAlertCheck.AddEvents(events)
 }
 
-func DefaultAlertCheckConfig() AlertCheckConfig {
-	return AlertCheckConfig{
+func DefaultAlertCheckConfig() *AlertCheckConfig {
+	return &AlertCheckConfig{
 		Sampling:       "first",
 		CacheMinutes:   20,
 		MaxConcurrency: 1,

--- a/backend/pkg/repository/dify/client.go
+++ b/backend/pkg/repository/dify/client.go
@@ -32,6 +32,19 @@ func (c *DifyClient) alertCheck(req *WorkflowRequest, authorization string, user
 	return nil, fmt.Errorf("alertCheck must be run in blocking mode")
 }
 
+func (c *DifyClient) alertAnalyze(req *WorkflowRequest, authorization string, user string) (*AlertAnalyzeResponse, error) {
+	req.ResponseMode = "blocking"
+	req.User = user
+	resp, err := c.WorkflowsRun(req, authorization)
+	if err != nil {
+		return nil, err
+	}
+	if resp, ok := resp.(*CompletionResponse); ok {
+		return &AlertAnalyzeResponse{resp}, err
+	}
+	return nil, fmt.Errorf("alertAnalyze must be run in blocking mode")
+}
+
 func (c *DifyClient) WorkflowsRun(req *WorkflowRequest, authorization string) (WorkflowResponse, error) {
 	jsonBytes, _ := json.Marshal(req)
 	fullReq, _ := http.NewRequest("POST", c.BaseURL+"/v1/workflows/run", bytes.NewReader(jsonBytes))
@@ -65,8 +78,6 @@ func (c *DifyClient) WorkflowsRun(req *WorkflowRequest, authorization string) (W
 	}
 	return nil, nil
 }
-
-
 
 var DefaultDifyFastHttpClient = &http.Client{
 	Transport: &http.Transport{

--- a/backend/pkg/repository/dify/dao.go
+++ b/backend/pkg/repository/dify/dao.go
@@ -45,7 +45,6 @@ type DifyRepo interface {
 
 	PrepareAsyncAlertCheckWorkflow(cfg *AlertCheckConfig, logger *zap.Logger) (records <-chan *model.WorkflowRecord, err error)
 	SubmitAlertEvents(events []alert.AlertEvent)
-
 	GetCacheMinutes() int
 	GetAlertCheckFlowID() string
 	GetAlertAnalyzeFlowID() string
@@ -59,7 +58,7 @@ type difyRepo struct {
 
 	asyncAlertCheck
 
-	AlertCheckCFG      AlertCheckConfig
+	AlertCheckCFG      *AlertCheckConfig
 	AlertAnalyzeFlowId string
 }
 

--- a/backend/pkg/repository/dify/service_tools.go
+++ b/backend/pkg/repository/dify/service_tools.go
@@ -1,0 +1,165 @@
+package dify
+
+import (
+	"time"
+
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
+	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
+)
+
+func tryGetAlertService(ctx core.Context, repo prometheus.Repo, event *alert.AlertEvent, startTime time.Time, endTime time.Time) ([]clickhouse.AlertService, error) {
+	var tryMethods = []func(core.Context, prometheus.Repo, *alert.AlertEvent, time.Time, time.Time) ([]clickhouse.AlertService, error){
+		tryGetAlertServiceByService,
+		tryGetAlertServiceByDB,
+		tryGetAlertServiceByK8sPod,
+		tryGetAlertServiceByVMProcess,
+		tryGetAlertServiceByInfraNode,
+	}
+	var endpoints []clickhouse.AlertService
+	for _, tryGetService := range tryMethods {
+		var err error
+		endpoints, err = tryGetService(ctx, repo, event, startTime, endTime)
+		if err == nil && len(endpoints) > 0 {
+			return endpoints, nil
+		}
+	}
+
+	return endpoints, nil
+}
+
+func tryGetAlertServiceByService(ctx core.Context, _ prometheus.Repo, event *alert.AlertEvent, _ time.Time, _ time.Time) ([]clickhouse.AlertService, error) {
+	serviceName := event.GetServiceNameTag()
+	if len(serviceName) == 0 {
+		return nil, nil
+	}
+
+	alertServices := []clickhouse.AlertService{
+		{
+			Service:  serviceName,
+			Endpoint: event.GetEndpointTag(),
+		},
+	}
+
+	return alertServices, nil
+}
+
+func tryGetAlertServiceByK8sPod(ctx core.Context, repo prometheus.Repo, event *alert.AlertEvent, startTime time.Time, endTime time.Time) ([]clickhouse.AlertService, error) {
+	podName := event.GetNetSrcPodTag()
+	namespace := event.GetK8sNamespaceTag()
+	if len(podName) == 0 || len(namespace) == 0 {
+		return nil, nil
+	}
+
+	// 通常也只会有一个Service
+	services, err := repo.GetServiceListByFilter(
+		ctx,
+		startTime, endTime,
+		prometheus.NamespacePQLFilter, namespace,
+		prometheus.PodPQLFilter, podName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var endpoints []clickhouse.AlertService
+	// 通常只有一个service
+	for _, service := range services {
+		// 不关系ContentKey
+		endpoints = append(endpoints, clickhouse.AlertService{
+			Service: service,
+		})
+	}
+
+	return endpoints, nil
+}
+
+func tryGetAlertServiceByVMProcess(ctx core.Context, repo prometheus.Repo, event *alert.AlertEvent, startTime time.Time, endTime time.Time) ([]clickhouse.AlertService, error) {
+	nodeName := event.GetNetSrcNodeTag()
+	pid := event.GetNetSrcPidTag()
+	if len(nodeName) == 0 || len(pid) == 0 {
+		return nil, nil
+	}
+
+	services, err := repo.GetServiceListByFilter(
+		ctx,
+		startTime, endTime,
+		prometheus.NodeNamePQLFilter, nodeName,
+		prometheus.PidPQLFilter, pid,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var endpoints []clickhouse.AlertService
+	for _, service := range services {
+		endpoints = append(endpoints, clickhouse.AlertService{
+			Service: service,
+		})
+	}
+
+	return endpoints, nil
+}
+
+func tryGetAlertServiceByInfraNode(ctx core.Context, repo prometheus.Repo, event *alert.AlertEvent, startTime time.Time, endTime time.Time) ([]clickhouse.AlertService, error) {
+	if event.Group != string(clickhouse.INFRA_GROUP) {
+		return nil, nil
+	}
+
+	nodeName := event.GetInfraNodeTag()
+	if len(nodeName) == 0 {
+		return nil, nil
+	}
+
+	services, err := repo.GetServiceListByFilter(
+		ctx,
+		startTime, endTime,
+		prometheus.NodeNamePQLFilter, nodeName,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var endpoints []clickhouse.AlertService
+	for _, service := range services {
+		endpoints = append(endpoints, clickhouse.AlertService{
+			Service: service,
+		})
+	}
+
+	return endpoints, nil
+}
+
+func tryGetAlertServiceByDB(ctx core.Context, repo prometheus.Repo, event *alert.AlertEvent, startTime time.Time, endTime time.Time) ([]clickhouse.AlertService, error) {
+	// 尝试获取数据库URL
+	dbURL := event.GetDatabaseURL()
+	dbIP := event.GetDatabaseIP()
+	dbPort := event.GetDatabasePort()
+	if len(dbURL) == 0 && len(dbIP) == 0 {
+		return nil, nil
+	}
+
+	// 查询受此数据库影响的服务
+	services, err := repo.GetServiceListByDatabase(
+		ctx,
+		startTime, endTime, dbURL, dbIP, dbPort)
+
+	if err != nil {
+		return nil, err
+	}
+	var endpoints []clickhouse.AlertService
+	endpoints = append(endpoints, clickhouse.AlertService{
+		DatabaseURL:  dbURL,
+		DatabaseIP:   dbIP,
+		DatabasePort: dbPort,
+	})
+	for _, service := range services {
+		endpoints = append(endpoints, clickhouse.AlertService{
+			Service: service,
+		})
+	}
+
+	return endpoints, nil
+}

--- a/backend/pkg/repository/dify/workflow_req.go
+++ b/backend/pkg/repository/dify/workflow_req.go
@@ -43,6 +43,10 @@ type ChunkCompletionResponse struct{}
 
 func (r *ChunkCompletionResponse) _WorkflowResponse() {}
 
+type AlertAnalyzeResponse struct {
+	resp *CompletionResponse
+}
+
 type AlertCheckResponse struct {
 	resp *CompletionResponse
 }
@@ -68,6 +72,29 @@ func (r *AlertCheckResponse) getOutput(defaultV string) string {
 	}
 
 	text, find := res["text"]
+	if !find {
+		return defaultV
+	}
+
+	return text
+}
+
+func (r *AlertAnalyzeResponse) WorkflowRunID() string {
+	return r.resp.WorkflowRunID
+}
+
+func (r *AlertAnalyzeResponse) getOutput(defaultV string) string {
+	if r.resp.Data.Status != "succeeded" {
+		return fmt.Sprintf("failed: status: %s, output: %s", r.resp.Data.Status, string(r.resp.Data.Outputs))
+	}
+
+	var res map[string]string
+	err := json.Unmarshal(r.resp.Data.Outputs, &res)
+	if err != nil {
+		return defaultV
+	}
+
+	text, find := res["alertDirection"]
 	if !find {
 		return defaultV
 	}

--- a/backend/pkg/repository/dify/workflow_worker.go
+++ b/backend/pkg/repository/dify/workflow_worker.go
@@ -73,7 +73,7 @@ func (w *worker) run(c *DifyClient, eventInput <-chan *alert.AlertEvent, results
 					record.AnalyzeErr = err.Error()
 					record.AlertDirection = "序列化告警分析参数失败"
 				} else {
-					resp, err := c.alertAnalyze(&WorkflowRequest{Inputs: inputStr}, w.Authorization, w.User)
+					resp, err := c.alertAnalyze(&WorkflowRequest{Inputs: inputStr}, w.AnalyzeAuth, w.User)
 					if err != nil {
 						record.AnalyzeRunID = resp.WorkflowRunID()
 						record.AnalyzeErr = err.Error()

--- a/backend/pkg/repository/dify/workflow_worker.go
+++ b/backend/pkg/repository/dify/workflow_worker.go
@@ -45,7 +45,9 @@ func (w *worker) run(c *DifyClient, eventInput <-chan *alert.AlertEvent, results
 		if w.expiredTS > 0 && endTime < w.expiredTS {
 			record = w.createExpiredRecord(event)
 		} else {
+			runner.Add(1)
 			record = w.doAlertCheck(event, endTime, c)
+			runner.Add(-1)
 		}
 		if !timeout.Stop() {
 			select {

--- a/backend/pkg/router/router.go
+++ b/backend/pkg/router/router.go
@@ -155,6 +155,8 @@ func NewHTTPServer(logger *zap.Logger) (*Server, error) {
 			MaxConcurrency: difyConfig.MaxConcurrency,
 			CacheMinutes:   difyConfig.CacheMinutes,
 			Sampling:       difyConfig.Sampling,
+
+			Prom: r.prom,
 		}, r.logger)
 		if err != nil {
 			logger.Error("failed to setup alertCheck workflow", zap.Error(err))

--- a/backend/pkg/router/router.go
+++ b/backend/pkg/router/router.go
@@ -148,9 +148,11 @@ func NewHTTPServer(logger *zap.Logger) (*Server, error) {
 	difyConfig := config.Get().Dify
 	if len(difyConfig.APIKeys.AlertCheck) > 0 {
 		records, err := r.dify.PrepareAsyncAlertCheckWorkflow(&dify.AlertCheckConfig{
-			FlowId:         difyConfig.FlowIDs.AlertCheck,
-			APIKey:         difyConfig.APIKeys.AlertCheck,
-			Authorization:  fmt.Sprintf("Bearer %s", difyConfig.APIKeys.AlertCheck),
+			FlowId:        difyConfig.FlowIDs.AlertCheck,
+			APIKey:        difyConfig.APIKeys.AlertCheck,
+			Authorization: fmt.Sprintf("Bearer %s", difyConfig.APIKeys.AlertCheck),
+			AnalyzeAuth:   fmt.Sprintf("Bearer %s", difyConfig.APIKeys.AlertAnalyze),
+
 			User:           "apo-backend",
 			MaxConcurrency: difyConfig.MaxConcurrency,
 			CacheMinutes:   difyConfig.CacheMinutes,


### PR DESCRIPTION
## Summary by Sourcery

Fix time interval calculation in workflow-related ClickHouse queries to use the configured cache window and proper unit conversions, and improve the async alert-check shutdown procedure with periodic progress logging and worker tracking. Refactor the alert-check configuration to use pointer semantics consistently.

Bug Fixes:
- Use configurable cacheMinutes instead of a fixed 5-minute window for workflow search intervals
- Correct endTime conversion for ClickHouse query boundaries

Enhancements:
- Periodically log shutdown progress every 30 seconds in the async alert-check routine
- Track active alert-check workers using an atomic counter
- Extend waitForShutDown to accept a logger for contextual debug output