### PR TITLE
Optimize log query performance

### DIFF
--- a/backend/pkg/repository/clickhouse/dao_query_log_context.go
+++ b/backend/pkg/repository/clickhouse/dao_query_log_context.go
@@ -43,7 +43,7 @@ func reverseSlice(s []map[string]any) {
 func (ch *chRepo) QueryLogContext(ctx core.Context, req *request.LogQueryContextRequest) ([]map[string]any, []map[string]any, error) {
 	//condition := NewQueryCondition(req.StartTime, req.EndTime, req.TimeField, req.Query)
 	logtime := req.Time / 1000000
-	timefront := fmt.Sprintf("toUnixTimestamp(timestamp) < %d AND  toUnixTimestamp(timestamp) > %d ", logtime, logtime-60)
+	timefront := fmt.Sprintf("timestamp < toDateTime(%d) AND  timestamp > toDateTime(%d) ", logtime, logtime-60)
 	tags := tagsCondition(req.Tags)
 	// check the first 50, reverse
 	bySqlfront := NewByLimitBuilder().
@@ -56,7 +56,7 @@ func (ch *chRepo) QueryLogContext(ctx core.Context, req *request.LogQueryContext
 		front = []map[string]any{}
 	}
 	reverseSlice(front)
-	timeend := fmt.Sprintf("toUnixTimestamp(timestamp) >= %d AND toUnixTimestamp(timestamp) < %d ", logtime, logtime+60)
+	timeend := fmt.Sprintf("timestamp >= toDateTime(%d) AND timestamp < toDateTime(%d) ", logtime, logtime+60)
 	bySqlend := NewByLimitBuilder().
 		OrderBy("timestamp", true).
 		Limit(50).

--- a/backend/pkg/repository/clickhouse/sql_builder.go
+++ b/backend/pkg/repository/clickhouse/sql_builder.go
@@ -256,5 +256,5 @@ func (builder *ByLimitBuilder) String() string {
 }
 
 func NewQueryCondition(st, et int64, timeField, query string) string {
-	return fmt.Sprintf("toUnixTimestamp(`%s`) >= %d AND toUnixTimestamp(`%s`) < %d AND %s", timeField, st/1000000, timeField, et/1000000, query)
+	return fmt.Sprintf("`%s` >= toDateTime(%d) AND `%s` < toDateTime(%d) AND %s", timeField, st/1000000, timeField, et/1000000, query)
 }


### PR DESCRIPTION
## Summary by Sourcery

Optimize ClickHouse log queries by replacing toUnixTimestamp filters with direct DateTime comparisons using toDateTime to improve performance

Enhancements:
- Switch log context timestamp filters to use direct timestamp comparisons with toDateTime instead of toUnixTimestamp
- Update NewQueryCondition to apply range filters with toDateTime for consistent performance improvements