### PR TITLE
Feat/add DataPlane config APIs

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -945,7 +945,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -989,7 +989,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1338,7 +1338,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1466,7 +1466,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1510,7 +1510,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1819,7 +1819,7 @@ const docTemplate = `{
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -2597,6 +2597,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/dataplane/create": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.CreateDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/customtopology/create": {
             "post": {
                 "description": "Create custom topology.",
@@ -2748,6 +2792,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/dataplane/delete": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.DeleteDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/endpoints": {
             "get": {
                 "description": "Get service's endpoints.",
@@ -2853,6 +2941,41 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.QueryServiceInstancesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/list": {
+            "get": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListDataPlaneResponse"
                         }
                     },
                     "400": {
@@ -3223,6 +3346,85 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.QueryTopologyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/type/list": {
+            "get": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListDataPlaneTypeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/update": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.UpdateDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "400": {
@@ -10777,6 +10979,87 @@ const docTemplate = `{
                 "type": "string"
             }
         },
+        "integration.DataPlaneType": {
+            "type": "object",
+            "properties": {
+                "capabilitySpec": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "paramSpec": {
+                    "description": "JSONStr",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-integration_ParamSpec"
+                        }
+                    ]
+                },
+                "typeName": {
+                    "type": "string"
+                }
+            }
+        },
+        "integration.DataPlaneWithClusterIDs": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "capabilitySpec": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "clusterIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "paramSpec": {
+                    "description": "JSONStr",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-integration_ParamSpec"
+                        }
+                    ]
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
+                    "type": "string"
+                },
+                "typeName": {
+                    "type": "string"
+                }
+            }
+        },
         "integration.ElasticConfig": {
             "type": "object",
             "properties": {
@@ -10824,6 +11107,17 @@ const docTemplate = `{
                 }
             }
         },
+        "integration.JSONField-array_string": {
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "integration.JSONField-integration_LogAPI": {
             "type": "object",
             "properties": {
@@ -10848,6 +11142,14 @@ const docTemplate = `{
                 }
             }
         },
+        "integration.JSONField-integration_ParamSpec": {
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "$ref": "#/definitions/integration.ParamSpec"
+                }
+            }
+        },
         "integration.JSONField-integration_TraceAPI": {
             "type": "object",
             "properties": {
@@ -10863,6 +11165,25 @@ const docTemplate = `{
                     "$ref": "#/definitions/integration.TraceSelfCollectConfig"
                 }
             }
+        },
+        "integration.JSONType": {
+            "type": "string",
+            "enum": [
+                "object",
+                "array",
+                "string",
+                "number",
+                "boolean",
+                "null"
+            ],
+            "x-enum-varnames": [
+                "JSONTypeObject",
+                "JSONTypeArray",
+                "JSONTypeString",
+                "JSONTypeNumber",
+                "JSONTypeBoolean",
+                "JSONTypeNull"
+            ]
         },
         "integration.JaegerConfig": {
             "type": "object",
@@ -10962,6 +11283,26 @@ const docTemplate = `{
                 },
                 "user": {
                     "type": "string"
+                }
+            }
+        },
+        "integration.ParamSpec": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.ParamSpec"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "optional": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "$ref": "#/definitions/integration.JSONType"
                 }
             }
         },
@@ -11871,6 +12212,32 @@ const docTemplate = `{
                 }
             }
         },
+        "request.CreateDataPlaneRequest": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
+                    "type": "string"
+                }
+            }
+        },
         "request.CreateTeamRequest": {
             "type": "object",
             "required": [
@@ -11992,6 +12359,17 @@ const docTemplate = `{
             }
         },
         "request.DeleteCustomTopologyRequest": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "request.DeleteDataPlaneRequest": {
             "type": "object",
             "required": [
                 "id"
@@ -12931,6 +13309,32 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "oldGroup": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.UpdateDataPlaneRequest": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
                     "type": "string"
                 }
             }
@@ -14304,6 +14708,28 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/database.CustomServiceTopology"
+                    }
+                }
+            }
+        },
+        "response.ListDataPlaneResponse": {
+            "type": "object",
+            "properties": {
+                "dataPlanes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.DataPlaneWithClusterIDs"
+                    }
+                }
+            }
+        },
+        "response.ListDataPlaneTypeResponse": {
+            "type": "object",
+            "properties": {
+                "dpTypes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.DataPlaneType"
                     }
                 }
             }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -937,7 +937,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -981,7 +981,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1330,7 +1330,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1458,7 +1458,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1502,7 +1502,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -1811,7 +1811,7 @@
                 ],
                 "responses": {
                     "200": {
-                        "description": "OK",
+                        "description": "ok",
                         "schema": {
                             "type": "string"
                         }
@@ -2589,6 +2589,50 @@
                 }
             }
         },
+        "/api/dataplane/create": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.CreateDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/customtopology/create": {
             "post": {
                 "description": "Create custom topology.",
@@ -2740,6 +2784,50 @@
                 }
             }
         },
+        "/api/dataplane/delete": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.DeleteDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
         "/api/dataplane/endpoints": {
             "get": {
                 "description": "Get service's endpoints.",
@@ -2845,6 +2933,41 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.QueryServiceInstancesResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/list": {
+            "get": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListDataPlaneResponse"
                         }
                     },
                     "400": {
@@ -3215,6 +3338,85 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/response.QueryTopologyResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/type/list": {
+            "get": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/response.ListDataPlaneTypeResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/code.Failure"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/dataplane/update": {
+            "post": {
+                "consumes": [
+                    "application/x-www-form-urlencoded"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "API.dataplane"
+                ],
+                "parameters": [
+                    {
+                        "description": "Request information",
+                        "name": "Request",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/request.UpdateDataPlaneRequest"
+                        }
+                    },
+                    {
+                        "type": "string",
+                        "description": "Bearer accessToken",
+                        "name": "Authorization",
+                        "in": "header"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "ok",
+                        "schema": {
+                            "type": "string"
                         }
                     },
                     "400": {
@@ -10769,6 +10971,87 @@
                 "type": "string"
             }
         },
+        "integration.DataPlaneType": {
+            "type": "object",
+            "properties": {
+                "capabilitySpec": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "paramSpec": {
+                    "description": "JSONStr",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-integration_ParamSpec"
+                        }
+                    ]
+                },
+                "typeName": {
+                    "type": "string"
+                }
+            }
+        },
+        "integration.DataPlaneWithClusterIDs": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "capabilitySpec": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "clusterIds": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "desc": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "paramSpec": {
+                    "description": "JSONStr",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-integration_ParamSpec"
+                        }
+                    ]
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
+                    "type": "string"
+                },
+                "typeName": {
+                    "type": "string"
+                }
+            }
+        },
         "integration.ElasticConfig": {
             "type": "object",
             "properties": {
@@ -10816,6 +11099,17 @@
                 }
             }
         },
+        "integration.JSONField-array_string": {
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
         "integration.JSONField-integration_LogAPI": {
             "type": "object",
             "properties": {
@@ -10840,6 +11134,14 @@
                 }
             }
         },
+        "integration.JSONField-integration_ParamSpec": {
+            "type": "object",
+            "properties": {
+                "obj": {
+                    "$ref": "#/definitions/integration.ParamSpec"
+                }
+            }
+        },
         "integration.JSONField-integration_TraceAPI": {
             "type": "object",
             "properties": {
@@ -10855,6 +11157,25 @@
                     "$ref": "#/definitions/integration.TraceSelfCollectConfig"
                 }
             }
