### PR TITLE
Feat/integration DataDog alert

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.8
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0
 	github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95
+	github.com/DataDog/datadog-api-client-go/v2 v2.43.0
 	github.com/dave/dst v0.27.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/zapr v1.3.0
@@ -48,6 +49,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/coder/quartz v0.1.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -49,7 +49,11 @@ github.com/ClickHouse/clickhouse-go/v2 v2.34.0 h1:Y4rqkdrRHgExvC4o/NTbLdY5LFQ3LH
 github.com/ClickHouse/clickhouse-go/v2 v2.34.0/go.mod h1:yioSINoRLVZkLyDzdMXPLRIqhDvel8iLBlwh6Iefso8=
 github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95 h1:52seV0rUftzIronLQOHOHbnlz4YHS4/dAB9rSHa+24M=
 github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95/go.mod h1:YpCyr1yI2rybhXMo7STmU7qVvkRp6EDVaDRnU9Wf8ls=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.0 h1:HiRaKLfMe9qnoZ1r6Gm0dHg30i9wi1YqdYPVJ8/Fkgc=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/backend/pkg/model/integration/alert/alert_enrich.go
+++ b/backend/pkg/model/integration/alert/alert_enrich.go
@@ -22,6 +22,10 @@ type AlertEnrichRule struct {
 	SchemaSource string `json:"schemaSource,omitempty" gorm:"type:varchar(255);column:schema_source"`
 }
 
