### PR TITLE
Fix: Conditionally include cluster ID filter in k8s event query

### DIFF
--- a/backend/pkg/repository/clickhouse/dao_service_k8s_events.go
+++ b/backend/pkg/repository/clickhouse/dao_service_k8s_events.go
@@ -4,6 +4,7 @@
 package clickhouse
 
 import (
+	"fmt"
 	"log"
 
 	core "github.com/CloudDetail/apo/backend/pkg/core"
@@ -20,7 +21,7 @@ const (
 		  FROM k8s_events
 		  WHERE Timestamp BETWEEN toDateTime($1) AND toDateTime($2)
 		  AND ResourceAttributes['k8s.object.name'] IN ($3)
-		  AND ResourceAttributes['cluster.id'] IN ($4)
+		  %s
 		  GROUP BY LogAttributes['k8s.event.reason'], SeverityText
 		)
 		UNION ALL
@@ -33,7 +34,7 @@ const (
 		  FROM k8s_events
 		  WHERE Timestamp BETWEEN toDateTime($2) - toIntervalDay(7) AND toDateTime($2)
 		  AND ResourceAttributes['k8s.object.name'] IN ($3)
-		  AND ResourceAttributes['cluster.id'] IN ($4)
+		  %s
 		  GROUP BY LogAttributes['k8s.event.reason'], SeverityText
 		)
 		UNION ALL
@@ -46,17 +47,34 @@ const (
 		  FROM k8s_events
 		  WHERE Timestamp BETWEEN toDateTime($2) - toIntervalDay(30) AND toDateTime($2)
 		  AND ResourceAttributes['k8s.object.name'] IN ($3)
-		  AND ResourceAttributes['cluster.id'] IN ($4)
+		  %s
 		  GROUP BY LogAttributes['k8s.event.reason'], SeverityText
 		)`
 )
 
 // CountK8sEvents count the number of K8s events
 // Time in microseconds
-func (ch *chRepo) CountK8sEvents(ctx core.Context, startTime int64, endTim int64, pods []string, clusterIDs []string) ([]K8sEventsCount, error) {
+func (ch *chRepo) CountK8sEvents(ctx core.Context, startTime int64, endTime int64, pods []string, clusterIDs []string) ([]K8sEventsCount, error) {
 	result := make([]K8sEventsCount, 0)
+
+	clusterIdSQLPart := ""
+	var argsForClusterID interface{}
+	if len(clusterIDs) > 0 {
+		clusterIdSQLPart = "AND ResourceAttributes['cluster.id'] IN ($4)"
+		argsForClusterID = clusterIDs
+	}
+	finalQuery := fmt.Sprintf(countK8sEventsSQL, clusterIdSQLPart, clusterIdSQLPart, clusterIdSQLPart)
+	queryArgs := []interface{}{
+		startTime / 1e6,
+		endTime / 1e6,
+		pods,
+	}
+
+	if len(clusterIDs) > 0 {
+		queryArgs = append(queryArgs, argsForClusterID)
+	}
 	// Execute query
-	rows, err := ch.GetContextDB(ctx).Query(ctx.GetContext(), countK8sEventsSQL, startTime/1e6, endTim/1e6, pods, clusterIDs)
+	rows, err := ch.GetContextDB(ctx).Query(ctx.GetContext(), finalQuery, queryArgs...)
 	if err != nil {
 		return result, err
 	}


### PR DESCRIPTION
## Summary by Sourcery

Dynamically construct the CountK8sEvents ClickHouse query to include the cluster.id filter only when clusterIDs are provided and correct the endTime parameter name.

Bug Fixes:
- Omit the cluster.id filter when clusterIDs is empty to return events across all clusters
- Fix typo in parameter name from endTim to endTime in CountK8sEvents signature