### PR TITLE
feat(config): Add ClickHouse connection pool configuration

### DIFF
--- a/backend/config/apo.yml
+++ b/backend/config/apo.yml
@@ -35,6 +35,11 @@ clickhouse:
   username: admin
   password: admin
   database: apo
+  # Connection pool settings (optional, defaults are provided) by heaven96
+  max_open_conns: 20      # Max open connections. Default: 20. Env: APO_CH_MAX_OPEN_CONNS
+  max_idle_conns: 10      # Max idle connections. Default: 10. Env: APO_CH_MAX_IDLE_CONNS
+  conn_max_lifetime_minutes: 60   # Connection max lifetime (minutes). Env: APO_CH_CONN_MAX_LIFETIME_MINUTES
+  dial_timeout_seconds: 5         # Connection dial timeout (seconds). Env: APO_CH_DIAL_TIMEOUT_SECONDS
   cluster:
   replica: false
 promethues:

--- a/backend/pkg/repository/clickhouse/dao.go
+++ b/backend/pkg/repository/clickhouse/dao.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
 
+	"github.com/CloudDetail/apo/backend/config"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/datagroup"
@@ -155,6 +156,9 @@ type chRepo struct {
 func New(logger *zap.Logger, address []string, database string, username string, password string) (Repo, error) {
 	settings := clickhouse.Settings{}
 
+	// Get connection pool settings
+	maxOpenConns, maxIdleConns, connMaxLifetime, dialTimeout := config.GetClickHouseConnPoolConfig()
+
 	conn, err := clickhouse.Open(&clickhouse.Options{
 		Addr:     address,
 		Settings: settings,
@@ -163,7 +167,10 @@ func New(logger *zap.Logger, address []string, database string, username string,
 			Username: username,
 			Password: password,
 		},
-		DialTimeout: time.Duration(5) * time.Second,
+		DialTimeout:     dialTimeout,
+		MaxOpenConns:    maxOpenConns,
+		MaxIdleConns:    maxIdleConns,
+		ConnMaxLifetime: connMaxLifetime,
 	})
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
- 在 apo.yml 中添加 ClickHouse 连接池相关配置选项
- 在 config.go 中添加 ClickHouse 连接池配置的结构体和获取方法
- 在 dao.go 中使用配置的连接池参数初始化 ClickHouse 连接

新增的配置选项包括：
- max_open_conns: 最大打开连接数
- max_idle_conns: 最大空闲连接数
- conn_max_lifetime_minutes: 连接最大生命周期（分钟）
- dial_timeout_seconds: 连接拨号超时（秒）

这些配置选项可以通过环境变量进行覆盖，以便于在不同环境中灵活配置:
- `APO_CH_MAX_OPEN_CONNS`: 最大打开连接数
- `APO_CH_MAX_IDLE_CONNS`: 最大空闲连接数
- `APO_CH_CONN_MAX_LIFETIME_MINUTES`: 连接最大生命周期（分钟）
- `APO_CH_DIAL_TIMEOUT_SECONDS`: 连接拨号超时（秒）

## Summary by Sourcery

Add configurable ClickHouse connection pool settings with default values and environment variable overrides, and apply them during ClickHouse client initialization.

New Features:
- Introduce new ClickHouse pool configuration options: max open connections, max idle connections, connection max lifetime minutes, and dial timeout seconds
- Implement GetClickHouseConnPoolConfig to load pool settings from config and environment variables with defaults

Enhancements:
- Apply configured pool parameters when initializing the ClickHouse client in dao.go

Documentation:
- Document new pool settings and environment variable overrides in apo.yml