+        },
+        "integration.JSONType": {
+            "type": "string",
+            "enum": [
+                "object",
+                "array",
+                "string",
+                "number",
+                "boolean",
+                "null"
+            ],
+            "x-enum-varnames": [
+                "JSONTypeObject",
+                "JSONTypeArray",
+                "JSONTypeString",
+                "JSONTypeNumber",
+                "JSONTypeBoolean",
+                "JSONTypeNull"
+            ]
         },
         "integration.JaegerConfig": {
             "type": "object",
@@ -10954,6 +11275,26 @@
                 },
                 "user": {
                     "type": "string"
+                }
+            }
+        },
+        "integration.ParamSpec": {
+            "type": "object",
+            "properties": {
+                "children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.ParamSpec"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "optional": {
+                    "type": "boolean"
+                },
+                "type": {
+                    "$ref": "#/definitions/integration.JSONType"
                 }
             }
         },
@@ -11863,6 +12204,32 @@
                 }
             }
         },
+        "request.CreateDataPlaneRequest": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
+                    "type": "string"
+                }
+            }
+        },
         "request.CreateTeamRequest": {
             "type": "object",
             "required": [
@@ -11984,6 +12351,17 @@
             }
         },
         "request.DeleteCustomTopologyRequest": {
+            "type": "object",
+            "required": [
+                "id"
+            ],
+            "properties": {
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "request.DeleteDataPlaneRequest": {
             "type": "object",
             "required": [
                 "id"
@@ -12923,6 +13301,32 @@
                     "type": "string"
                 },
                 "oldGroup": {
+                    "type": "string"
+                }
+            }
+        },
+        "request.UpdateDataPlaneRequest": {
+            "type": "object",
+            "properties": {
+                "capability": {
+                    "description": "Str Slice",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/integration.JSONField-array_string"
+                        }
+                    ]
+                },
+                "id": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "params": {
+                    "description": "JSONStr",
+                    "type": "string"
+                },
+                "typ": {
                     "type": "string"
                 }
             }
@@ -14296,6 +14700,28 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/database.CustomServiceTopology"
+                    }
+                }
+            }
+        },
+        "response.ListDataPlaneResponse": {
+            "type": "object",
+            "properties": {
+                "dataPlanes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.DataPlaneWithClusterIDs"
+                    }
+                }
+            }
+        },
+        "response.ListDataPlaneTypeResponse": {
+            "type": "object",
+            "properties": {
+                "dpTypes": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/integration.DataPlaneType"
                     }
                 }
             }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1086,6 +1086,53 @@ definitions:
     additionalProperties:
       type: string
     type: object
+  integration.DataPlaneType:
+    properties:
+      capabilitySpec:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-array_string'
+        description: Str Slice
+      desc:
+        type: string
+      paramSpec:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-integration_ParamSpec'
+        description: JSONStr
+      typeName:
+        type: string
+    type: object
+  integration.DataPlaneWithClusterIDs:
+    properties:
+      capability:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-array_string'
+        description: Str Slice
+      capabilitySpec:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-array_string'
+        description: Str Slice
+      clusterIds:
+        items:
+          type: string
+        type: array
+      desc:
+        type: string
+      id:
+        type: integer
+      name:
+        type: string
+      paramSpec:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-integration_ParamSpec'
+        description: JSONStr
+      params:
+        description: JSONStr
+        type: string
+      typ:
+        type: string
+      typeName:
+        type: string
+    type: object
   integration.ElasticConfig:
     properties:
       address:
@@ -1116,6 +1163,13 @@ definitions:
       accessSecret:
         type: string
     type: object
+  integration.JSONField-array_string:
+    properties:
+      obj:
+        items:
+          type: string
+        type: array
+    type: object
   integration.JSONField-integration_LogAPI:
     properties:
       obj:
@@ -1131,6 +1185,11 @@ definitions:
       obj:
         $ref: '#/definitions/integration.MetricAPI'
     type: object
+  integration.JSONField-integration_ParamSpec:
+    properties:
+      obj:
+        $ref: '#/definitions/integration.ParamSpec'
+    type: object
   integration.JSONField-integration_TraceAPI:
     properties:
       obj:
@@ -1141,6 +1200,22 @@ definitions:
       obj:
         $ref: '#/definitions/integration.TraceSelfCollectConfig'
     type: object
+  integration.JSONType:
+    enum:
+    - object
+    - array
+    - string
+    - number
+    - boolean
+    - "null"
+    type: string
+    x-enum-varnames:
+    - JSONTypeObject
+    - JSONTypeArray
+    - JSONTypeString
+    - JSONTypeNumber
+    - JSONTypeBoolean
+    - JSONTypeNull
   integration.JaegerConfig:
     properties:
       address:
@@ -1205,6 +1280,19 @@ definitions:
         type: string
       user:
         type: string
+    type: object
+  integration.ParamSpec:
+    properties:
+      children:
+        items:
+          $ref: '#/definitions/integration.ParamSpec'
+        type: array
+      name:
+        type: string
+      optional:
+        type: boolean
+      type:
+        $ref: '#/definitions/integration.JSONType'
     type: object
   integration.PinpointConfig:
     properties:
@@ -1807,6 +1895,22 @@ definitions:
           type: string
         type: array
     type: object
+  request.CreateDataPlaneRequest:
+    properties:
+      capability:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-array_string'
+        description: Str Slice
+      id:
+        type: integer
+      name:
+        type: string
+      params:
+        description: JSONStr
+        type: string
+      typ:
+        type: string
+    type: object
   request.CreateTeamRequest:
     properties:
       dataGroupPermission:
@@ -1890,6 +1994,13 @@ definitions:
     - group
     type: object
   request.DeleteCustomTopologyRequest:
+    properties:
+      id:
+        type: integer
+    required:
+    - id
+    type: object
+  request.DeleteDataPlaneRequest:
     properties:
       id:
         type: integer
@@ -2529,6 +2640,22 @@ definitions:
     required:
     - oldAlert
     - oldGroup
+    type: object
+  request.UpdateDataPlaneRequest:
+    properties:
+      capability:
+        allOf:
+        - $ref: '#/definitions/integration.JSONField-array_string'
+        description: Str Slice
+      id:
+        type: integer
+      name:
+        type: string
+      params:
+        description: JSONStr
+        type: string
+      typ:
+        type: string
     type: object
   request.UpdateLogParseRequest:
     properties:
@@ -3446,6 +3573,20 @@ definitions:
       topologies:
         items:
           $ref: '#/definitions/database.CustomServiceTopology'
+        type: array
+    type: object
+  response.ListDataPlaneResponse:
+    properties:
+      dataPlanes:
+        items:
+          $ref: '#/definitions/integration.DataPlaneWithClusterIDs'
+        type: array
+    type: object
+  response.ListDataPlaneTypeResponse:
+    properties:
+      dpTypes:
+        items:
+          $ref: '#/definitions/integration.DataPlaneType'
         type: array
     type: object
   response.ListServiceNameRule:
@@ -4624,7 +4765,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -4653,7 +4794,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -4876,7 +5017,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -4959,7 +5100,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -4988,7 +5129,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -5190,7 +5331,7 @@ paths:
       - application/json
       responses:
         "200":
-          description: OK
+          description: ok
           schema:
             type: string
         "400":
@@ -5698,6 +5839,34 @@ paths:
       summary: Get app info tag values.
       tags:
       - API.dataplane
+  /api/dataplane/create:
+    post:
+      consumes:
+      - application/x-www-form-urlencoded
+      parameters:
+      - description: Request information
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.CreateDataPlaneRequest'
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
+      tags:
+      - API.dataplane
   /api/dataplane/customtopology/create:
     post:
       consumes:
@@ -5799,6 +5968,34 @@ paths:
       summary: List custom topology.
       tags:
       - API.dataplane
+  /api/dataplane/delete:
+    post:
+      consumes:
+      - application/x-www-form-urlencoded
+      parameters:
+      - description: Request information
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.DeleteDataPlaneRequest'
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
+      tags:
+      - API.dataplane
   /api/dataplane/endpoints:
     get:
       consumes:
