### PR TITLE
feat(metric qeury): Fill in .* for unknown parameters.

### DIFF
--- a/backend/pkg/services/metric/service_predefined_metrics.go
+++ b/backend/pkg/services/metric/service_predefined_metrics.go
@@ -182,7 +182,7 @@ func (s *service) executeTargets(ctx core.Context, groupId int, target *Target, 
 
 		varSpec, find := queryDict.GetVarSpec(groupId, variable)
 		if !find {
-			varMap[variable] = ""
+			varMap[variable] = ".*"
 			continue
 		}
 		varSpecs = append(varSpecs, *varSpec)
@@ -192,7 +192,7 @@ func (s *service) executeTargets(ctx core.Context, groupId int, target *Target, 
 	for {
 		if retry <= 0 {
 			for i := 0; i < len(varSpecs); i++ {
-				varMap[varSpecs[i].Name] = ""
+				varMap[varSpecs[i].Name] = ".*"
 			}
 			break
 		}


### PR DESCRIPTION
## Summary by Sourcery

Use regex wildcard '.*' instead of empty string for unknown parameters in metric queries.

Enhancements:
- Assign '.*' to varMap entries when variable specs are not found in executeTargets.
- Use '.*' as the default value for all remaining varSpecs when retry limit is reached.