### PR TITLE
fix: add clusterName into ScopeInfo

### DIFF
--- a/backend/pkg/model/datagroup/data_scope.go
+++ b/backend/pkg/model/datagroup/data_scope.go
@@ -35,6 +35,8 @@ type DataScope struct {
 
 	// Special Labels for this Scope
 	ScopeLabels
+
+	ClusterName string `gorm:"-" json:"clusterName,omitempty"`
 }
 
 type DataScopeWithFullName struct {
@@ -137,6 +139,27 @@ func (t *DataScopeTreeNode) GetScopeRef(scopeID string) *DataScopeTreeNode {
 		}
 	}
 	return nil
+}
+
+func FillWithClusterName(scopes []DataScope, clusterNameMap map[string]string) []DataScope {
+	if clusterNameMap == nil {
+		return scopes
+	}
+	for i := 0; i < len(scopes); i++ {
+		if name, find := clusterNameMap[scopes[i].ClusterID]; find {
+			scopes[i].ClusterName = name
+		}
+	}
+	return scopes
+}
+
+func (t *DataScopeTreeNode) FillWithClusterName(clusterNameMap map[string]string) {
+	if name, find := clusterNameMap[t.ClusterID]; find {
+		t.ClusterName = name
+	}
+	for i := 0; i < len(t.Children); i++ {
+		t.Children[i].FillWithClusterName(clusterNameMap)
+	}
 }
 
 func (t *DataScopeTreeNode) GetFullPermissionSvcList(permScopeIDs []string) []string {

--- a/backend/pkg/repository/clickhouse/dao_alert_events.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_events.go
@@ -140,11 +140,6 @@ func (ch *chRepo) GetAlertEventsSample(ctx core.Context, sampleCount int, startT
 		And(whereInstance)
 
 	if len(filter.ClusterIDs) > 0 {
-		for i := 0; i < len(filter.ClusterIDs); i++ {
-			if filter.ClusterIDs[i] == "unknown" {
-				filter.ClusterIDs[i] = ""
-			}
-		}
 		builder.InStrings("cluster_id", filter.ClusterIDs)
 	}
 
@@ -178,9 +173,6 @@ func (ch *chRepo) GetAlertDataScope(ctx core.Context, startTime time.Time, endTi
 			datasources[i].Name = datasources[i].Namespace
 		} else {
 			datasources[i].Type = datagroup.DATASOURCE_TYP_CLUSTER
-			if datasources[i].ClusterID == "" {
-				datasources[i].ClusterID = "unknown"
-			}
 			datasources[i].Name = datasources[i].ClusterID
 		}
 	}
@@ -208,11 +200,6 @@ func (ch *chRepo) GetAlertEvents(ctx core.Context, startTime time.Time, endTime 
 		And(whereInstance)
 
 	if len(filter.ClusterIDs) > 0 {
-		for i := 0; i < len(filter.ClusterIDs); i++ {
-			if filter.ClusterIDs[i] == "unknown" {
-				filter.ClusterIDs[i] = ""
-			}
-		}
 		builder.InStrings("cluster_id", filter.ClusterIDs)
 	}
 

--- a/backend/pkg/repository/clickhouse/dao_span_trace.go
+++ b/backend/pkg/repository/clickhouse/dao_span_trace.go
@@ -46,11 +46,6 @@ func (ch *chRepo) GetFaultLogPageList(ctx core.Context, query *FaultLogQuery) ([
 		EqualsNotEmpty("labels['pod_name']", query.Pod)
 
 	if len(query.ClusterIDs) > 0 {
-		for i := 0; i < len(query.ClusterIDs); i++ {
-			if query.ClusterIDs[i] == "unknown" {
-				query.ClusterIDs[i] = ""
-			}
-		}
 		queryBuilder.InStrings("labels['cluster_id']", query.ClusterIDs)
 	}
 	if len(query.MultiServices) > 0 {
@@ -151,11 +146,6 @@ func (ch *chRepo) GetTracePageList(ctx core.Context, req *request.GetTracePageLi
 		EqualsNotEmpty("labels['container_id']", req.ContainerId)
 
 	if len(req.ClusterIDs) > 0 {
-		for i := 0; i < len(req.ClusterIDs); i++ {
-			if req.ClusterIDs[i] == "unknown" {
-				req.ClusterIDs[i] = ""
-			}
-		}
 		queryBuilder.InStrings("labels['cluster_id']", req.ClusterIDs)
 	}
 

--- a/backend/pkg/repository/database/integration/dao.go
+++ b/backend/pkg/repository/database/integration/dao.go
@@ -28,6 +28,8 @@ type ObservabilityInputManage interface {
 	GetCluster(ctx core.Context, clusterID string) (integration.Cluster, error)
 	CheckClusterNameExisted(ctx core.Context, clusterName string) (bool, error)
 
+	ListClusterName(ctx core.Context) (map[string]string, error)
+
 	SaveIntegrationConfig(ctx core.Context, iConfig integration.ClusterIntegration) error
 	GetIntegrationConfig(ctx core.Context, clusterID string) (*integration.ClusterIntegration, error)
 	DeleteIntegrationConfig(ctx core.Context, clusterID string) error

--- a/backend/pkg/repository/database/integration/dao_manage_cluster.go
+++ b/backend/pkg/repository/database/integration/dao_manage_cluster.go
@@ -40,6 +40,21 @@ func (repo *subRepos) ListCluster(ctx core.Context) ([]integration.Cluster, erro
 	return clusters, err
 }
 
+func (repo *subRepos) ListClusterName(ctx core.Context) (map[string]string, error) {
+	var clusters []integration.Cluster
+	err := repo.GetContextDB(ctx).Select("id", "name").Find(&clusters).Error
+	if err != nil {
+		return nil, err
+	}
+
+	clustersMap := make(map[string]string)
+	for _, cluster := range clusters {
+		clustersMap[cluster.ID] = cluster.Name
+	}
+
+	return clustersMap, nil
+}
+
 func (repo *subRepos) GetCluster(ctx core.Context, clusterID string) (integration.Cluster, error) {
 	var cluster integration.Cluster
 	err := repo.GetContextDB(ctx).First(&cluster, "id = ?", clusterID).Error

--- a/backend/pkg/repository/polarisanalyzer/dao_polaris_infer.go
+++ b/backend/pkg/repository/polarisanalyzer/dao_polaris_infer.go
@@ -27,12 +27,6 @@ func (p *polRepo) QueryPolarisInfer(req *request.GetPolarisInferRequest) (*Polar
 		req.Step = 60e6 // interval must be large than 1m
 	}
 
-	for i := 0; i < len(req.ClusterIDs); i++ {
-		if req.ClusterIDs[i] == "unknown" {
-			req.ClusterIDs[i] = ""
-		}
-	}
-
 	payload := PolarisInferReq{
 		StartTime:  req.StartTime,
 		EndTime:    req.EndTime,

--- a/backend/pkg/repository/prometheus/pql_filter.go
+++ b/backend/pkg/repository/prometheus/pql_filter.go
@@ -47,7 +47,7 @@ func NewFilter() *AndFilter {
 }
 
 func (f *AndFilter) EqualIfNotEmpty(k, v string) PQLFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	if len(v) == 0 || len(k) == 0 {
 		return f
 	}
@@ -56,25 +56,25 @@ func (f *AndFilter) EqualIfNotEmpty(k, v string) PQLFilter {
 }
 
 func (f *AndFilter) Equal(k, v string) PQLFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	f.Filters = append(f.Filters, k+`="`+v+`"`)
 	return f
 }
 
 func (f *AndFilter) NotEqual(k, v string) PQLFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	f.Filters = append(f.Filters, k+`!="`+v+`"`)
 	return f
 }
 
 func (f *AndFilter) RegexMatch(k, regexPattern string) PQLFilter {
-	regexPattern = strings.ReplaceAll(regexPattern, `unknown`, ``)
+	regexPattern = strings.ReplaceAll(regexPattern, `VM_NS`, ``)
 	f.Filters = append(f.Filters, k+`=~"`+regexPattern+`"`)
 	return f
 }
 
 func (f *AndFilter) AddPatternFilter(pattern, v string) PQLFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	f.Filters = append(f.Filters, pattern+`"`+v+`"`)
 	return f
 }
@@ -285,7 +285,7 @@ func (o *OrFilter) SplitFilters(keys []string) (PQLFilter, PQLFilter) {
 
 // Fast Filter
 func EqualFilter(k, v string) *AndFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{k + `="` + v + `"`}}
 }
 
@@ -293,17 +293,17 @@ func EqualIfNotEmptyFilter(k, v string) *AndFilter {
 	if len(v) == 0 {
 		return nil
 	}
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{k + `="` + v + `"`}}
 }
 
 func NotEqualFilter(k, v string) *AndFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{k + `!="` + v + `"`}}
 }
 
 func RegexMatchFilter(k, regexPattern string) *AndFilter {
-	regexPattern = strings.ReplaceAll(regexPattern, `unknown`, ``)
+	regexPattern = strings.ReplaceAll(regexPattern, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{k + `=~"` + regexPattern + `"`}}
 }
 
@@ -311,12 +311,12 @@ func RegexMatchIfNotEmptyFilter(k, regexPattern string) *AndFilter {
 	if len(regexPattern) == 0 {
 		return nil
 	}
-	regexPattern = strings.ReplaceAll(regexPattern, `unknown`, ``)
+	regexPattern = strings.ReplaceAll(regexPattern, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{k + `=~"` + regexPattern + `"`}}
 }
 
 func PatternFilter(pattern, v string) *AndFilter {
-	v = strings.ReplaceAll(v, `unknown`, ``)
+	v = strings.ReplaceAll(v, `VM_NS`, ``)
 	return &AndFilter{Filters: []string{pattern + `"` + v + `"`}}
 }
 

--- a/backend/pkg/services/common/data_group_store_v2.go
+++ b/backend/pkg/services/common/data_group_store_v2.go
@@ -365,25 +365,12 @@ func createClusterScope(baseScope datagroup.DataScope, labels datagroup.ScopeLab
 func fillEmptyLabel(s *datagroup.ScopeLabels, typ string) {
 	switch typ {
 	case datagroup.DATASOURCE_TYP_SERVICE:
-		if s.Service == "" {
-			s.Service = "unknown"
-		}
 		if s.Namespace == "" {
-			s.Namespace = "unknown"
-		}
-		if s.ClusterID == "" {
-			s.ClusterID = "unknown"
+			s.Namespace = "VM_NS"
 		}
 	case datagroup.DATASOURCE_TYP_NAMESPACE:
 		if s.Namespace == "" {
-			s.Namespace = "unknown"
-		}
-		if s.ClusterID == "" {
-			s.ClusterID = "unknown"
-		}
-	case datagroup.DATASOURCE_TYP_CLUSTER:
-		if s.ClusterID == "" {
-			s.ClusterID = "unknown"
+			s.Namespace = "VM_NS"
 		}
 	}
 }

--- a/backend/pkg/services/data/service.go
+++ b/backend/pkg/services/data/service.go
@@ -29,8 +29,6 @@ type Service interface {
 	GroupSubsOperation(ctx core.Context, req *request.GroupSubsOperationRequest) error
 	GetGroupSubs(ctx core.Context, req *request.GetGroupSubsRequest) (response.GetGroupSubsResponse, error)
 
-	// TestStoreScope(ctx core.Context)
-
 	ListDataGroupV2(ctx core.Context) (*datagroup.DataGroupTreeNode, error)
 
 	ListDataScopeByGroupID(ctx core.Context, req *request.DGScopeListRequest) (*response.ListDataScopesResponse, error)

--- a/backend/pkg/services/data/service_data_group_v2.go
+++ b/backend/pkg/services/data/service_data_group_v2.go
@@ -41,11 +41,14 @@ func (s *service) GetGroupDetailWithSubGroup(ctx core.Context, groupID int64) (*
 	}
 
 	var subGroups = make([]datagroup.DataGroupWithScopes, 0)
+
+	clusterNameMap, _ := s.dbRepo.ListClusterName(ctx)
 	for _, subGroup := range group.SubGroups {
 		scopes, err := s.dbRepo.GetScopesByGroupIDAndCat(ctx, subGroup.GroupID, "")
 		if err != nil {
 			return nil, err
 		}
+		scopes = datagroup.FillWithClusterName(scopes, clusterNameMap)
 		subGroups = append(subGroups, datagroup.DataGroupWithScopes{
 			DataGroup:      subGroup.DataGroup,
 			PermissionType: subGroup.PermissionType,
@@ -57,6 +60,7 @@ func (s *service) GetGroupDetailWithSubGroup(ctx core.Context, groupID int64) (*
 	if err != nil {
 		return nil, err
 	}
+	scopes = datagroup.FillWithClusterName(scopes, clusterNameMap)
 	return &response.SubGroupDetailResponse{
 		Datasources: scopes,
 		SubGroups:   subGroups,

--- a/backend/pkg/services/data/service_data_scope.go
+++ b/backend/pkg/services/data/service_data_scope.go
@@ -33,6 +33,11 @@ func (s *service) ListDataScopeByGroupID(ctx core.Context, req *request.DGScopeL
 		scopes = common.DataGroupStorage.CloneScopeWithPermission(options, selected)
 	}
 
+	clusterNameMap, err := s.dbRepo.ListClusterName(ctx)
+	if err == nil && clusterNameMap != nil {
+		scopes.FillWithClusterName(clusterNameMap)
+	}
+
 	return &response.ListDataScopesResponse{
 		Scopes:      scopes,
 		DataSources: selected,
@@ -46,6 +51,7 @@ func (s *service) GetFilterByGroupID(ctx core.Context, req *request.DGFilterRequ
 	}
 
 	scopes, leafs := common.DataGroupStorage.CloneWithCategory(scopeIDs, req.Category)
+
 	filter := common.ConvertScopeNodeToPQLFilter(scopes)
 
 	switch req.Extra {
@@ -120,6 +126,12 @@ func (s *service) GetFilterByGroupID(ctx core.Context, req *request.DGFilterRequ
 			}
 		}
 	}
+
+	clusterNameMap, err := s.dbRepo.ListClusterName(ctx)
+	if err != nil {
+		return nil, err
+	}
+	scopes.FillWithClusterName(clusterNameMap)
 
 	return &response.ListDataScopeFilterResponse{
 		Scopes: scopes,

--- a/backend/pkg/services/dataplane/service_delete_servicename_rule.go
+++ b/backend/pkg/services/dataplane/service_delete_servicename_rule.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package dataplane
 
 import (
@@ -6,7 +9,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 )
 
-func (s *service) DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error{
+func (s *service) DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error {
 	exists, err := s.dbRepo.ServiceNameRuleExists(ctx, req.RuleId)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary by Sourcery

Enrich DataScope responses with cluster names by adding a clusterName field, implementing DAO support for retrieving cluster names, and integrating helper functions across service methods to populate this new field.

New Features:
- Include clusterName attribute in DataScope and DataScopeTreeNode models
- Add ListClusterName DAO method to fetch cluster ID-to-name mappings
- Provide FillWithClusterName helpers to set clusterName on scope slices and trees
- Populate clusterName in ListDataScopeByGroupID, GetFilterByGroupID, and group detail service endpoints

Chores:
- Remove unused commented-out TestStoreScope method from the service interface