@@ -5875,6 +6072,28 @@ paths:
           schema:
             $ref: '#/definitions/code.Failure'
       summary: Get service's instances.
+      tags:
+      - API.dataplane
+  /api/dataplane/list:
+    get:
+      consumes:
+      - application/x-www-form-urlencoded
+      parameters:
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.ListDataPlaneResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
       tags:
       - API.dataplane
   /api/dataplane/redcharts:
@@ -6119,6 +6338,56 @@ paths:
           schema:
             $ref: '#/definitions/code.Failure'
       summary: Get service's topology.
+      tags:
+      - API.dataplane
+  /api/dataplane/type/list:
+    get:
+      consumes:
+      - application/x-www-form-urlencoded
+      parameters:
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/response.ListDataPlaneTypeResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
+      tags:
+      - API.dataplane
+  /api/dataplane/update:
+    post:
+      consumes:
+      - application/x-www-form-urlencoded
+      parameters:
+      - description: Request information
+        in: body
+        name: Request
+        required: true
+        schema:
+          $ref: '#/definitions/request.UpdateDataPlaneRequest'
+      - description: Bearer accessToken
+        in: header
+        name: Authorization
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: ok
+          schema:
+            type: string
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/code.Failure'
       tags:
       - API.dataplane
   /api/health:

--- a/backend/pkg/api/alerts/func_deletealertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_deletealertmanagerconfigreceiver.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Param Request body request.DeleteAlertManagerConfigReceiverRequest true "Delete object"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/alertmanager/receiver [delete]
 func (h *handler) DeleteAlertManagerConfigReceiver() core.HandlerFunc {

--- a/backend/pkg/api/alerts/func_deletealertrule.go
+++ b/backend/pkg/api/alerts/func_deletealertrule.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Param Request body request.DeleteAlertRuleRequest true "Delete object"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/rule [delete]
 func (h *handler) DeleteAlertRule() core.HandlerFunc {

--- a/backend/pkg/api/alerts/func_inputalertmanager.go
+++ b/backend/pkg/api/alerts/func_inputalertmanager.go
@@ -19,7 +19,7 @@ import (
 // @Accept application/json
 // @Produce json
 // @Param Request body request.InputAlertManagerRequest true "Request information"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/inputs/alertmanager [post]
 func (h *handler) InputAlertManager() core.HandlerFunc {

--- a/backend/pkg/api/alerts/func_updatealertmanagerconfigreceiver.go
+++ b/backend/pkg/api/alerts/func_updatealertmanagerconfigreceiver.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Param Request body request.UpdateAlertManagerConfigReceiver true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/alertmanager/receiver [post]
 func (h *handler) UpdateAlertManagerConfigReceiver() core.HandlerFunc {

--- a/backend/pkg/api/alerts/func_updatealertrule.go
+++ b/backend/pkg/api/alerts/func_updatealertrule.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Param Request body request.UpdateAlertRuleRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/rule [post]
 func (h *handler) UpdateAlertRule() core.HandlerFunc {

--- a/backend/pkg/api/alerts/func_updatealertrulefile.go
+++ b/backend/pkg/api/alerts/func_updatealertrulefile.go
@@ -19,7 +19,7 @@ import (
 // @Produce json
 // @Param Request body request.UpdateAlertRuleRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string ok
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/alerts/rules/file [post]
 func (h *handler) UpdateAlertRuleFile() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_createdataplane.go
+++ b/backend/pkg/api/dataplane/func_createdataplane.go
@@ -1,0 +1,47 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// CreateDataPlane
+// @Summary
+// @Description
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.CreateDataPlaneRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 string "ok"
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/create [post]
+func (h *handler) CreateDataPlane() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.CreateDataPlaneRequest)
+		if err := c.ShouldBindJSON(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		err := h.dataplaneService.CreateDataPlane(c, req)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ServerError, // TODO CreateDataPlaneError
+				err,
+			)
+			return
+		}
+		c.Payload("ok")
+	}
+}

--- a/backend/pkg/api/dataplane/func_createdataplane.go
+++ b/backend/pkg/api/dataplane/func_createdataplane.go
@@ -37,7 +37,7 @@ func (h *handler) CreateDataPlane() core.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
-				code.ServerError, // TODO CreateDataPlaneError
+				code.CreateDataPlaneError,
 				err,
 			)
 			return

--- a/backend/pkg/api/dataplane/func_createdataplane.go
+++ b/backend/pkg/api/dataplane/func_createdataplane.go
@@ -18,7 +18,7 @@ import (
 // @Produce json
 // @Param Request body request.CreateDataPlaneRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string "ok"
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/dataplane/create [post]
 func (h *handler) CreateDataPlane() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_deletedataplane.go
+++ b/backend/pkg/api/dataplane/func_deletedataplane.go
@@ -33,12 +33,11 @@ func (h *handler) DeleteDataPlane() core.HandlerFunc {
 			return
 		}
 
-		// TODO replace with Service call
 		err := h.dataplaneService.DeleteDataPlane(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
-				code.ServerError, // TODO DeleteDataPlaneError
+				code.DeleteDataPlaneError,
 				err,
 			)
 			return

--- a/backend/pkg/api/dataplane/func_deletedataplane.go
+++ b/backend/pkg/api/dataplane/func_deletedataplane.go
@@ -1,0 +1,48 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// DeleteDataPlane
+// @Summary
+// @Description
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.deleteDataPlaneRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 string "ok"
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/delete [post]
+func (h *handler) DeleteDataPlane() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.DeleteDataPlaneRequest)
+		if err := c.ShouldBindJSON(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		// TODO replace with Service call
+		err := h.dataplaneService.DeleteDataPlane(c, req)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ServerError, // TODO DeleteDataPlaneError
+				err,
+			)
+			return
+		}
+		c.Payload("ok")
+	}
+}

--- a/backend/pkg/api/dataplane/func_deletedataplane.go
+++ b/backend/pkg/api/dataplane/func_deletedataplane.go
@@ -16,9 +16,9 @@ import (
 // @Tags API.dataplane
 // @Accept application/x-www-form-urlencoded
 // @Produce json
-// @Param Request body request.deleteDataPlaneRequest true "Request information"
+// @Param Request body request.DeleteDataPlaneRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string "ok"
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/dataplane/delete [post]
 func (h *handler) DeleteDataPlane() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_listdataplane.go
+++ b/backend/pkg/api/dataplane/func_listdataplane.go
@@ -1,0 +1,37 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+)
+
+// ListDataPlane
+// @Summary
+// @Description
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// TODO The following request parameter types and response types must be changed according to actual requirements.
+// @Param Request body request.listDataPlaneRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} response.listDataPlaneResponse
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/list [get]
+func (h *handler) ListDataPlane() core.HandlerFunc {
+	return func(c core.Context) {
+		resp, err := h.dataplaneService.ListDataPlane(c)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ServerError, // TODO err code
+				err,
+			)
+			return
+		}
+		c.Payload(resp)
+	}
+}

--- a/backend/pkg/api/dataplane/func_listdataplane.go
+++ b/backend/pkg/api/dataplane/func_listdataplane.go
@@ -25,7 +25,7 @@ func (h *handler) ListDataPlane() core.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
-				code.ServerError, // TODO err code
+				code.ListDataPlaneError,
 				err,
 			)
 			return

