### PR TITLE
fix(permission): Mismatch when router has leading of trailing '/'.

### DIFF
--- a/backend/pkg/services/permission/check_router_test.go
+++ b/backend/pkg/services/permission/check_router_test.go
@@ -103,6 +103,20 @@ func TestCheckRouterMatch(t *testing.T) {
 			want:         true,
 			errorMessage: "含点路径应精确匹配",
 		},
+		{
+			name:         "前置/",
+			checkRouter:  "/user/list",
+			matchRouter:  "user/list",
+			want:         true,
+			errorMessage: "前置/需要忽略",
+		},
+		{
+			name:         "后置/",
+			checkRouter:  "user/list/",
+			matchRouter:  "user/list",
+			want:         true,
+			errorMessage: "后置/需要忽略",
+		},
 	}
 
 	for _, tt := range tests {

--- a/backend/pkg/services/permission/service_check_router.go
+++ b/backend/pkg/services/permission/service_check_router.go
@@ -65,6 +65,8 @@ func (s *service) CheckRouterPermission(ctx core.Context, userID int64, routerTo
 }
 
 func checkRouterMatch(checkRouter, matchRouter string) bool {
+	checkRouter = strings.Trim(checkRouter, "/")
+	matchRouter = strings.Trim(matchRouter, "/")
 	checkParts := strings.Split(checkRouter, "/")
 	matchParts := strings.Split(matchRouter, "/")
 


### PR DESCRIPTION
## Summary by Sourcery

Trim leading and trailing slashes when matching router paths to ensure consistent comparisons

Bug Fixes:
- Fix router matching to ignore leading or trailing slashes by trimming them before comparison

Tests:
- Add test cases for router paths with leading and trailing slashes