### PR TITLE
fix: filter svcInstance by namespace

### DIFF
--- a/backend/pkg/api/service/func_getserviceentryendpoints.go
+++ b/backend/pkg/api/service/func_getserviceentryendpoints.go
@@ -126,7 +126,7 @@ func (h *handler) GetServiceEntryEndpoints() core.HandlerFunc {
 			for serviceName := range result {
 				serviceNames = append(serviceNames, serviceName)
 			}
-			alertResps, err = h.serviceoverviewService.GetServicesAlert(c, 0, nil, startTime, endTime, step, serviceNames, nil)
+			alertResps, err = h.serviceoverviewService.GetServicesAlert(c, 0, nil, startTime, endTime, step, serviceNames, req.Namespaces, nil)
 			if err == nil {
 				for _, alertResp := range alertResps {
 					if serviceResp, found := result[alertResp.ServiceName]; found {

--- a/backend/pkg/api/serviceoverview/func_getservicesalert.go
+++ b/backend/pkg/api/serviceoverview/func_getservicesalert.go
@@ -62,7 +62,7 @@ func (h *handler) GetServicesAlert() core.HandlerFunc {
 		}
 
 		var resp []response.ServiceAlertRes
-		data, err := h.serviceoverview.GetServicesAlert(c, 0, req.ClusterIDs, startTime, endTime, step, req.ServiceNames, returnData)
+		data, err := h.serviceoverview.GetServicesAlert(c, 0, req.ClusterIDs, startTime, endTime, step, req.ServiceNames, req.Namespaces, returnData)
 		if err != nil {
 			c.AbortWithError(
 				http.StatusBadRequest,

--- a/backend/pkg/model/request/service_req.go
+++ b/backend/pkg/model/request/service_req.go
@@ -156,6 +156,7 @@ type GetServiceAlertRequest struct {
 	ServiceNames []string `form:"serviceNames" json:"serviceNames"`
 	ReturnData   []string `form:"returnData" json:"returnData"`
 
+	Namespaces []string `form:"namespaces" json:"namespaces"`
 	ClusterIDs []string `form:"clusterIds" json:"clusterIds"`
 	GroupID    int64    `form:"groupId" json:"groupId"`
 }
@@ -261,6 +262,7 @@ type GetServiceEntryEndpointsRequest struct {
 	Step        int64  `form:"step" binding:"required" json:"step"`                         // query step (us)
 	ShowMissTop bool   `form:"showMissTop" json:"showMissTop"`                              // whether to display the lost non-portal service
 
+	Namespaces []string `form:"namespaces" json:"namespaces"`
 	ClusterIDs []string `form:"clusterIds" json:"clusterIds"`
 	GroupID    int64    `form:"groupId" json:"groupId"`
 }

--- a/backend/pkg/repository/prometheus/helper.go
+++ b/backend/pkg/repository/prometheus/helper.go
@@ -44,6 +44,7 @@ const (
 	ClusterIDKey   = "cluster_id"
 	ServiceNameKey = "svc_name"
 	ContentKeyKey  = "content_key"
+	NamespaceKey   = "namespace"
 )
 
 type Granularity string

--- a/backend/pkg/services/serviceoverview/service.go
+++ b/backend/pkg/services/serviceoverview/service.go
@@ -22,7 +22,7 @@ type Service interface {
 	GetServiceMoreUrl(ctx core.Context, req *request.GetServiceMoreUrlListRequest) (res []response.ServiceDetail, err error)
 	GetThreshold(ctx core.Context, level string, serviceName string, endPoint string) (res response.GetThresholdResponse, err error)
 	SetThreshold(ctx core.Context, level string, serviceName string, endPoint string, latency float64, errorRate float64, tps float64, log float64) (res response.SetThresholdResponse, err error)
-	GetServicesAlert(ctx core.Context, groupID int64, clusterIDs []string, startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, returnData []string) (res []response.ServiceAlertRes, err error)
+	GetServicesAlert(ctx core.Context, groupID int64, clusterIDs []string, startTime time.Time, endTime time.Time, step time.Duration, serviceNames []string, namespaces []string, returnData []string) (res []response.ServiceAlertRes, err error)
 	GetServicesEndPointData(ctx core.Context, req *request.GetEndPointsDataRequest) (res []response.ServiceEndPointsRes, err error)
 
 	// TODO move to prometheus package and avoid to repeated again

--- a/backend/pkg/services/serviceoverview/service_alert.go
+++ b/backend/pkg/services/serviceoverview/service_alert.go
@@ -31,7 +31,7 @@ func (s *service) GetServicesAlert(
 	groupID int64, clusterIDs []string,
 	startTime time.Time, endTime time.Time,
 	step time.Duration,
-	serviceNames []string,
+	serviceNames []string, namespaces []string,
 	returnData []string,
 ) (res []response.ServiceAlertRes, err error) {
 	pqlFilter, err := common.GetPQLFilterByGroupID(ctx, s.dbRepo, "", groupID)
@@ -40,6 +40,9 @@ func (s *service) GetServicesAlert(
 	}
 	if len(clusterIDs) > 0 {
 		pqlFilter.RegexMatch(prometheus.ClusterIDKey, prometheus.RegexMultipleValue(clusterIDs...))
+	}
+	if len(namespaces) > 0 {
+		pqlFilter.RegexMatch(prometheus.NamespaceKey, prometheus.RegexMultipleValue(namespaces...))
 	}
 	pqlFilter.RegexMatch(prometheus.ServiceNameKey, prometheus.RegexMultipleValue(serviceNames...))
 


### PR DESCRIPTION
## Summary by Sourcery

Add namespace-based filtering for service alerts by extending the request models, updating handler invocations, adjusting the service interface signature, and incorporating namespace matching in Prometheus queries.

Enhancements:
- Enable filtering service alerts by namespace in the service overview API and service layer
- Extend GetServicesAlert signature and request models to include a namespaces parameter
- Apply namespace regex matching in Prometheus PQL filters
- Introduce NamespaceKey constant in Prometheus helper