--- a/backend/pkg/api/dataplane/func_listdataplane.go
+++ b/backend/pkg/api/dataplane/func_listdataplane.go
@@ -15,10 +15,8 @@ import (
 // @Tags API.dataplane
 // @Accept application/x-www-form-urlencoded
 // @Produce json
-// TODO The following request parameter types and response types must be changed according to actual requirements.
-// @Param Request body request.listDataPlaneRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 {object} response.listDataPlaneResponse
+// @Success 200 {object} response.ListDataPlaneResponse
 // @Failure 400 {object} code.Failure
 // @Router /api/dataplane/list [get]
 func (h *handler) ListDataPlane() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_listdataplanetype.go
+++ b/backend/pkg/api/dataplane/func_listdataplanetype.go
@@ -1,0 +1,35 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+)
+
+// ListDataPlaneType
+// @Summary
+// @Description
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} response.listDataPlaneTypeResponse
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/type/list [get]
+func (h *handler) ListDataPlaneType() core.HandlerFunc {
+	return func(c core.Context) {
+		resp, err := h.dataplaneService.ListDataPlaneType(c)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ServerError, // TODO err code
+				err,
+			)
+			return
+		}
+		c.Payload(resp)
+	}
+}

--- a/backend/pkg/api/dataplane/func_listdataplanetype.go
+++ b/backend/pkg/api/dataplane/func_listdataplanetype.go
@@ -25,7 +25,7 @@ func (h *handler) ListDataPlaneType() core.HandlerFunc {
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
-				code.ServerError, // TODO err code
+				code.ListDataPlaneTypeError,
 				err,
 			)
 			return

--- a/backend/pkg/api/dataplane/func_listdataplanetype.go
+++ b/backend/pkg/api/dataplane/func_listdataplanetype.go
@@ -16,7 +16,7 @@ import (
 // @Accept application/x-www-form-urlencoded
 // @Produce json
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 {object} response.listDataPlaneTypeResponse
+// @Success 200 {object} response.ListDataPlaneTypeResponse
 // @Failure 400 {object} code.Failure
 // @Router /api/dataplane/type/list [get]
 func (h *handler) ListDataPlaneType() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_updatedataplane.go
+++ b/backend/pkg/api/dataplane/func_updatedataplane.go
@@ -18,7 +18,7 @@ import (
 // @Produce json
 // @Param Request body request.UpdateDataPlaneRequest true "Request information"
 // @Param Authorization header string false "Bearer accessToken"
-// @Success 200 string "ok"
+// @Success 200 {object} string "ok"
 // @Failure 400 {object} code.Failure
 // @Router /api/dataplane/update [post]
 func (h *handler) UpdateDataPlane() core.HandlerFunc {

--- a/backend/pkg/api/dataplane/func_updatedataplane.go
+++ b/backend/pkg/api/dataplane/func_updatedataplane.go
@@ -1,0 +1,48 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package dataplane
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// UpdateDataPlane
+// @Summary
+// @Description
+// @Tags API.dataplane
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.UpdateDataPlaneRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 string "ok"
+// @Failure 400 {object} code.Failure
+// @Router /api/dataplane/update [post]
+func (h *handler) UpdateDataPlane() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.UpdateDataPlaneRequest)
+		if err := c.ShouldBindJSON(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		// TODO replace with Service call
+		err := h.dataplaneService.UpdateDataPlane(c, req)
+		if err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ServerError, // TODO UpdateDataPlaneError
+				err,
+			)
+			return
+		}
+		c.Payload("ok")
+	}
+}

--- a/backend/pkg/api/dataplane/func_updatedataplane.go
+++ b/backend/pkg/api/dataplane/func_updatedataplane.go
@@ -33,12 +33,11 @@ func (h *handler) UpdateDataPlane() core.HandlerFunc {
 			return
 		}
 
-		// TODO replace with Service call
 		err := h.dataplaneService.UpdateDataPlane(c, req)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,
-				code.ServerError, // TODO UpdateDataPlaneError
+				code.UpdateDataPlaneError,
 				err,
 			)
 			return