+func (AlertEnrichRule) TableName() string {
+	return "alert_enrich_rules"
+}
+
 type AlertEnrichCondition struct {
 	EnrichRuleID string `json:"-" gorm:"type:varchar(255);column:enrich_rule_id;index"`
 	SourceID     string `json:"-" gorm:"type:varchar(255);column:source_id;index"`

--- a/backend/pkg/model/integration/alert/alert_event.go
+++ b/backend/pkg/model/integration/alert/alert_event.go
@@ -19,9 +19,11 @@ import (
 type AlertEvent struct {
 	Alert `mapstructure:",squash"`
 
-	ID uuid.UUID `json:"id" ch:"id"`
+	// Deprecated: use @EventID instead
+	ID uuid.UUID `json:"-" ch:"id"`
 
-	Detail string `json:"detail" ch:"detail" mapstructure:"detail"`
+	EventID string `json:"id" ch:"event_id"`
+	Detail  string `json:"detail" ch:"detail" mapstructure:"detail"`
 
 	CreateTime   time.Time `json:"createTime" ch:"create_time" mapstructure:"createTime"`
 	UpdateTime   time.Time `json:"updateTime" ch:"update_time" mapstructure:"updateTime"`
@@ -104,7 +106,7 @@ func (e *AlertEvent) ToAMAlert(externalURL string, timeout bool) *types.Alert {
 			Annotations:  convertAnnos,
 			StartsAt:     e.CreateTime,
 			EndsAt:       e.EndTime,
-			GeneratorURL: fmt.Sprintf("%s/#alerts/events/detail/%s/%s", externalURL, e.AlertID, e.ID.String()),
+			GeneratorURL: fmt.Sprintf("%s/#alerts/events/detail/%s/%s", externalURL, e.AlertID, e.EventID),
 		},
 		UpdatedAt: e.UpdateTime,
 		Timeout:   timeout,

--- a/backend/pkg/model/integration/alert/alert_source.go
+++ b/backend/pkg/model/integration/alert/alert_source.go
@@ -11,9 +11,18 @@ const ApoVMAlertSourceID = "efc91f08-86c4-3696-aba8-570d4a8dc069"
 
 type AlertSource struct {
 	SourceFrom
-
 	Clusters []integration.Cluster `json:"clusters" gorm:"-"`
+
+	Params         integration.JSONField[AlertSourceParams] `json:"params" gorm:"type:varchar(2000);column:params;default:'{}'"`
+	EnabledPull    bool                                     `json:"enabledPull" gorm:"type:bool;column:enabled_pull;default:false"`
+	LastPullMillTS int64                                    `json:"lastPullMillTS" gorm:"type:bigint;column:last_pull_mill_ts;default:0"`
 }
+
+func (AlertSource) TableName() string {
+	return "alert_sources"
+}
+
+type AlertSourceParams map[string]any
 
 type AlertSource2Cluster struct {
 	SourceID  string `gorm:"type:varchar(255);column:source_id"`

--- a/backend/pkg/receiver/handle_record.go
+++ b/backend/pkg/receiver/handle_record.go
@@ -53,7 +53,7 @@ func (r *InnerReceivers) sendAlert(ctx core.Context, alert *alert.AlertEvent) er
 	notifyRecord := &model.AlertNotifyRecord{
 		AlertID:   alert.AlertID,
 		CreatedAt: time.Now().UnixMicro(),
-		EventID:   alert.ID.String(),
+		EventID:   alert.EventID,
 	}
 
 	var fails []string

--- a/backend/pkg/receiver/handle_record.go
+++ b/backend/pkg/receiver/handle_record.go
@@ -46,7 +46,7 @@ func (r *InnerReceivers) HandleAlertCheckRecord(ctx core.Context, record *model.
 }
 
 func (r *InnerReceivers) sendAlert(ctx core.Context, alert *alert.AlertEvent) error {
-	if _, find := r.slientCFGMap.Load(alert.AlertID); find {
+	if _, find := r.silentCFGMap.Load(alert.AlertID); find {
 		return nil
 	}
 

--- a/backend/pkg/receiver/slient_config.go
+++ b/backend/pkg/receiver/slient_config.go
@@ -12,7 +12,7 @@ import (
 )
 
 func (r *InnerReceivers) GetSlienceConfigByAlertID(ctx core.Context, alertID string) (*sc.AlertSlienceConfig, error) {
-	if cfgPtr, find := r.slientCFGMap.Load(alertID); find {
+	if cfgPtr, find := r.silentCFGMap.Load(alertID); find {
 		return cfgPtr.(*sc.AlertSlienceConfig), nil
 	}
 	return nil, nil
@@ -29,33 +29,33 @@ func (r *InnerReceivers) SetSlienceConfigByAlertID(ctx core.Context, alertID str
 	}
 
 	now := time.Now()
-	slienceconfig := &sc.AlertSlienceConfig{
+	silenceConfig := &sc.AlertSlienceConfig{
 		AlertID: alertID,
 		For:     forDuration,
 		StartAt: time.Now(),
 		EndAt:   now.Add(duration),
 	}
 
-	if oldCFGPtr, find := r.slientCFGMap.Swap(alertID, slienceconfig); find {
+	if oldCFGPtr, find := r.silentCFGMap.Swap(alertID, silenceConfig); find {
 		cfg := oldCFGPtr.(*sc.AlertSlienceConfig)
-		slienceconfig.ID = cfg.ID
-		slienceconfig.AlertName = cfg.AlertName
-		slienceconfig.Group = cfg.Group
-		slienceconfig.Tags = cfg.Tags
-		return r.database.UpdateAlertSlience(ctx, slienceconfig)
+		silenceConfig.ID = cfg.ID
+		silenceConfig.AlertName = cfg.AlertName
+		silenceConfig.Group = cfg.Group
+		silenceConfig.Tags = cfg.Tags
+		return r.database.UpdateAlertSlience(ctx, silenceConfig)
 	} else {
 		event, err := r.ch.GetLatestAlertEventByAlertID(ctx, alertID)
 		if err == nil && event != nil {
-			slienceconfig.AlertName = event.Name
-			slienceconfig.Tags = event.EnrichTags
-			slienceconfig.Group = event.Group
+			silenceConfig.AlertName = event.Name
+			silenceConfig.Tags = event.EnrichTags
+			silenceConfig.Group = event.Group
 		}
-		return r.database.AddAlertSlience(ctx, slienceconfig)
+		return r.database.AddAlertSlience(ctx, silenceConfig)
 	}
 }
 
 func (r *InnerReceivers) RemoveSlienceConfigByAlertID(ctx core.Context, alertID string) error {
-	if cfgPtr, loaded := r.slientCFGMap.LoadAndDelete(alertID); loaded {
+	if cfgPtr, loaded := r.silentCFGMap.LoadAndDelete(alertID); loaded {
 		cfg := cfgPtr.(*sc.AlertSlienceConfig)
 		return r.database.DeleteAlertSlience(ctx, cfg.ID)
 	}

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -97,7 +97,7 @@ filtered_workflows AS (
   ORDER BY created_at DESC LIMIT 1 BY ref
 )
 SELECT
-  ae.id,
+  ae.event_id,
   ae.group,
   ae.name,
   ae.alert_id,

--- a/backend/pkg/repository/clickhouse/integration/alert.go
+++ b/backend/pkg/repository/clickhouse/integration/alert.go
@@ -13,7 +13,7 @@ import (
 
 func (ch *chRepo) InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error {
 	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
-		INSERT INTO alert_event (id,name,group,severity, status, detail, alert_id, raw_tags, tags,create_time, update_time, end_time, received_time, source_id, source)
+		INSERT INTO alert_event (event_id,name,group,severity, status, detail, alert_id, raw_tags, tags,create_time, update_time, end_time, received_time, source_id, source)
 		VALUES
 	`)
 
@@ -32,7 +32,7 @@ func (ch *chRepo) InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEv
 		}
 
 		if err := batch.Append(
-			event.ID,
+			event.EventID,
 			event.Name, event.Group, event.Severity, event.Status,
 			event.Detail, event.AlertID,
 			rawTagsStr, event.EnrichTags,

--- a/backend/pkg/repository/database/integration/alert/dao.go
+++ b/backend/pkg/repository/database/integration/alert/dao.go
@@ -4,9 +4,10 @@
 package alert
 
 import (
+	"time"
+
 	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
-	dbdriver "github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
 
 	"github.com/CloudDetail/apo/backend/config"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
@@ -19,6 +20,7 @@ type AlertInput interface {
 	CreateAlertSource(ctx core.Context, source *alert.AlertSource) error
 	GetAlertSource(ctx core.Context, sourceId string) (*alert.AlertSource, error)
 	UpdateAlertSource(ctx core.Context, alertSource *alert.AlertSource) error
+	UpdateAlertSourceLastPullTime(ctx core.Context, sourceID string, lastPullTime time.Time) error
 	DeleteAlertSource(ctx core.Context, alertSource alert.SourceFrom) (*alert.AlertSource, error)
 	ListAlertSource(ctx core.Context) ([]alert.AlertSource, error)
 
@@ -79,7 +81,17 @@ func NewAlertInputRepo(db *gorm.DB, cfg *config.Config) (*subRepo, error) {
 		return nil, err
 	}
 
-	err := dbdriver.InitSQL(db, &alert.TargetTag{})
+	err := driver.InitSQL(db, &alert.TargetTag{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = driver.InitSQL(db, &alert.AlertSource{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = driver.InitSQL(db, &alert.AlertEnrichRule{})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/database/integration/alert/dao_manage_alert_source.go
+++ b/backend/pkg/repository/database/integration/alert/dao_manage_alert_source.go
@@ -4,6 +4,8 @@
 package alert
 
 import (
+	"time"
+
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	input "github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
@@ -132,4 +134,10 @@ func (repo *subRepo) DeleteAlertSource(ctx core.Context, alertSource alert.Sourc
 		return nil, err
 	}
 	return &deletedSource, nil
+}
+
+func (repo *subRepo) UpdateAlertSourceLastPullTime(ctx core.Context, sourceID string, lastPullTime time.Time) error {
+	return repo.GetContextDB(ctx).Model(&alert.AlertSource{}).
+		Where("source_id = ?", sourceID).
+		Update("last_pull_mill_ts", lastPullTime.UnixMilli()).Error
 }

--- a/backend/pkg/repository/dify/workflow_worker.go
+++ b/backend/pkg/repository/dify/workflow_worker.go
@@ -117,7 +117,7 @@ func (w *worker) getAlertClassify(c *DifyClient, event *alert.AlertEvent) model.
 
 func (w *worker) createExpiredRecord(c *DifyClient, event *alert.AlertEvent, endTime int64) model.WorkflowRecord {
 	w.logger.Error("alert event is expired, skip alert check",
-		zap.String("event_id", event.ID.String()),
+		zap.String("event_id", event.EventID),
 		zap.Int64("expired_ts", w.expiredTS),
 		zap.Int64("event_ts", endTime),
 	)
@@ -131,7 +131,7 @@ func (w *worker) createExpiredRecord(c *DifyClient, event *alert.AlertEvent, end
 		WorkflowID:    classify.WorkflowId,
 		WorkflowName:  w.FlowName,
 		Ref:           event.AlertID,
-		Input:         event.ID.String(),
+		Input:         event.EventID,
 		Output:        "failed: alert check too late, could be too many event to check or last check cost too much time, skipped",
 		CreatedAt:     roundedTime.UnixMicro(),
 		RoundedTime:   roundedTime.UnixMicro(),
@@ -160,7 +160,7 @@ func (w *worker) doAlertCheck(c *DifyClient, event *alert.AlertEvent, endTime in
 			WorkflowID:    classify.WorkflowId,
 			WorkflowName:  w.FlowName,
 			Ref:           event.AlertID,
-			Input:         event.ID.String(),
+			Input:         event.EventID,
 			Output:        "failed: workflow execution failed due to API call failure",
 			CreatedAt:     roundedTime.UnixMicro(),
 			RoundedTime:   roundedTime.UnixMicro(),
@@ -179,8 +179,8 @@ func (w *worker) doAlertCheck(c *DifyClient, event *alert.AlertEvent, endTime in
 		WorkflowID:    classify.WorkflowId,
 		WorkflowName:  w.FlowName,
 		Ref:           event.AlertID,
-		Input:         event.ID.String(), // TODO record input param
-		Output:        output,            // 'false' means valid alert
+		Input:         event.EventID, // TODO record input param
+		Output:        output,        // 'false' means valid alert
 		CreatedAt:     resp.CreatedAt(),
 		RoundedTime:   roundedTime.UnixMicro(),
 
@@ -252,7 +252,7 @@ func (w *worker) getWorkflowParams(event *alert.AlertEvent) *alert.WorkflowParam
 		ContainerID:  event.GetContainerIDTag(),
 		Tags:         event.EnrichTags,
 		RawTags:      event.Tags,
-		AlertEventId: event.ID.String(),
+		AlertEventId: event.EventID,
 	}
 
 	if len(services) == 1 {

--- a/backend/pkg/services/alerts/service_alert_event_detail.go
+++ b/backend/pkg/services/alerts/service_alert_event_detail.go
@@ -36,7 +36,7 @@ func (s *service) AlertDetail(ctx core.Context, req *request.GetAlertDetailReque
 	req.Pagination.Total = total
 	var localIndex int
 	for idx, event := range releatedEvents {
-		if event.ID.String() == req.EventID {
+		if event.EventID == req.EventID {
 			localIndex = idx
 		}
 	}

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -18,7 +18,6 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	"github.com/CloudDetail/apo/backend/pkg/services/common"
-	"github.com/google/uuid"
 )
 
 func (s *service) AlertEventList(ctx core.Context, req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
@@ -152,7 +151,8 @@ func (s *service) fillWorkflowParams(ctx core.Context, record *alert.AEventWithW
 
 	if len(record.Input) > 0 {
 		// replace EventID by checkedEvent
-		record.ID, _ = uuid.Parse(record.Input)
+		// record.ID, _ = uuid.Parse(record.Input)
+		record.EventID = record.Input
 	}
 
 	record.WorkflowParams = alert.WorkflowParams{

--- a/backend/pkg/services/integration/alert/decoder/datadog_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/datadog_decoder.go
@@ -1,0 +1,53 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package decoder
+
+import (
+	"encoding/json"
+
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
+
+type DatadogDecoder struct {
+}
+
+func (d *DatadogDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]alert.AlertEvent, error) {
+	var event map[string]any
+	err := json.Unmarshal(data, &event)
+	if err != nil {
+		return nil, err
+	}
+
+	alertEvent := alert.AlertEvent{
+		Alert: alert.Alert{
+			Source:     sourceFrom.SourceName,
+			SourceID:   sourceFrom.SourceID,
+			AlertID:    getJson[string](event, "alert_id"),
+			Group:      getJson[string](event, "group"),
+			Name:       getJson[string](event, "name"),
+			EnrichTags: make(map[string]string),
+			Tags:       getJson[map[string]any](event, "tags"),
+		},
+		// ID:      uuid.UUID{},
+		EventID: getJson[string](event, "event_id"),
+		Detail:  getJson[string](event, "message"),
+		// CreateTime:   time.Time{},
+		// UpdateTime:   time.Time{},
+		// EndTime:      time.Time{},
+		// ReceivedTime: time.Time{},
+		// Severity:     "",
+		// Status:       "",
+	}
+	return []alert.AlertEvent{alertEvent}, nil
+}
+
+func getJson[T any](data map[string]any, key string) T {
+	var result T
+	if value, ok := data[key]; ok {
+		if value, ok := value.(T); ok {
+			return value
+		}
+	}
+	return result
+}

--- a/backend/pkg/services/integration/alert/decoder/json_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/json_decoder.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
-	"github.com/google/uuid"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -30,7 +29,8 @@ func (d JsonDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]alert.A
 	if len(alertEvent.AlertID) == 0 {
 		alertEvent.AlertID = alert.FastAlertID(alertEvent.Name, alertEvent.Tags)
 	}
-	alertEvent.ID = uuid.New()
+	// alertEvent.ID = uuid.New()
+	alertEvent.EventID = alertEvent.AlertID
 	alertEvent.SourceID = sourceFrom.SourceID
 	alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 	alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)

--- a/backend/pkg/services/integration/alert/decoder/json_decoder_test.go
+++ b/backend/pkg/services/integration/alert/decoder/json_decoder_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
-	"github.com/google/uuid"
 )
 
 func TestJsonDecoder_Decode(t *testing.T) {
@@ -69,7 +68,7 @@ func TestJsonDecoder_Decode(t *testing.T) {
 							"node":      "larger-server-6",
 						},
 					},
-					ID:           uuid.UUID{},
+					EventID:      "",
 					Detail:       "服务出现异常",
 					CreateTime:   createTime,
 					UpdateTime:   time.UnixMilli(1737514800000),
@@ -87,7 +86,7 @@ func TestJsonDecoder_Decode(t *testing.T) {
 			d := JsonDecoder{}
 			got, err := d.Decode(tt.args.sourceFrom, tt.args.data)
 			for i := range got {
-				got[i].ID = uuid.UUID{}
+				got[i].EventID = ""
 				got[i].ReceivedTime = time.Unix(0, 0)
 			}
 

--- a/backend/pkg/services/integration/alert/decoder/prom_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/prom_decoder.go
@@ -10,7 +10,6 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/model"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
-	"github.com/google/uuid"
 	"go.uber.org/multierr"
 )
 
@@ -38,7 +37,8 @@ func (d PrometheusDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]a
 		if len(alertEvent.AlertID) == 0 {
 			alertEvent.AlertID = alert.FastAlertID(alertEvent.Name, alertEvent.Tags)
 		}
-		alertEvent.ID = uuid.New()
+		// alertEvent.ID = uuid.New()
+		alertEvent.EventID = alertEvent.AlertID
 		alertEvent.SourceID = sourceFrom.SourceID
 		alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 		alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)

--- a/backend/pkg/services/integration/alert/decoder/zabbix_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/zabbix_decoder.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
-	"github.com/google/uuid"
 )
 
 type ZabbixDecoder struct {
@@ -44,7 +43,8 @@ func (d ZabbixDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]alert
 	}
 
 	alertEvent, err := d.jsDecoder.convertAlertEvent(event)
-	alertEvent.ID = uuid.New()
+	// alertEvent.ID = uuid.New()
+	alertEvent.EventID = alertEvent.AlertID
 	alertEvent.SourceID = sourceFrom.SourceID
 	alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 	alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)

--- a/backend/pkg/services/integration/alert/dispatch.go
+++ b/backend/pkg/services/integration/alert/dispatch.go
@@ -53,6 +53,18 @@ func (d *Dispatcher) DispatchEvents(
 	return events, err
 }
 
+func (d *Dispatcher) DispatchDecodedEvents(
+	source *alert.SourceFrom, events []alert.AlertEvent,
+) error {
+	enricherPtr, find := d.EnricherMap.Load(source.SourceID)
+	if !find {
+		return alert.ErrAlertSourceNotExist{}
+	}
+
+	enricher := enricherPtr.(*enrich.AlertEnricher)
+	return enricher.Enrich(events)
+}
+
 // AddOrUpdateAlertSourceRule
 func (d *Dispatcher) AddOrUpdateAlertSourceRule(
 	source alert.SourceFrom, enricher *enrich.AlertEnricher,

--- a/backend/pkg/services/integration/alert/provider.go
+++ b/backend/pkg/services/integration/alert/provider.go
@@ -1,0 +1,51 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package alert
+
+import (
+	"time"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/provider"
+)
+
+var providerMap = map[string]func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) provider.Provider{
+	"datadog": provider.NewDatadogProvider,
+}
+
+func (s *service) KeepPullAlert(ctx core.Context, source alert.AlertSource, interval time.Duration, p provider.Provider) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	now := time.Now()
+
+	lastPullTime := time.UnixMilli(source.LastPullMillTS)
+	if lastPullTime.Add(15 * 24 * time.Hour).Before(now) {
+		lastPullTime = now.Add(-15 * 24 * time.Hour)
+	}
+
+	for range ticker.C {
+		now := time.Now()
+		if now.Sub(lastPullTime) < interval {
+			continue
+		}
+		events, err := p.GetAlerts(nil)
+		if err != nil {
+			continue
+		}
+
+		err = s.dispatcher.DispatchDecodedEvents(&source.SourceFrom, events)
+		if err != nil {
+			continue
+		}
+
+		lastPullTime = now
+		s.difyRepo.SubmitAlertEvents(events)
+		err = s.ckRepo.InsertAlertEvent(ctx, events, source.SourceFrom)
+		if err == nil {
+			s.dbRepo.UpdateAlertSourceLastPullTime(ctx, source.SourceID, lastPullTime)
+		}
+	}
+}

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -1,0 +1,261 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+type DatadogProvider struct {
+	api *datadogV2.EventsApi
+
+	ctx        context.Context
+	sourceFrom alert.SourceFrom
+}
+
+func NewDatadogProvider(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) Provider {
+	configuration := datadog.NewConfiguration()
+	client := datadog.NewAPIClient(configuration)
+
+	ctx := context.WithValue(context.Background(),
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": params["site"].(string),
+		},
+	)
+
+	ctx = context.WithValue(ctx,
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {Key: params["apiKey"].(string)},
+			"appKeyAuth": {Key: params["appKey"].(string)},
+		},
+	)
+
+	return &DatadogProvider{
+		api:        datadogV2.NewEventsApi(client),
+		ctx:        ctx,
+		sourceFrom: sourceFrom,
+	}
+}
+
+func (f *DatadogProvider) GetAlerts(args map[string]any) ([]alert.AlertEvent, error) {
+	lastPullTs := args["from"].(time.Time)
+	now := args["to"].(time.Time)
+
+	resChan, cancel := f.api.ListEventsWithPagination(f.ctx, *datadogV2.NewListEventsOptionalParameters().
+		WithPageLimit(1000).
+		WithSort(datadogV2.EVENTSSORT_TIMESTAMP_ASCENDING).
+		WithFilterFrom(strconv.FormatInt(lastPullTs.UnixMilli(), 10)).
+		WithFilterTo(strconv.FormatInt(now.UnixMilli(), 10)).
+		WithFilterQuery("source:alert"),
+	)
+	defer cancel()
+
+	receivedTime := time.Now()
+
+	var events []alert.AlertEvent
+	var err error
+	for item := range resChan {
+		if item.Error != nil {
+			err = item.Error
+			break
+		}
+
+		attrs := item.Item.Attributes
+		nestedAttrs := item.Item.Attributes.Attributes
+
+		monitor := nestedAttrs.GetMonitor()
+		var priority = alert.SeverityUnknownLevel
+		if priorityLevel, find := monitor.AdditionalProperties["priority"]; find {
+			priority = getDDPriority(priorityLevel.(float64))
+		}
+
+		var status = alert.StatusFiring
+		var createTime, endTime time.Time
+		if transition, find := monitor.AdditionalProperties["transition"]; find {
+			status = getDDStatus(transition)
+
+			if status == alert.StatusResolved {
+				endTime = time.UnixMilli(nestedAttrs.GetTimestamp())
+			}
+		}
+		if nestedAttrs.GetDuration() > 0 {
+			createTime = time.UnixMilli(nestedAttrs.GetTimestamp() - nestedAttrs.GetDuration()/1e6)
+		} else {
+			createTime = time.UnixMilli(nestedAttrs.GetTimestamp())
+		}
+
+		tags := buildDDTags(nestedAttrs, attrs.GetTags())
+		group := getGroup(nestedAttrs, attrs.GetTags())
+
+		events = append(events, alert.AlertEvent{
+			Alert: alert.Alert{
+				Source:     f.sourceFrom.SourceName,
+				SourceID:   f.sourceFrom.SourceID,
+				AlertID:    nestedAttrs.GetAggregationKey(),
+				Group:      group,
+				Name:       nestedAttrs.GetTitle(),
+				EnrichTags: make(map[string]string),
+				Tags:       tags,
+			},
+			// ID:           uuid.UUID{},
+			EventID:      item.Item.GetId(),
+			Detail:       buildDDDetail(attrs.GetMessage(), tags),
+			CreateTime:   createTime,
+			UpdateTime:   time.UnixMilli(nestedAttrs.GetTimestamp()),
+			EndTime:      endTime,
+			ReceivedTime: receivedTime,
+			Severity:     priority,
+			Status:       status,
+		})
+	}
+
+	return events, err
+}
+
+/*
+*
+
+	{
+		... // resp tags to map
+		"attr": {
+			... // attr tags to map
+			"title": attrs.GetTitle(),
+			"service": attrs.GetService(),
+			"monitor": {
+				... // monitor tags to map
+				"id": attrs.GetMonitorId(),
+				"name": monitor.GetName(),
+				"query": monitor.GetQuery(),
+			},
+		},
+	}
+
+*
+*/
+func buildDDTags(attrs *datadogV2.EventAttributes, eventTags []string) map[string]any {
+	tags := make(map[string]any)
+
+	for _, tagStr := range eventTags {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			tags[tag[0]] = tag[1]
+		} else {
+			tags[tagStr] = ""
+		}
+	}
+
+	attrTags := make(map[string]any)
+	attrTags["title"] = attrs.GetTitle()
+	attrTags["service"] = attrs.GetService()
+	attrTags["hostname"] = attrs.GetHostname()
+	for _, tagStr := range attrs.GetTags() {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			attrTags[tag[0]] = tag[1]
+		} else {
+			attrTags[tagStr] = ""
+		}
+	}
+
+	monitor := attrs.GetMonitor()
+
+	monitorTags := make(map[string]any)
+	monitorTags["id"] = attrs.GetMonitorId()
+	monitorTags["name"] = monitor.GetName()
+	monitorTags["query"] = monitor.GetQuery()
+	for _, tagStr := range monitor.GetTags() {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			monitorTags[tag[0]] = tag[1]
+		} else {
+			monitorTags[tagStr] = ""
+		}
+	}
+
+	tags["attr"] = attrTags
+	attrTags["monitor"] = monitorTags
+
+	return tags
+}
+
+func getDDPriority(priority float64) string {
+	switch priority {
+	case 1:
+		return alert.SeverityCriticalLevel
+	case 2:
+		return alert.SeverityErrorLevel
+	case 3:
+		return alert.SeverityWarnLevel
+	case 4, 5:
+		return alert.SeverityInfoLevel
+	default:
+		return alert.SeverityUnknownLevel
+	}
+}
+
+func getDDStatus(transition any) string {
+	if transition == nil {
+		return alert.StatusFiring
+	}
+
+	transitionMap := transition.(map[string]any)
+	if status, find := transitionMap["transition_type"]; find {
+		if status == "alert recovery" {
+			return alert.StatusResolved
+		}
+	}
+	return alert.StatusFiring
+}
+
+func buildDDDetail(message string, tags map[string]any) string {
+	detail := make(map[string]any)
+	detail["summary"] = message
+	detail["description"] = tags
+	detailBytes, err := json.Marshal(detail)
+	if err != nil {
+		return ""
+	}
+	return string(detailBytes)
+}
+
+func getGroup(attrs *datadogV2.EventAttributes, eventTags []string) string {
+	for _, tag := range eventTags {
+		if strings.HasPrefix(tag, "apo_group:") {
+			return tag[6:]
+		}
+	}
+
+	tags := attrs.GetTags()
+
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, "apo_group:") {
+			return tag[6:]
+		}
+	}
+
+	monitorTags := attrs.GetTags()
+	if len(monitorTags) > 0 {
+		for _, tag := range monitorTags {
+			if strings.HasPrefix(tag, "apo_group:") {
+				return tag[6:]
+			}
+		}
+	}
+
+	if len(attrs.GetService()) > 0 && attrs.GetService() != "undefined" {
+		return string(clickhouse.APP_GROUP)
+	}
+	return ""
+}

--- a/backend/pkg/services/integration/alert/provider/provider.go
+++ b/backend/pkg/services/integration/alert/provider/provider.go
@@ -1,0 +1,10 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+
+type Provider interface {
+	GetAlerts(args map[string]any) ([]alert.AlertEvent, error)
+}

--- a/backend/sqlscripts/target_tags.sql
+++ b/backend/sqlscripts/target_tags.sql
@@ -60,7 +60,15 @@ INSERT INTO alert_enrich_rules (enrich_rule_id,source_id,r_type,rule_order,from_
 	 ('c3c86c94-3a98-479b-adb7-a5895d28b6c5','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.db_url','',8,'','',''),
 	 ('6dcbf6b6-ecd5-494f-afcb-3cfbbd2290f2','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_name','([^(]+)$',9,'','',''),
 	 ('763d0d00-c160-4944-80b5-9d0d347841fc','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_name','(\d+\.\d+\.\d+\.\d+)',10,'','',''),
-	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_port','(\d+)',11,'','','');
+	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_port','(\d+)',11,'','',''),
+	 ('e6436efb-681c-452d-9364-828877b782b2','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.service','',1,'','',''),
+	 ('e44657d1-2acd-4be0-acb0-31e8899e0761','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.content_key','',2,'','',''),
+	 ('fd96ba9d-9a47-41cc-998c-807add758baf','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.namespace','',3,'','',''),
+	 ('6cb42756-7d9e-4696-b7e9-1a561ac40beb','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pod','',4,'','',''),
+	 ('95d1708b-3328-4f25-8aec-8a0d6be3d010','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.hostname','',5,'','',''),
+	 ('f552f112-b071-4384-afcb-80a7c62da595','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.node','',5,'','',''),
+	 ('2ab88029-72a3-41cb-8490-96d85af93987','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pid','',6,'','','');
+
 
 INSERT INTO alert_enrich_conditions (enrich_rule_id,source_id,from_field,operation,expr) VALUES
 	 ('55df6363-90ef-48c6-9594-9a95b7836fed','825079a8-4d05-3507-b347-1272a078f9ff','.group','match','middleware'),
@@ -76,7 +84,8 @@ INSERT INTO alert_enrich_conditions (enrich_rule_id,source_id,from_field,operati
 	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','.group','match','middleware'),
 	 ('e09ff3cc-70b6-4da5-ad60-ab2576bfc522','efc91f08-86c4-3696-aba8-570d4a8dc069','.group','match','infra');
 
-INSERT INTO alert_sources (source_id,source_name,source_type) VALUES
-	 ('825079a8-4d05-3507-b347-1272a078f9ff','APO_DEFAULT_ENRICH_RULE_PROMETHEUS','prometheus'),
-	 ('2213d3d5-41da-32a8-9026-22c2bf6aa448','APO_DEFAULT_ENRICH_RULE_JSON','json'),
-	 ('efc91f08-86c4-3696-aba8-570d4a8dc069','APO-VM-ALERT','prometheus');
+INSERT INTO alert_sources (source_id,source_name,source_type,params,enable_pull,last_pull_mill_ts) VALUES
+	 ('825079a8-4d05-3507-b347-1272a078f9ff','APO_DEFAULT_ENRICH_RULE_PROMETHEUS','prometheus','{}',false,0),
+	 ('2213d3d5-41da-32a8-9026-22c2bf6aa448','APO_DEFAULT_ENRICH_RULE_JSON','json','{}',false,0),
+	 ('563a44a3-839f-3e23-adff-e00ac8a3e18f','APO_DEFAULT_ENRICH_RULE_DATADOG','datadog','{}',false,0),
+	 ('efc91f08-86c4-3696-aba8-570d4a8dc069','APO-VM-ALERT','prometheus','{}',false,0);

--- a/backend/sqlscripts/upgrade/alert_enrich_rules/1.11.0-upgrade.sql
+++ b/backend/sqlscripts/upgrade/alert_enrich_rules/1.11.0-upgrade.sql
@@ -1,0 +1,8 @@
+INSERT INTO alert_enrich_rules (enrich_rule_id,source_id,r_type,rule_order,from_field,from_regex,target_tag_id,custom_tag,"schema",schema_source) VALUES
+    ('e6436efb-681c-452d-9364-828877b782b2','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.service','',1,'','',''),
+	('e44657d1-2acd-4be0-acb0-31e8899e0761','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.content_key','',2,'','',''),
+	('fd96ba9d-9a47-41cc-998c-807add758baf','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.namespace','',3,'','',''),
+	('6cb42756-7d9e-4696-b7e9-1a561ac40beb','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pod','',4,'','',''),
+	('95d1708b-3328-4f25-8aec-8a0d6be3d010','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.hostname','',5,'','',''),
+	('f552f112-b071-4384-afcb-80a7c62da595','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.node','',5,'','',''),
+	('2ab88029-72a3-41cb-8490-96d85af93987','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pid','',6,'','','');

--- a/backend/sqlscripts/upgrade/alert_sources/1.11.0-upgrade.sql
+++ b/backend/sqlscripts/upgrade/alert_sources/1.11.0-upgrade.sql
@@ -1,0 +1,5 @@
+UPDATE alert_sources SET params = '{}',enable_pull = false,last_pull_mill_ts = 0 WHERE params IS NULL;
+
+INSERT INTO alert_sources (source_id,source_name,source_type,params,enable_pull,last_pull_mill_ts) VALUES
+    ('563a44a3-839f-3e23-adff-e00ac8a3e18f','APO_DEFAULT_ENRICH_RULE_DATADOG','datadog','{}',false,0);
+


### PR DESCRIPTION
## Summary by Sourcery

Integrate DataDog as a new alert source with background pulling and enrich rule support, update schemas and migrations, standardize alert event identification, and correct silent-configuration naming.

New Features:
- Add DataDogProvider and DatadogDecoder for fetching and decoding DataDog alerts.
- Launch background pulling tasks for enabled alert sources using KeepPullAlert.

Bug Fixes:
- Correct misspelling of silent configuration map and cleanup methods (slientCFGMap → silentCFGMap).

Enhancements:
- Extend alert_sources and alert_enrich_rules tables (params, enable_pull, last_pull_mill_ts) with corresponding SQL migrations.
- Replace deprecated AlertEvent ID with EventID across models, DAOs, decoders, and tests.
- Introduce DispatchDecodedEvents in dispatcher and UpdateAlertSourceLastPullTime in database repo.

Build:
- Add github.com/DataDog/datadog-api-client-go/v2 dependency to go.mod.

Tests:
- Update JSON decoder tests to reflect EventID changes.