### PR TITLE
fix: swagger json miss param QueryMetricsRequest

### DIFF
--- a/backend/pkg/api/metric/func_querymetrics.go
+++ b/backend/pkg/api/metric/func_querymetrics.go
@@ -17,6 +17,7 @@ import (
 // @Tags API.metric
 // @Accept application/x-www-form-urlencoded
 // @Produce json
+// @Param Request body metric.QueryMetricsRequest true
 // @Success 200 {object} metric.QueryMetricsResult
 // @Failure 400 {object} code.Failure
 // @Router /api/metric/query [post]


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Include the QueryMetricsRequest body parameter in Swagger documentation via @Param annotation