--- a/backend/pkg/api/dataplane/handler.go
+++ b/backend/pkg/api/dataplane/handler.go
@@ -75,6 +75,24 @@ type Handler interface {
 	// @Tags API.dataplane
 	// @Router /api/dataplane/appinfo/tags/values [get]
 	QueryAPPInfoTagValues() core.HandlerFunc
+
+	// ListDataPlaneType
+	// @Tags API.dataplane
+	// @Router /api/dataplane/type/list [get]
+	ListDataPlaneType() core.HandlerFunc
+
+	// CreateDataPlane
+	// @Tags API.dataplane
+	// @Router /api/dataplane/create [post]
+	CreateDataPlane() core.HandlerFunc
+
+	// ListDataPlane
+	// @Tags API.dataplane
+	// @Router /api/dataplane/list [get]
+	ListDataPlane() core.HandlerFunc
+
+	// UpdateDataPlane() core.HandlerFunc
+	// DeleteDataPlane() core.HandlerFunc
 }
 
 type handler struct {

--- a/backend/pkg/api/dataplane/handler.go
+++ b/backend/pkg/api/dataplane/handler.go
@@ -91,8 +91,15 @@ type Handler interface {
 	// @Router /api/dataplane/list [get]
 	ListDataPlane() core.HandlerFunc
 
-	// UpdateDataPlane() core.HandlerFunc
-	// DeleteDataPlane() core.HandlerFunc
+	// UpdateDataPlane
+	// @Tags API.dataplane
+	// @Router /api/dataplane/update [post]
+	UpdateDataPlane() core.HandlerFunc
+
+	// DeleteDataPlane
+	// @Tags API.dataplane
+	// @Router /api/dataplane/delete [post]
+	DeleteDataPlane() core.HandlerFunc
 }
 
 type handler struct {

--- a/backend/pkg/code/code.go
+++ b/backend/pkg/code/code.go
@@ -261,11 +261,14 @@ const (
 	QueryAPPInfoTagsError         = "B1809"
 	QueryAPPInfoValuesError       = "B1810"
 
-	CreateDataPlaneError   = "B1811"
-	DeleteDataPlaneError   = "B1812"
-	ListDataPlaneError     = "B1813"
-	ListDataPlaneTypeError = "B1814"
-	UpdateDataPlaneError   = "B1815"
+	CreateDataPlaneError       = "B1811"
+	DeleteDataPlaneError       = "B1812"
+	ListDataPlaneError         = "B1813"
+	ListDataPlaneTypeError     = "B1814"
+	UpdateDataPlaneError       = "B1815"
+	DataPlaneNotExistError     = "B1816"
+	DataPlaneTypeNotExistError = "B1817"
+	DataPlaneParamInvalidError = "B1818"
 )
 
 func Text(lang string, code string) string {

--- a/backend/pkg/code/code.go
+++ b/backend/pkg/code/code.go
@@ -260,6 +260,12 @@ const (
 	ServiceNameRuleNotExistsError = "B1808"
 	QueryAPPInfoTagsError         = "B1809"
 	QueryAPPInfoValuesError       = "B1810"
+
+	CreateDataPlaneError   = "B1811"
+	DeleteDataPlaneError   = "B1812"
+	ListDataPlaneError     = "B1813"
+	ListDataPlaneTypeError = "B1814"
+	UpdateDataPlaneError   = "B1815"
 )
 
 func Text(lang string, code string) string {

--- a/backend/pkg/code/en.go
+++ b/backend/pkg/code/en.go
@@ -227,4 +227,10 @@ var enText = map[string]string{
 	ServiceNameRuleNotExistsError: "service name rule not exists",
 	QueryAPPInfoTagsError:         "Failed to query APP info tags",
 	QueryAPPInfoValuesError:       "Failed to query APP info values",
+
+	CreateDataPlaneError:   "Failed to create data plane",
+	DeleteDataPlaneError:   "Failed to delete data plane",
+	ListDataPlaneError:     "Failed to list data plane",
+	ListDataPlaneTypeError: "Failed to list data plane type",
+	UpdateDataPlaneError:   "Failed to update data plane",
 }

--- a/backend/pkg/code/zh-cn.go
+++ b/backend/pkg/code/zh-cn.go
@@ -229,4 +229,10 @@ var zhCnText = map[string]string{
 	ServiceNameRuleNotExistsError: "服务名匹配规则不存在",
 	QueryAPPInfoTagsError:         "查询APP信息标签失败",
 	QueryAPPInfoValuesError:       "查询APP信息值失败",
+
+	CreateDataPlaneError:   "创建数据平面失败",
+	DeleteDataPlaneError:   "删除数据平面失败",
+	ListDataPlaneError:     "列出数据平面失败",
+	ListDataPlaneTypeError: "列出数据平面类型失败",
+	UpdateDataPlaneError:   "更新数据平面失败",
 }

--- a/backend/pkg/model/integration/data_plane.go
+++ b/backend/pkg/model/integration/data_plane.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"slices"
+	"time"
 )
 
 type DataPlane struct {
@@ -16,6 +17,9 @@ type DataPlane struct {
 	Typ        string              `gorm:"typ" json:"typ"`
 	Params     string              `gorm:"params" json:"params"`         // JSONStr
 	Capability JSONField[[]string] `gorm:"capability" json:"capability"` // Str Slice
+
+	UpdatedAt time.Time `gorm:"update_at;autoUpdateTime:second" json:"-"`
+	IsDelete  bool      `gorm:"is_delete" json:"-"`
 }
 
 func (DataPlane) TableName() string {

--- a/backend/pkg/model/integration/data_plane.go
+++ b/backend/pkg/model/integration/data_plane.go
@@ -18,7 +18,7 @@ type DataPlane struct {
 	Params     string              `gorm:"params" json:"params"`         // JSONStr
 	Capability JSONField[[]string] `gorm:"capability" json:"capability"` // Str Slice
 
-	UpdatedAt time.Time `gorm:"update_at;autoUpdateTime:second" json:"-"`
+	UpdatedAt time.Time `gorm:"updated_at;autoUpdateTime:second" json:"-"`
 	IsDelete  bool      `gorm:"is_delete" json:"-"`
 }
 

--- a/backend/pkg/model/integration/data_plane.go
+++ b/backend/pkg/model/integration/data_plane.go
@@ -19,7 +19,7 @@ type DataPlane struct {
 	Capability JSONField[[]string] `gorm:"capability" json:"capability"` // Str Slice
 
 	UpdatedAt time.Time `gorm:"updated_at;autoUpdateTime:second" json:"-"`
-	IsDelete  bool      `gorm:"is_delete" json:"-"`
+	IsDeleted bool      `gorm:"is_deleted" json:"-"`
 }
 
 func (DataPlane) TableName() string {

--- a/backend/pkg/model/integration/data_plane.go
+++ b/backend/pkg/model/integration/data_plane.go
@@ -1,0 +1,60 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"slices"
+)
+
+type DataPlane struct {
+	ID   int    `gorm:"id;primaryKey;autoIncrement" json:"id"`
+	Name string `gorm:"name" json:"name"`
+
+	Typ        string              `gorm:"typ" json:"typ"`
+	Params     string              `gorm:"params" json:"params"`         // JSONStr
+	Capability JSONField[[]string] `gorm:"capability" json:"capability"` // Str Slice
+}
+
+func (DataPlane) TableName() string {
+	return "data_plane"
+}
+
+type DataPlaneWithType struct {
+	DataPlane
+	DataPlaneType
+}
+
+type DataPlaneWithClusterIDs struct {
+	DataPlaneWithType
+	ClusterIDs []string `json:"clusterIds"`
+}
+
+func CheckInvalid(d *DataPlane, dpt *DataPlaneType) error {
+	if len(dpt.CapabilitySpec.Obj) == 0 {
+		return fmt.Errorf("unexpected empty capability in data plane spec: %s", dpt.TypeName)
+	}
+
+	for _, capability := range d.Capability.Obj {
+		if !slices.Contains(dpt.CapabilitySpec.Obj, capability) {
+			return fmt.Errorf("unsupported capability %s in data plane: %s", capability, d.Name)
+		}
+	}
+
+	var obj interface{}
+	if err := json.Unmarshal([]byte(d.Params), &obj); err != nil {
+		return err
+	}
+	return ValidateJSON(obj, dpt.ParamSpec.Obj)
+}
+
+func (d *DataPlaneWithType) CheckInvalid() error {
+	return CheckInvalid(&d.DataPlane, &d.DataPlaneType)
+}
+
+type Cluster2DataPlane struct {
+	ClusterID   string `gorm:"cluster_id;primary_key" json:"clusterId"`
+	DataPlaneID int    `gorm:"data_plane_id;primary_key" json:"dataPlaneId"`
+}

--- a/backend/pkg/model/integration/data_plane_test.go
+++ b/backend/pkg/model/integration/data_plane_test.go
@@ -1,0 +1,93 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDataPlaneValidate(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramSpec string
+		param     string
+	}{
+		{
+			name:      "apo",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"promAddress","type":"string"},{"name":"promStorage","type":"string"}]}`,
+			param:     `{"promAddress": "http://0.0.0.0:8428", "promStorage": "vm"}`,
+		},
+		{
+			name:      "datadog",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"site","type":"string"},{"name":"apiKey","type":"string"},{"name":"appKey","type":"string"},{"name":"env","type":"string"}]}`,
+			param:     `{"site": "datadoghq.com", "apiKey": "", "appKey": "", "env": "dev"}`,
+		},
+		{
+			name:      "nginxLog",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"address","type":"string"},{"name":"userName","type":"string"},{"name":"password","type":"string"},{"name":"database","type":"string"},{"name":"logTable","type":"string"}]}`,
+			param:     `{"address": "0.0.0.0:9000", "userName": "uname", "password": "pwdtest", "database": "xxx", "logTable": "logs_nginx_access_log"}`,
+		},
+		{
+			name:      "arms",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"address","type":"string"},{"name":"accessKey","type":"string"},{"name":"accessSecret","type":"string"}]}`,
+			param:     `{"address": "arms.cn-xxxx.aliyuncs.com", "accessKey": "exampleaccessKey", "accessSecret": "examplesecret"}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var obj interface{}
+			if err := json.Unmarshal([]byte(tt.param), &obj); err != nil {
+				t.Fatal(err)
+			}
+
+			var paramSpec ParamSpec
+			if err := json.Unmarshal([]byte(tt.paramSpec), &paramSpec); err != nil {
+				t.Fatal(err)
+			}
+			err := ValidateJSON(obj, paramSpec)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestUnsatisfiedParam(t *testing.T) {
+	tests := []struct {
+		name      string
+		paramSpec string
+		param     string
+		want      error
+	}{
+		{
+			name:      "missing field",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"promAddress","type":"string"},{"name":"promStorage","type":"string"}]}`,
+			param:     `{"promStorage": "vm"}`,
+			want:      fmt.Errorf("missing required field: promAddress"),
+		},
+		{
+			name:      "type mismatch",
+			paramSpec: `{"name":"root","type":"object","children":[{"name":"site","type":"string"},{"name":"apiKey","type":"string"},{"name":"appKey","type":"string"},{"name":"env","type":"string"}]}`,
+			param:     `{"site": 123, "apiKey": "", "appKey": "", "env": "dev"}`,
+			want:      fmt.Errorf("field 'site' expected string"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var obj interface{}
+			if err := json.Unmarshal([]byte(tt.param), &obj); err != nil {
+				t.Fatal(err)
+			}
+
+			var paramSpec ParamSpec
+			if err := json.Unmarshal([]byte(tt.paramSpec), &paramSpec); err != nil {
+				t.Fatal(err)
+			}
+			err := ValidateJSON(obj, paramSpec)
+			assert.Equal(t, tt.want, err)
+		})
+	}
+}

