### PR TITLE
feat: add query appInfo Tags API

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -2505,6 +2505,98 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/dataplane/appinfo/tags": {
+            "get": {
+                "description": "Get app info tags.",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "summary": "Get app info tags.",
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.QueryAPPInfoTagsRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.QueryAPPInfoTagsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/appinfo/tags/values": {
+            "get": {
+                "description": "Get app info tag values.",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "summary": "Get app info tag values.",
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.QueryAPPInfoTagValuesRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.QueryAPPInfoTagValuesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/customtopology/create": {
             "post": {
                 "description": "Create custom topology.",
@@ -8064,14 +8156,14 @@ const docTemplate = `{
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "start time",
+                        "description": "start time, unit nanosecond",
                         "name": "startTime",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "end time",
+                        "description": "end time, unit nanosecond",
                         "name": "endTime",
                         "in": "query",
                         "required": true
@@ -12603,6 +12695,31 @@ const docTemplate = `{
                 "PF_Flags"
             ]
         },
+        "request.QueryAPPInfoTagValuesRequest": {
+            "type": "object",
+            "properties": {
+                "endTime": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "request.QueryAPPInfoTagsRequest": {
+            "type": "object",
+            "properties": {
+                "endTime": {
+                    "type": "integer"
+                },
+                "startTime": {
+                    "type": "integer"
+                }
+            }
+        },
         "request.QueryServiceNameRequest": {
             "type": "object",
             "required": [
@@ -14573,6 +14690,31 @@ const docTemplate = `{
                     "items": {
                         "type": "array",
                         "items": {}
+                    }
+                }
+            }
+        },
+        "response.QueryAPPInfoTagValuesResponse": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "response.QueryAPPInfoTagsResponse": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -2497,6 +2497,98 @@
                 }
             }
         },
+        "/api/dataplane/appinfo/tags": {
+            "get": {
+                "description": "Get app info tags.",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "summary": "Get app info tags.",
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.QueryAPPInfoTagsRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.QueryAPPInfoTagsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/appinfo/tags/values": {
+            "get": {
+                "description": "Get app info tag values.",
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "summary": "Get app info tag values.",
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.QueryAPPInfoTagValuesRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.QueryAPPInfoTagValuesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/customtopology/create": {
             "post": {
                 "description": "Create custom topology.",
@@ -8056,14 +8148,14 @@
                 "parameters": [
                     {
                         "type": "integer",
-                        "description": "start time",
+                        "description": "start time, unit nanosecond",
                         "name": "startTime",
                         "in": "query",
                         "required": true
                     },
                     {
                         "type": "integer",
-                        "description": "end time",
+                        "description": "end time, unit nanosecond",
                         "name": "endTime",
                         "in": "query",
                         "required": true
@@ -12595,6 +12687,31 @@
                 "PF_Flags"
             ]
         },
+        "request.QueryAPPInfoTagValuesRequest": {
+            "type": "object",
+            "properties": {
+                "endTime": {
+                    "type": "integer"
+                },
+                "key": {
+                    "type": "string"
+                },
+                "startTime": {
+                    "type": "integer"
+                }
+            }
+        },
+        "request.QueryAPPInfoTagsRequest": {
+            "type": "object",
+            "properties": {
+                "endTime": {
+                    "type": "integer"
+                },
+                "startTime": {
+                    "type": "integer"
+                }
+            }
+        },
         "request.QueryServiceNameRequest": {
             "type": "object",
             "required": [
@@ -14565,6 +14682,31 @@
                     "items": {
                         "type": "array",
                         "items": {}
+                    }
+                }
+            }
+        },
+        "response.QueryAPPInfoTagValuesResponse": {
+            "type": "object",
+            "properties": {
+                "label": {
+                    "type": "string"
+                },
+                "values": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "response.QueryAPPInfoTagsResponse": {
+            "type": "object",
+            "properties": {
+                "labels": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
                     }
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -2370,6 +2370,22 @@ definitions:
     x-enum-varnames:
     - PF_Labels
     - PF_Flags
+  request.QueryAPPInfoTagValuesRequest:
+    properties:
+      endTime:
+        type: integer
+      key:
+        type: string
+      startTime:
+        type: integer
+    type: object
+  request.QueryAPPInfoTagsRequest:
+    properties:
+      endTime:
+        type: integer
+      startTime:
+        type: integer
+    type: object
   request.QueryServiceNameRequest:
     properties:
       cluster:
@@ -3684,6 +3700,22 @@ definitions:
         items:
           items: {}
           type: array
+        type: array
+    type: object
+  response.QueryAPPInfoTagValuesResponse:
+    properties:
+      label:
+        type: string
+      values:
+        items:
+          type: string
+        type: array
+    type: object
+  response.QueryAPPInfoTagsResponse:
+    properties:
+      labels:
+        items:
+          type: string
         type: array
     type: object
   response.QueryChartResult:
@@ -5612,6 +5644,66 @@ paths:
       summary: Get user's assigned data group.
       tags:
       - API.data
+  /api/dataplane/appinfo/tags:
+    get:
+      consumes:
+      - application/x-www-form-urlencoded
+      description: Get app info tags.
+      parameters:
+      - description: Request information
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.QueryAPPInfoTagsRequest'
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.QueryAPPInfoTagsResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
+      summary: Get app info tags.
+      tags:
+      - API.dataplane
+  /api/dataplane/appinfo/tags/values:
+    get:
+      consumes:
+      - application/x-www-form-urlencoded
+      description: Get app info tag values.
+      parameters:
+      - description: Request information
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.QueryAPPInfoTagValuesRequest'
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.QueryAPPInfoTagValuesResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
+      summary: Get app info tag values.
+      tags:
+      - API.dataplane
   /api/dataplane/customtopology/create:
     post:
       consumes:
@@ -9310,12 +9402,12 @@ paths:
       - application/x-www-form-urlencoded
       description: get span execution consumption
       parameters:
-      - description: start time
+      - description: start time, unit nanosecond
         in: query
         name: startTime
         required: true
         type: integer
-      - description: end time
+      - description: end time, unit nanosecond
         in: query
         name: endTime
         required: true

--- a/backend/pkg/api/dataplane/func_queryappinfotags.go
+++ b/backend/pkg/api/dataplane/func_queryappinfotags.go
@@ -1,0 +1,47 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// QueryAPPInfoTags Get app info tags.
+// @Summary Get app info tags.
+// @Description Get app info tags.
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.QueryAPPInfoTagsRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} response.QueryAPPInfoTagsResponse
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/appinfo/tags [get]
+func (h *handler) QueryAPPInfoTags() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.QueryAPPInfoTagsRequest)
+		if err := c.ShouldBindQuery(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		resp, err := h.dataplaneService.ListAPPInfoLabelsKeys(c, req)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.QueryAPPInfoTagsError,
+				err,
+			)
+			return
+		}
+		c.Payload(resp)
+	}
+}

--- a/backend/pkg/api/dataplane/func_queryappinfotags.go
+++ b/backend/pkg/api/dataplane/func_queryappinfotags.go
@@ -1,4 +1,4 @@
-// Copyright 2024 CloudDetail
+// Copyright 2025 CloudDetail
 // SPDX-License-Identifier: Apache-2.0
 package dataplane
 

--- a/backend/pkg/api/dataplane/func_queryappinfotagvalues.go
+++ b/backend/pkg/api/dataplane/func_queryappinfotagvalues.go
@@ -1,0 +1,47 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// QueryAPPInfoTagValues Get app info tag values.
+// @Summary Get app info tag values.
+// @Description Get app info tag values.
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.QueryAPPInfoTagValuesRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} response.QueryAPPInfoTagValuesResponse
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/appinfo/tags/values [get]
+func (h *handler) QueryAPPInfoTagValues() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.QueryAPPInfoTagValuesRequest)
+		if err := c.ShouldBindQuery(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		resp, err := h.dataplaneService.ListAPPInfoLabelValues(c, req)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.QueryAPPInfoValuesError,
+				err,
+			)
+			return
+		}
+		c.Payload(resp)
+	}
+}

--- a/backend/pkg/api/dataplane/func_queryappinfotagvalues.go
+++ b/backend/pkg/api/dataplane/func_queryappinfotagvalues.go
@@ -1,4 +1,4 @@
-// Copyright 2024 CloudDetail
+// Copyright 2025 CloudDetail
 // SPDX-License-Identifier: Apache-2.0
 package dataplane
 

--- a/backend/pkg/api/dataplane/handler.go
+++ b/backend/pkg/api/dataplane/handler.go
@@ -65,6 +65,16 @@ type Handler interface {
 	// @Tags API.dataplane
 	// @Router /api/dataplane/servicename/deleteRule [post]
 	DeleteServiceNameRule() core.HandlerFunc
+
+	// QueryAPPInfoTags Get app info tags.
+	// @Tags API.dataplane
+	// @Router /api/dataplane/appinfo/tags [get]
+	QueryAPPInfoTags() core.HandlerFunc
+
+	// QueryAPPInfoTagValues Get app info tag values.
+	// @Tags API.dataplane
+	// @Router /api/dataplane/appinfo/tags/values [get]
+	QueryAPPInfoTagValues() core.HandlerFunc
 }
 
 type handler struct {

--- a/backend/pkg/code/code.go
+++ b/backend/pkg/code/code.go
@@ -258,6 +258,8 @@ const (
 	ListServiceNameRuleError      = "B1806"
 	DeleteServiceNameRuleError    = "B1807"
 	ServiceNameRuleNotExistsError = "B1808"
+	QueryAPPInfoTagsError         = "B1809"
+	QueryAPPInfoValuesError       = "B1810"
 )
 
 func Text(lang string, code string) string {

--- a/backend/pkg/code/en.go
+++ b/backend/pkg/code/en.go
@@ -225,4 +225,6 @@ var enText = map[string]string{
 	ListServiceNameRuleError:      "Failed to list service name rule",
 	DeleteServiceNameRuleError:    "Failed to delete service name rule",
 	ServiceNameRuleNotExistsError: "service name rule not exists",
+	QueryAPPInfoTagsError:         "Failed to query APP info tags",
+	QueryAPPInfoValuesError:       "Failed to query APP info values",
 }

--- a/backend/pkg/code/zh-cn.go
+++ b/backend/pkg/code/zh-cn.go
@@ -227,4 +227,6 @@ var zhCnText = map[string]string{
 	ListServiceNameRuleError:      "列出所有服务名匹配规则失败",
 	DeleteServiceNameRuleError:    "删除服务名匹配规则失败",
 	ServiceNameRuleNotExistsError: "服务名匹配规则不存在",
+	QueryAPPInfoTagsError:         "查询APP信息标签失败",
+	QueryAPPInfoValuesError:       "查询APP信息值失败",
 }

--- a/backend/pkg/model/request/data_plane_req.go
+++ b/backend/pkg/model/request/data_plane_req.go
@@ -86,5 +86,17 @@ type SetServiceNameRuleConditionRequest struct {
 }
 
 type DeleteServiceNameRuleRequest struct {
-	RuleId int `form:"ruleId" binding:"required"`
+	RuleId int `form:"ruleId" json:"ruleId" binding:"required"`
+}
+
+type QueryAPPInfoTagsRequest struct {
+	StartTime int64 `form:"startTime" json:"startTime"`
+	EndTime   int64 `form:"endTime" json:"endTime"`
+}
+
+type QueryAPPInfoTagValuesRequest struct {
+	StartTime int64 `form:"startTime" json:"startTime"`
+	EndTime   int64 `form:"endTime" json:"endTime"`
+
+	Label string `form:"key" json:"key"`
 }

--- a/backend/pkg/model/response/dataplane_resp.go
+++ b/backend/pkg/model/response/dataplane_resp.go
@@ -74,6 +74,6 @@ type QueryAPPInfoTagsResponse struct {
 }
 
 type QueryAPPInfoTagValuesResponse struct {
-	Labels string   `json:"label"`
+	Label  string   `json:"label"`
 	Values []string `json:"values"`
 }

--- a/backend/pkg/model/response/dataplane_resp.go
+++ b/backend/pkg/model/response/dataplane_resp.go
@@ -68,3 +68,12 @@ type ListServiceNameRule struct {
 type CheckServiceNameRuleResponse struct {
 	Apps []*model.AppInfo `json:"apps"`
 }
+
+type QueryAPPInfoTagsResponse struct {
+	Labels []string `json:"labels"`
+}
+
+type QueryAPPInfoTagValuesResponse struct {
+	Labels string   `json:"label"`
+	Values []string `json:"values"`
+}

--- a/backend/pkg/repository/clickhouse/dao.go
+++ b/backend/pkg/repository/clickhouse/dao.go
@@ -141,6 +141,8 @@ type Repo interface {
 	WriteServiceTopology(ctx core.Context, timestamp int64, clusterId string, source string, topologies []*model.ServiceToplogy) error
 	GetToResolveApps(ctx core.Context) ([]*model.AppInfo, error)
 	WriteRelateApp(ctx core.Context, app *model.AppInfo) error
+	ListAppInfoLabelKeys(ctx core.Context, startTime, endTime int64) ([]string, error)
+	ListAppInfoLabelValues(ctx core.Context, startTime, endTime int64, key string) ([]string, error)
 
 	integration.Input
 }

--- a/backend/pkg/repository/clickhouse/dao_list_app_info_label_keys.go
+++ b/backend/pkg/repository/clickhouse/dao_list_app_info_label_keys.go
@@ -1,0 +1,73 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package clickhouse
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/CloudDetail/apo/backend/pkg/core"
+)
+
+const SQL_LIST_APP_INFO_LABEL_KEYS = `SELECT DISTINCT arrayJoin(mapKeys(labels)) AS key
+FROM originx_app_info
+%s`
+
+const SQL_LIST_APP_INFO_LABEL_VALUES = `SELECT DISTINCT %s AS value
+FROM originx_app_info
+%s`
+
+func (repo *chRepo) ListAppInfoLabelKeys(ctx core.Context, startTime, endTime int64) ([]string, error) {
+	qb := NewQueryBuilder().
+		Between("timestamp", startTime/1e6, endTime/1e6)
+
+	sql := fmt.Sprintf(SQL_LIST_APP_INFO_LABEL_KEYS, qb.String())
+	rows, err := repo.GetConn(ctx).Query(ctx.GetContext(), sql, qb.values...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var labelsKey string
+		if err := rows.Scan(&labelsKey); err != nil {
+			return nil, err
+		}
+		result = append(result, labelsKey)
+	}
+	return result, nil
+}
+
+func escapeAppInfoKeys(key string) string {
+	escapedKey := strings.ReplaceAll(key, `'`, `''`)
+	expr := `labels['` + escapedKey + `']`
+	escapedExpr := strings.ReplaceAll(expr, "`", "``")
+	return "`" + escapedExpr + "`"
+}
+
+func (repo *chRepo) ListAppInfoLabelValues(ctx core.Context, startTime, endTime int64, key string) ([]string, error) {
+	fb := NewFieldBuilder().
+		Alias(escapeAppInfoKeys(key), "value")
+
+	qb := NewQueryBuilder().
+		Between("timestamp", startTime/1e6, endTime/1e6)
+
+	sql := fmt.Sprintf(SQL_LIST_APP_INFO_LABEL_VALUES, fb.String(), qb.String())
+	rows, err := repo.GetConn(ctx).Query(ctx.GetContext(), sql, qb.values...)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+	var result []string
+	for rows.Next() {
+		var labelsValue string
+		if err := rows.Scan(&labelsValue); err != nil {
+			return nil, err
+		}
+		result = append(result, labelsValue)
+	}
+	return result, nil
+}

--- a/backend/pkg/services/dataplane/service.go
+++ b/backend/pkg/services/dataplane/service.go
@@ -30,13 +30,14 @@ type Service interface {
 	SetServiceNameRule(ctx core.Context, req *request.SetServiceNameRuleRequest) error
 	ListServiceNameRule(ctx core.Context) (*response.ListServiceNameRuleResponse, error)
 	DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error
+	ListAPPInfoLabelsKeys(ctx core.Context, req *request.QueryAPPInfoTagsRequest) (*response.QueryAPPInfoTagsResponse, error)
+	ListAPPInfoLabelValues(ctx core.Context, req *request.QueryAPPInfoTagValuesRequest) (*response.QueryAPPInfoTagValuesResponse, error)
 }
 
 type service struct {
 	chRepo   clickhouse.Repo
 	promRepo prometheus.Repo
 	dbRepo   database.Repo
-	
 }
 
 func New(

--- a/backend/pkg/services/dataplane/service_delete_servicename_rule.go
+++ b/backend/pkg/services/dataplane/service_delete_servicename_rule.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package dataplane
 
 import (
@@ -6,7 +9,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error{
+func (s *service) DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error {
 	exists, err := s.dbRepo.ServiceNameRuleExists(ctx, req.RuleId)
 	if err != nil {
 		return err

--- a/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
+++ b/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
@@ -25,7 +25,7 @@ func (s *service) ListAPPInfoLabelValues(ctx core.Context, req *request.QueryAPP
 		return nil, err
 	}
 	return &response.QueryAPPInfoTagValuesResponse{
-		Labels: req.Label,
+		Label:  req.Label,
 		Values: values,
 	}, nil
 }

--- a/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
+++ b/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package dataplane
 
 import (

--- a/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
+++ b/backend/pkg/services/dataplane/service_list_app_info_labels_keys.go
@@ -1,0 +1,28 @@
+package dataplane
+
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+	"github.com/CloudDetail/apo/backend/pkg/model/response"
+)
+
+func (s *service) ListAPPInfoLabelsKeys(ctx core.Context, req *request.QueryAPPInfoTagsRequest) (*response.QueryAPPInfoTagsResponse, error) {
+	labels, err := s.chRepo.ListAppInfoLabelKeys(ctx, req.StartTime, req.EndTime)
+	if err != nil {
+		return nil, err
+	}
+	return &response.QueryAPPInfoTagsResponse{
+		Labels: labels,
+	}, nil
+}
+
+func (s *service) ListAPPInfoLabelValues(ctx core.Context, req *request.QueryAPPInfoTagValuesRequest) (*response.QueryAPPInfoTagValuesResponse, error) {
+	values, err := s.chRepo.ListAppInfoLabelValues(ctx, req.StartTime, req.EndTime, req.Label)
+	if err != nil {
+		return nil, err
+	}
+	return &response.QueryAPPInfoTagValuesResponse{
+		Labels: req.Label,
+		Values: values,
+	}, nil
+}


### PR DESCRIPTION
## Summary by Sourcery

Add two new dataplane APIs to query application info tags and values, including request/response models, handlers, service and ClickHouse repository methods, error codes, and documentation updates

New Features:
- Introduce QueryAPPInfoTags endpoint to list application info tag keys within a specified time range
- Introduce QueryAPPInfoTagValues endpoint to list values for a given application info tag within a specified time range

Enhancements:
- Clarify in API docs that startTime and endTime are measured in nanoseconds
- Add error codes and translations for APP info tag querying failures

Documentation:
- Update Swagger/OpenAPI definitions and internal docs to include the new endpoints and their request/response schemas