### PR TITLE
feat: Change the EventID field type of AlertEventId from UUID to String

### DIFF
--- a/backend/pkg/model/integration/alert/alert_enrich.go
+++ b/backend/pkg/model/integration/alert/alert_enrich.go
@@ -22,6 +22,10 @@ type AlertEnrichRule struct {
 	SchemaSource string `json:"schemaSource,omitempty" gorm:"type:varchar(255);column:schema_source"`
 }
 
+func (AlertEnrichRule) TableName() string {
+	return "alert_enrich_rules"
+}
+
 type AlertEnrichCondition struct {
 	EnrichRuleID string `json:"-" gorm:"type:varchar(255);column:enrich_rule_id;index"`
 	SourceID     string `json:"-" gorm:"type:varchar(255);column:source_id;index"`

--- a/backend/pkg/model/integration/alert/alert_event.go
+++ b/backend/pkg/model/integration/alert/alert_event.go
@@ -19,7 +19,9 @@ import (
 type AlertEvent struct {
 	Alert `mapstructure:",squash"`
 
-	ID uuid.UUID `json:"id" ch:"id"`
+	// Deprecated: use @EventID instead
+	ID      uuid.UUID `json:"-" ch:"id"`
+	EventID string    `json:"id" ch:"event_id"`
 
 	Detail string `json:"detail" ch:"detail" mapstructure:"detail"`
 
@@ -104,7 +106,7 @@ func (e *AlertEvent) ToAMAlert(externalURL string, timeout bool) *types.Alert {
 			Annotations:  convertAnnos,
 			StartsAt:     e.CreateTime,
 			EndsAt:       e.EndTime,
-			GeneratorURL: fmt.Sprintf("%s/#alerts/events/detail/%s/%s", externalURL, e.AlertID, e.ID.String()),
+			GeneratorURL: fmt.Sprintf("%s/#alerts/events/detail/%s/%s", externalURL, e.AlertID, e.EventID),
 		},
 		UpdatedAt: e.UpdateTime,
 		Timeout:   timeout,

--- a/backend/pkg/receiver/handle_record.go
+++ b/backend/pkg/receiver/handle_record.go
@@ -53,7 +53,7 @@ func (r *InnerReceivers) sendAlert(ctx core.Context, alert *alert.AlertEvent) er
 	notifyRecord := &model.AlertNotifyRecord{
 		AlertID:   alert.AlertID,
 		CreatedAt: time.Now().UnixMicro(),
-		EventID:   alert.ID.String(),
+		EventID:   alert.EventID,
 	}
 
 	var fails []string

--- a/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
+++ b/backend/pkg/repository/clickhouse/dao_alert_event_with_workflow.go
@@ -97,7 +97,7 @@ filtered_workflows AS (
   ORDER BY created_at DESC LIMIT 1 BY ref
 )
 SELECT
-  ae.id,
+  ae.event_id,
   ae.group,
   ae.name,
   ae.alert_id,

--- a/backend/pkg/repository/clickhouse/integration/alert.go
+++ b/backend/pkg/repository/clickhouse/integration/alert.go
@@ -13,7 +13,7 @@ import (
 
 func (ch *chRepo) InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEvent, sourceFrom alert.SourceFrom) error {
 	batch, err := ch.GetContextDB(ctx).PrepareBatch(ctx.GetContext(), `
-		INSERT INTO alert_event (id,name,group,severity, status, detail, alert_id, raw_tags, tags,create_time, update_time, end_time, received_time, source_id, source)
+		INSERT INTO alert_event (event_id,name,group,severity, status, detail, alert_id, raw_tags, tags,create_time, update_time, end_time, received_time, source_id, source)
 		VALUES
 	`)
 
@@ -32,7 +32,7 @@ func (ch *chRepo) InsertAlertEvent(ctx core.Context, alertEvents []alert.AlertEv
 		}
 
 		if err := batch.Append(
-			event.ID,
+			event.EventID,
 			event.Name, event.Group, event.Severity, event.Status,
 			event.Detail, event.AlertID,
 			rawTagsStr, event.EnrichTags,

--- a/backend/pkg/repository/dify/workflow_worker.go
+++ b/backend/pkg/repository/dify/workflow_worker.go
@@ -117,7 +117,7 @@ func (w *worker) getAlertClassify(c *DifyClient, event *alert.AlertEvent) model.
 
 func (w *worker) createExpiredRecord(c *DifyClient, event *alert.AlertEvent, endTime int64) model.WorkflowRecord {
 	w.logger.Error("alert event is expired, skip alert check",
-		zap.String("event_id", event.ID.String()),
+		zap.String("event_id", event.EventID),
 		zap.Int64("expired_ts", w.expiredTS),
 		zap.Int64("event_ts", endTime),
 	)
@@ -131,7 +131,7 @@ func (w *worker) createExpiredRecord(c *DifyClient, event *alert.AlertEvent, end
 		WorkflowID:    classify.WorkflowId,
 		WorkflowName:  w.FlowName,
 		Ref:           event.AlertID,
-		Input:         event.ID.String(),
+		Input:         event.EventID,
 		Output:        "failed: alert check too late, could be too many event to check or last check cost too much time, skipped",
 		CreatedAt:     roundedTime.UnixMicro(),
 		RoundedTime:   roundedTime.UnixMicro(),
@@ -160,7 +160,7 @@ func (w *worker) doAlertCheck(c *DifyClient, event *alert.AlertEvent, endTime in
 			WorkflowID:    classify.WorkflowId,
 			WorkflowName:  w.FlowName,
 			Ref:           event.AlertID,
-			Input:         event.ID.String(),
+			Input:         event.EventID,
 			Output:        "failed: workflow execution failed due to API call failure",
 			CreatedAt:     roundedTime.UnixMicro(),
 			RoundedTime:   roundedTime.UnixMicro(),
@@ -179,8 +179,8 @@ func (w *worker) doAlertCheck(c *DifyClient, event *alert.AlertEvent, endTime in
 		WorkflowID:    classify.WorkflowId,
 		WorkflowName:  w.FlowName,
 		Ref:           event.AlertID,
-		Input:         event.ID.String(), // TODO record input param
-		Output:        output,            // 'false' means valid alert
+		Input:         event.EventID,
+		Output:        output,
 		CreatedAt:     resp.CreatedAt(),
 		RoundedTime:   roundedTime.UnixMicro(),
 
@@ -252,7 +252,7 @@ func (w *worker) getWorkflowParams(event *alert.AlertEvent) *alert.WorkflowParam
 		ContainerID:  event.GetContainerIDTag(),
 		Tags:         event.EnrichTags,
 		RawTags:      event.Tags,
-		AlertEventId: event.ID.String(),
+		AlertEventId: event.EventID,
 	}
 
 	if len(services) == 1 {

--- a/backend/pkg/services/alerts/service_alert_event_detail.go
+++ b/backend/pkg/services/alerts/service_alert_event_detail.go
@@ -36,7 +36,7 @@ func (s *service) AlertDetail(ctx core.Context, req *request.GetAlertDetailReque
 	req.Pagination.Total = total
 	var localIndex int
 	for idx, event := range releatedEvents {
-		if event.ID.String() == req.EventID {
+		if event.EventID == req.EventID {
 			localIndex = idx
 		}
 	}

--- a/backend/pkg/services/alerts/service_alert_event_list.go
+++ b/backend/pkg/services/alerts/service_alert_event_list.go
@@ -18,7 +18,6 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	"github.com/CloudDetail/apo/backend/pkg/services/common"
-	"github.com/google/uuid"
 )
 
 func (s *service) AlertEventList(ctx core.Context, req *request.AlertEventSearchRequest) (*response.AlertEventSearchResponse, error) {
@@ -152,7 +151,7 @@ func (s *service) fillWorkflowParams(ctx core.Context, record *alert.AEventWithW
 
 	if len(record.Input) > 0 {
 		// replace EventID by checkedEvent
-		record.ID, _ = uuid.Parse(record.Input)
+		record.EventID = record.Input
 	}
 
 	record.WorkflowParams = alert.WorkflowParams{

--- a/backend/pkg/services/integration/alert/decoder/json_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/json_decoder.go
@@ -30,7 +30,9 @@ func (d JsonDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]alert.A
 	if len(alertEvent.AlertID) == 0 {
 		alertEvent.AlertID = alert.FastAlertID(alertEvent.Name, alertEvent.Tags)
 	}
-	alertEvent.ID = uuid.New()
+	if len(alertEvent.EventID) == 0 {
+		alertEvent.EventID = uuid.NewString()
+	}
 	alertEvent.SourceID = sourceFrom.SourceID
 	alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 	alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)

--- a/backend/pkg/services/integration/alert/decoder/json_decoder_test.go
+++ b/backend/pkg/services/integration/alert/decoder/json_decoder_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
-	"github.com/google/uuid"
 )
 
 func TestJsonDecoder_Decode(t *testing.T) {
@@ -69,7 +68,7 @@ func TestJsonDecoder_Decode(t *testing.T) {
 							"node":      "larger-server-6",
 						},
 					},
-					ID:           uuid.UUID{},
+					EventID:      "",
 					Detail:       "服务出现异常",
 					CreateTime:   createTime,
 					UpdateTime:   time.UnixMilli(1737514800000),
@@ -87,7 +86,7 @@ func TestJsonDecoder_Decode(t *testing.T) {
 			d := JsonDecoder{}
 			got, err := d.Decode(tt.args.sourceFrom, tt.args.data)
 			for i := range got {
-				got[i].ID = uuid.UUID{}
+				got[i].EventID = ""
 				got[i].ReceivedTime = time.Unix(0, 0)
 			}
 

--- a/backend/pkg/services/integration/alert/decoder/prom_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/prom_decoder.go
@@ -38,7 +38,7 @@ func (d PrometheusDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]a
 		if len(alertEvent.AlertID) == 0 {
 			alertEvent.AlertID = alert.FastAlertID(alertEvent.Name, alertEvent.Tags)
 		}
-		alertEvent.ID = uuid.New()
+		alertEvent.EventID = uuid.NewString()
 		alertEvent.SourceID = sourceFrom.SourceID
 		alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 		alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)

--- a/backend/pkg/services/integration/alert/decoder/zabbix_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/zabbix_decoder.go
@@ -44,7 +44,10 @@ func (d ZabbixDecoder) Decode(sourceFrom alert.SourceFrom, data []byte) ([]alert
 	}
 
 	alertEvent, err := d.jsDecoder.convertAlertEvent(event)
-	alertEvent.ID = uuid.New()
+	if len(alertEvent.EventID) == 0 {
+		alertEvent.EventID = uuid.NewString()
+	}
+
 	alertEvent.SourceID = sourceFrom.SourceID
 	alertEvent.Severity = alert.ConvertSeverity(sourceFrom.SourceType, alertEvent.Severity)
 	alertEvent.Status = alert.ConvertStatus(sourceFrom.SourceType, alertEvent.Status)


### PR DESCRIPTION
## Summary by Sourcery

Refactor AlertEvent identifier to use string-based EventID across models, database interactions, decoders, services, and tests, deprecating the UUID ID field and updating related queries and logic.

New Features:
- Introduce EventID string field as primary identifier for AlertEvent, deprecating the UUID ID field.

Enhancements:
- Consolidate ClickHouse queries and repository methods to use event_id directly, removing toString conversions.
- Adapt JSON, Zabbix, and Prometheus decoders to initialize and propagate string EventID via uuid.NewString() when missing.
- Update service and workflow worker components to reference EventID for filtering, logging, and notification records.
- Add TableName method for AlertEnrichRule to ensure correct GORM mapping.

Tests:
- Refactor JSON decoder tests to assert EventID instead of ID.