--- a/backend/pkg/model/integration/data_plane_type.go
+++ b/backend/pkg/model/integration/data_plane_type.go
@@ -1,0 +1,94 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package integration
+
+import "fmt"
+
+type DataPlaneType struct {
+	TypeName string `gorm:"type_name;primary_key" json:"typeName"`
+	Desc     string `gorm:"desc" json:"desc"`
+
+	ParamSpec      JSONField[ParamSpec] `gorm:"param_spec" json:"paramSpec"`           // JSONStr
+	CapabilitySpec JSONField[[]string]  `gorm:"capability_spec" json:"capabilitySpec"` // Str Slice
+}
+
+func (DataPlaneType) TableName() string {
+	return "data_plane_type"
+}
+
+type JSONType string
+
+const (
+	JSONTypeObject  JSONType = "object"
+	JSONTypeArray   JSONType = "array"
+	JSONTypeString  JSONType = "string"
+	JSONTypeNumber  JSONType = "number"
+	JSONTypeBoolean JSONType = "boolean"
+	JSONTypeNull    JSONType = "null"
+)
+
+type ParamSpec struct {
+	Name     string      `json:"name"`
+	Type     JSONType    `json:"type"`
+	Optional bool        `json:"optional,omitempty"`
+	Children []ParamSpec `json:"children,omitempty"`
+}
+
+func ValidateJSON(value any, schema ParamSpec) error {
+	switch schema.Type {
+	case JSONTypeObject:
+		obj, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("field '%s' expected object", schema.Name)
+		}
+		for _, child := range schema.Children {
+			val, exists := obj[child.Name]
+			if !exists {
+				if child.Optional {
+					continue
+				}
+				return fmt.Errorf("missing required field: %s", child.Name)
+			}
+			if err := ValidateJSON(val, child); err != nil {
+				return err
+			}
+		}
+	case JSONTypeArray:
+		arr, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("field '%s' expected array", schema.Name)
+		}
+		for _, item := range arr {
+			// 数组元素类型统一使用 schema.Children[0]
+			if len(schema.Children) == 0 {
+				return fmt.Errorf("field '%s' array has no element type defined", schema.Name)
+			}
+			if err := ValidateJSON(item, schema.Children[0]); err != nil {
+				return err
+			}
+		}
+	case JSONTypeString:
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("field '%s' expected string", schema.Name)
+		}
+	case JSONTypeNumber:
+		switch value.(type) {
+		case float64, float32, int, int64, int32:
+			// ok
+		default:
+			return fmt.Errorf("field '%s' expected number", schema.Name)
+		}
+	case JSONTypeBoolean:
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("field '%s' expected boolean", schema.Name)
+		}
+	case JSONTypeNull:
+		if value != nil {
+			return fmt.Errorf("field '%s' expected null", schema.Name)
+		}
+	default:
+		return fmt.Errorf("unknown type for field '%s'", schema.Name)
+	}
+	return nil
+}

--- a/backend/pkg/model/request/data_plane_req.go
+++ b/backend/pkg/model/request/data_plane_req.go
@@ -103,3 +103,11 @@ type QueryAPPInfoTagValuesRequest struct {
 type CreateDataPlaneRequest struct {
 	integration.DataPlane
 }
+
+type UpdateDataPlaneRequest struct {
+	integration.DataPlane
+}
+
+type DeleteDataPlaneRequest struct {
+	ID int `form:"id" json:"id" binding:"required"`
+}

--- a/backend/pkg/model/request/data_plane_req.go
+++ b/backend/pkg/model/request/data_plane_req.go
@@ -3,6 +3,8 @@
 
 package request
 
+import "github.com/CloudDetail/apo/backend/pkg/model/integration"
+
 type QueryServicesRequest struct {
 	Cluster   string `form:"cluster"`                                      // query Cluster
 	StartTime int64  `form:"startTime" binding:"min=0"`                    // query start time
@@ -39,9 +41,9 @@ type QueryServiceNameRequest struct {
 }
 
 type QueryTopologyRequest struct {
-	Cluster     string `form:"cluster"`                                      // query Cluster
-	StartTime   int64  `form:"startTime" binding:"min=0"`                    // query start time
-	EndTime     int64  `form:"endTime" binding:"required,gtfield=StartTime"` // query end time
+	Cluster   string `form:"cluster"`                                      // query Cluster
+	StartTime int64  `form:"startTime" binding:"min=0"`                    // query start time
+	EndTime   int64  `form:"endTime" binding:"required,gtfield=StartTime"` // query end time
 }
 
 type QueryServiceNameTag struct {
@@ -65,7 +67,7 @@ type ListCustomTopologyRequest struct {
 }
 
 type DeleteCustomTopologyRequest struct {
-	ID        int   `form:"id" binding:"required"`
+	ID int `form:"id" binding:"required"`
 }
 
 type SetServiceNameRuleRequest struct {
@@ -96,4 +98,8 @@ type QueryAPPInfoTagValuesRequest struct {
 	EndTime   int64 `form:"endTime" json:"endTime"`
 
 	Label string `form:"key" json:"key"`
+}
+
+type CreateDataPlaneRequest struct {
+	integration.DataPlane
 }

--- a/backend/pkg/model/response/dataplane_resp.go
+++ b/backend/pkg/model/response/dataplane_resp.go
@@ -5,6 +5,7 @@ package response
 
 import (
 	"github.com/CloudDetail/apo/backend/pkg/model"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 )
 
@@ -76,4 +77,12 @@ type QueryAPPInfoTagsResponse struct {
 type QueryAPPInfoTagValuesResponse struct {
 	Label  string   `json:"label"`
 	Values []string `json:"values"`
+}
+
+type ListDataPlaneTypeResponse struct {
+	DPTypes []integration.DataPlaneType `json:"dpTypes"`
+}
+
+type ListDataPlaneResponse struct {
+	DataPlanes []integration.DataPlaneWithClusterIDs `json:"dataPlanes"`
 }

--- a/backend/pkg/repository/database/dao.go
+++ b/backend/pkg/repository/database/dao.go
@@ -19,6 +19,8 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/logger"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database/integration"
+
+	mi "github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"go.uber.org/zap"
 	"gorm.io/gorm"
 
@@ -157,6 +159,10 @@ type Repo interface {
 	ListAllServiceNameRuleCondition(ctx core.Context) ([]ServiceNameRuleCondition, error)
 	ServiceNameRuleExists(ctx core.Context, ruleId int) (bool, error)
 	DeleteServiceNameRule(ctx core.Context, ruleId int) error
+	ListDataPlaneType(ctx core.Context) ([]mi.DataPlaneType, error)
+	GetDataPlaneType(ctx core.Context, typeName string) (*mi.DataPlaneType, error)
+	CreateDataPlane(ctx core.Context, d *mi.DataPlane) error
+	ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterIDs, error)
 
 	integration.ObservabilityInputManage
 	DaoDataScope
@@ -309,5 +315,8 @@ func migrateTable(db *gorm.DB) error {
 		&ServiceNameRule{},
 		&ServiceNameRuleCondition{},
 		&CustomServiceTopology{},
+		&mi.DataPlaneType{},
+		&mi.DataPlane{},
+		&mi.Cluster2DataPlane{},
 	)
 }

--- a/backend/pkg/repository/database/dao.go
+++ b/backend/pkg/repository/database/dao.go
@@ -163,6 +163,9 @@ type Repo interface {
 	GetDataPlaneType(ctx core.Context, typeName string) (*mi.DataPlaneType, error)
 	CreateDataPlane(ctx core.Context, d *mi.DataPlane) error
 	ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterIDs, error)
+	CheckDataPlaneExist(ctx core.Context, id int) (bool, error)
+	UpdateDataPlane(ctx core.Context, d *mi.DataPlane) error
+	DeleteDataPlane(ctx core.Context, id int) error
 
 	integration.ObservabilityInputManage
 	DaoDataScope

--- a/backend/pkg/repository/database/dao_dataplane.go
+++ b/backend/pkg/repository/database/dao_dataplane.go
@@ -58,3 +58,18 @@ func (repo *daoRepo) ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterI
 	return res, nil
 
 }
+
+func (repo *daoRepo) CheckDataPlaneExist(ctx core.Context, id int) (bool, error) {
+	var count int64
+	err := repo.GetContextDB(ctx).Model(&mi.DataPlane{}).Where("id = ?", id).Count(&count).Error
+	return count > 0, err
+}
+
+func (repo *daoRepo) UpdateDataPlane(ctx core.Context, d *mi.DataPlane) error {
+	// TODO update time
+	return repo.GetContextDB(ctx).Save(d).Error
+}
+
+func (repo *daoRepo) DeleteDataPlane(ctx core.Context, id int) error {
+	return repo.GetContextDB(ctx).Where("id = ?", id).Delete(&mi.DataPlane{}).Error
+}

--- a/backend/pkg/repository/database/dao_dataplane.go
+++ b/backend/pkg/repository/database/dao_dataplane.go
@@ -29,6 +29,7 @@ func (repo *daoRepo) ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterI
 			"type_name", "desc", "param_spec", "capability_spec").
 		Where("is_delete = ?", false).
 		Joins("LEFT JOIN data_plane_type dpt ON dp.typ = dpt.type_name").
+		Order("id asc").
 		Find(&dps).Error
 
 	if err != nil {

--- a/backend/pkg/repository/database/dao_dataplane.go
+++ b/backend/pkg/repository/database/dao_dataplane.go
@@ -1,0 +1,60 @@
+package database
+
+import (
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	mi "github.com/CloudDetail/apo/backend/pkg/model/integration"
+)
+
+func (repo *daoRepo) ListDataPlaneType(ctx core.Context) ([]mi.DataPlaneType, error) {
+	var res []mi.DataPlaneType
+	err := repo.GetContextDB(ctx).Find(&res).Error
+	return res, err
+}
+
+func (repo *daoRepo) GetDataPlaneType(ctx core.Context, typeName string) (*mi.DataPlaneType, error) {
+	var res mi.DataPlaneType
+	err := repo.GetContextDB(ctx).Where("type_name = ?", typeName).First(&res).Error
+	return &res, err
+}
+
+func (repo *daoRepo) CreateDataPlane(ctx core.Context, d *mi.DataPlane) error {
+	return repo.GetContextDB(ctx).Create(d).Error
+}
+
+func (repo *daoRepo) ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterIDs, error) {
+	var dps []mi.DataPlaneWithType
+
+	err := repo.GetContextDB(ctx).Table("data_plane as dp").
+		Select("id", "name", "typ", "params", "capability",
+			"type_name", "desc", "param_spec", "capability_spec").
+		Joins("LEFT JOIN data_plane_type dpt ON dp.typ = dpt.type_name").
+		Find(&dps).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	var c2Ds []mi.Cluster2DataPlane
+	err = repo.GetContextDB(ctx).Model(&mi.Cluster2DataPlane{}).
+		Find(&c2Ds).Error
+
+	if err != nil {
+		return nil, err
+	}
+
+	var res []mi.DataPlaneWithClusterIDs
+	for i := 0; i < len(dps); i++ {
+		var clusterIDs []string
+		for _, c2D := range c2Ds {
+			if c2D.DataPlaneID == dps[i].ID {
+				clusterIDs = append(clusterIDs, c2D.ClusterID)
+			}
+		}
+		res = append(res, mi.DataPlaneWithClusterIDs{
+			DataPlaneWithType: dps[i],
+			ClusterIDs:        clusterIDs,
+		})
+	}
+	return res, nil
+
+}

--- a/backend/pkg/repository/database/dao_dataplane.go
+++ b/backend/pkg/repository/database/dao_dataplane.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package database
 
 import (

--- a/backend/pkg/repository/database/dao_dataplane.go
+++ b/backend/pkg/repository/database/dao_dataplane.go
@@ -27,6 +27,7 @@ func (repo *daoRepo) ListDataPlane(ctx core.Context) ([]mi.DataPlaneWithClusterI
 	err := repo.GetContextDB(ctx).Table("data_plane as dp").
 		Select("id", "name", "typ", "params", "capability",
 			"type_name", "desc", "param_spec", "capability_spec").
+		Where("is_delete = ?", false).
 		Joins("LEFT JOIN data_plane_type dpt ON dp.typ = dpt.type_name").
 		Find(&dps).Error
 
@@ -66,10 +67,11 @@ func (repo *daoRepo) CheckDataPlaneExist(ctx core.Context, id int) (bool, error)
 }
 
 func (repo *daoRepo) UpdateDataPlane(ctx core.Context, d *mi.DataPlane) error {
-	// TODO update time
 	return repo.GetContextDB(ctx).Save(d).Error
 }
 
 func (repo *daoRepo) DeleteDataPlane(ctx core.Context, id int) error {
-	return repo.GetContextDB(ctx).Where("id = ?", id).Delete(&mi.DataPlane{}).Error
+	return repo.GetContextDB(ctx).Model(&mi.DataPlane{}).
+		Where("id = ?", id).
+		Update("is_deleted", true).Error
 }

--- a/backend/pkg/repository/database/dao_team.go
+++ b/backend/pkg/repository/database/dao_team.go
@@ -284,7 +284,7 @@ func (repo *daoRepo) getUsersIDNameByTeamIDs(ctx core.Context, teamIDs ...int64)
 			userIds = append(userIds, user2Team.UserID)
 		}
 	}
-	
+
 	users, err := repo.GetUsersInfoWithoutTeamAndRole(ctx, userIds)
 	if err != nil {
 		return nil, err

--- a/backend/pkg/router/router_api.go
+++ b/backend/pkg/router/router_api.go
@@ -333,5 +333,8 @@ func setApiRouter(r *resource) {
 		dataplaneAPI.POST("/servicename/upsertRule", handler.SetServiceNameRule())
 		dataplaneAPI.GET("/servicename/listRule", handler.ListServiceNameRule())
 		dataplaneAPI.POST("/servicename/deleteRule", handler.DeleteServiceNameRule())
+		dataplaneAPI.GET("/type/list", handler.ListDataPlaneType())
+		dataplaneAPI.GET("/list", handler.ListDataPlane())
+		dataplaneAPI.POST("/create", handler.CreateDataPlane())
 	}
 }

--- a/backend/pkg/services/dataplane/service.go
+++ b/backend/pkg/services/dataplane/service.go
@@ -32,6 +32,8 @@ type Service interface {
 	DeleteServiceNameRule(ctx core.Context, req *request.DeleteServiceNameRuleRequest) error
 	ListAPPInfoLabelsKeys(ctx core.Context, req *request.QueryAPPInfoTagsRequest) (*response.QueryAPPInfoTagsResponse, error)
 	ListAPPInfoLabelValues(ctx core.Context, req *request.QueryAPPInfoTagValuesRequest) (*response.QueryAPPInfoTagValuesResponse, error)
+
+	DPService
 }
 
 type service struct {

--- a/backend/pkg/services/dataplane/service_data_plane.go
+++ b/backend/pkg/services/dataplane/service_data_plane.go
@@ -32,13 +32,11 @@ func (s *service) ListDataPlaneType(ctx core.Context) (*response.ListDataPlaneTy
 func (s *service) CreateDataPlane(ctx core.Context, req *request.CreateDataPlaneRequest) error {
 	dpType, err := s.dbRepo.GetDataPlaneType(ctx, req.Typ)
 	if err != nil {
-		// TODO errCode DataPlaneTypeNotExist
-		return core.Error(code.ServerError, "data plane type not exist")
+		return core.Error(code.DataPlaneTypeNotExistError, "data plane type not exist")
 	}
 
 	if err := integration.CheckInvalid(&req.DataPlane, dpType); err != nil {
-		// TODO errCode DataPlaneInvalid
-		return core.Error(code.ServerError, err.Error())
+		return core.Error(code.DataPlaneParamInvalidError, err.Error())
 	}
 
 	return s.dbRepo.CreateDataPlane(ctx, &req.DataPlane)
@@ -53,18 +51,16 @@ func (s *service) ListDataPlane(ctx core.Context) (*response.ListDataPlaneRespon
 
 func (s *service) UpdateDataPlane(ctx core.Context, req *request.UpdateDataPlaneRequest) error {
 	if find, err := s.dbRepo.CheckDataPlaneExist(ctx, req.DataPlane.ID); err != nil || !find {
-		return core.Error(code.ServerError, "data plane not exist") // TODO DataPlaneNotExistError
+		return core.Error(code.DataPlaneNotExistError, "data plane not exist")
 	}
 
 	dpType, err := s.dbRepo.GetDataPlaneType(ctx, req.Typ)
 	if err != nil {
-		// TODO errCode DataPlaneTypeNotExist
-		return core.Error(code.ServerError, "data plane type not exist")
+		return core.Error(code.DataPlaneTypeNotExistError, "data plane type not exist")
 	}
 
 	if err := integration.CheckInvalid(&req.DataPlane, dpType); err != nil {
-		// TODO errCode DataPlaneInvalid
-		return core.Error(code.ServerError, err.Error())
+		return core.Error(code.DataPlaneParamInvalidError, err.Error())
 	}
 
 	return s.dbRepo.UpdateDataPlane(ctx, &req.DataPlane)
@@ -72,7 +68,7 @@ func (s *service) UpdateDataPlane(ctx core.Context, req *request.UpdateDataPlane
 
 func (s *service) DeleteDataPlane(ctx core.Context, req *request.DeleteDataPlaneRequest) error {
 	if find, err := s.dbRepo.CheckDataPlaneExist(ctx, req.ID); err != nil || !find {
-		return core.Error(code.ServerError, "data plane not exist") // TODO DataPlaneNotExistError
+		return core.Error(code.DataPlaneNotExistError, "data plane not exist")
 	}
 
 	return s.dbRepo.DeleteDataPlane(ctx, req.ID)

--- a/backend/pkg/services/dataplane/service_list_data_plane_type.go
+++ b/backend/pkg/services/dataplane/service_list_data_plane_type.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package dataplane
 
 import (

--- a/backend/pkg/services/dataplane/service_list_data_plane_type.go
+++ b/backend/pkg/services/dataplane/service_list_data_plane_type.go
@@ -1,0 +1,47 @@
+package dataplane
+
+import (
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+	"github.com/CloudDetail/apo/backend/pkg/model/response"
+)
+
+var _ DPService = (*service)(nil)
+
+type DPService interface {
+	ListDataPlaneType(ctx core.Context) (*response.ListDataPlaneTypeResponse, error)
+
+	CreateDataPlane(ctx core.Context, req *request.CreateDataPlaneRequest) error
+	ListDataPlane(ctx core.Context) (*response.ListDataPlaneResponse, error)
+}
+
+func (s *service) ListDataPlaneType(ctx core.Context) (*response.ListDataPlaneTypeResponse, error) {
+	dpTypes, err := s.dbRepo.ListDataPlaneType(ctx)
+	return &response.ListDataPlaneTypeResponse{
+		DPTypes: dpTypes,
+	}, err
+}
+
+func (s *service) CreateDataPlane(ctx core.Context, req *request.CreateDataPlaneRequest) error {
+	dpType, err := s.dbRepo.GetDataPlaneType(ctx, req.Typ)
+	if err != nil {
+		// TODO errCode DataPlaneTypeNotExist
+		return core.Error(code.ServerError, "data plane type not exist")
+	}
+
+	if err := integration.CheckInvalid(&req.DataPlane, dpType); err != nil {
+		// TODO errCode DataPlaneInvalid
+		return core.Error(code.ServerError, err.Error())
+	}
+
+	return s.dbRepo.CreateDataPlane(ctx, &req.DataPlane)
+}
+
+func (s *service) ListDataPlane(ctx core.Context) (*response.ListDataPlaneResponse, error) {
+	res, err := s.dbRepo.ListDataPlane(ctx)
+	return &response.ListDataPlaneResponse{
+		DataPlanes: res,
+	}, err
+}

--- a/backend/pkg/services/dataplane/service_list_data_plane_type.go
+++ b/backend/pkg/services/dataplane/service_list_data_plane_type.go
@@ -15,6 +15,8 @@ type DPService interface {
 
 	CreateDataPlane(ctx core.Context, req *request.CreateDataPlaneRequest) error
 	ListDataPlane(ctx core.Context) (*response.ListDataPlaneResponse, error)
+	UpdateDataPlane(ctx core.Context, req *request.UpdateDataPlaneRequest) error
+	DeleteDataPlane(ctx core.Context, req *request.DeleteDataPlaneRequest) error
 }
 
 func (s *service) ListDataPlaneType(ctx core.Context) (*response.ListDataPlaneTypeResponse, error) {
@@ -44,4 +46,31 @@ func (s *service) ListDataPlane(ctx core.Context) (*response.ListDataPlaneRespon
 	return &response.ListDataPlaneResponse{
 		DataPlanes: res,
 	}, err
+}
+
+func (s *service) UpdateDataPlane(ctx core.Context, req *request.UpdateDataPlaneRequest) error {
+	if find, err := s.dbRepo.CheckDataPlaneExist(ctx, req.DataPlane.ID); err != nil || !find {
+		return core.Error(code.ServerError, "data plane not exist") // TODO DataPlaneNotExistError
+	}
+
+	dpType, err := s.dbRepo.GetDataPlaneType(ctx, req.Typ)
+	if err != nil {
+		// TODO errCode DataPlaneTypeNotExist
+		return core.Error(code.ServerError, "data plane type not exist")
+	}
+
+	if err := integration.CheckInvalid(&req.DataPlane, dpType); err != nil {
+		// TODO errCode DataPlaneInvalid
+		return core.Error(code.ServerError, err.Error())
+	}
+
+	return s.dbRepo.UpdateDataPlane(ctx, &req.DataPlane)
+}
+
+func (s *service) DeleteDataPlane(ctx core.Context, req *request.DeleteDataPlaneRequest) error {
+	if find, err := s.dbRepo.CheckDataPlaneExist(ctx, req.ID); err != nil || !find {
+		return core.Error(code.ServerError, "data plane not exist") // TODO DataPlaneNotExistError
+	}
+
+	return s.dbRepo.DeleteDataPlane(ctx, req.ID)
 }


### PR DESCRIPTION
## Summary by Sourcery

Add DataPlane configuration support by implementing CRUD endpoints and type listing, integrating models and validation logic, updating service and repository layers, and enhancing API documentation and tests.

New Features:
- Introduce DataPlane config APIs including endpoints to list, create, update, and delete data planes
- Add endpoint to list available DataPlane types

Enhancements:
- Define DataPlane and DataPlaneType models with JSON parameter schema validation and database mappings
- Extend repository and service layers with methods for DataPlane operations
- Update OpenAPI and Swagger documentation for new DataPlane routes and normalize response descriptions

Tests:
- Add unit tests for JSON schema validation of data plane parameters