### PR TITLE
feat: support for integrating Alert in Datadog in Pull mode

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -7,6 +7,7 @@ toolchain go1.23.8
 require (
 	github.com/ClickHouse/clickhouse-go/v2 v2.34.0
 	github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95
+	github.com/DataDog/datadog-api-client-go/v2 v2.43.0
 	github.com/dave/dst v0.27.3
 	github.com/gin-gonic/gin v1.9.1
 	github.com/go-logr/zapr v1.3.0
@@ -48,6 +49,7 @@ require (
 )
 
 require (
+	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/armon/go-metrics v0.4.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/coder/quartz v0.1.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -49,7 +49,11 @@ github.com/ClickHouse/clickhouse-go/v2 v2.34.0 h1:Y4rqkdrRHgExvC4o/NTbLdY5LFQ3LH
 github.com/ClickHouse/clickhouse-go/v2 v2.34.0/go.mod h1:yioSINoRLVZkLyDzdMXPLRIqhDvel8iLBlwh6Iefso8=
 github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95 h1:52seV0rUftzIronLQOHOHbnlz4YHS4/dAB9rSHa+24M=
 github.com/CloudDetail/metadata v0.0.0-20240903055919-f0487c96aa95/go.mod h1:YpCyr1yI2rybhXMo7STmU7qVvkRp6EDVaDRnU9Wf8ls=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.0 h1:HiRaKLfMe9qnoZ1r6Gm0dHg30i9wi1YqdYPVJ8/Fkgc=
+github.com/DataDog/datadog-api-client-go/v2 v2.43.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
+github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
+github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc=
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=

--- a/backend/pkg/api/alertinput/func_getalertproviderparamsspec.go
+++ b/backend/pkg/api/alertinput/func_getalertproviderparamsspec.go
@@ -1,0 +1,39 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package alert
+
+import (
+	"net/http"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/request"
+)
+
+// GetAlertProviderParamsSpec Obtain alarm source parameter configuration
+// @Summary Obtain alarm source parameter configuration
+// @Description Obtain alarm source parameter configuration
+// @Tags API.alertinput
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body request.GetAlertProviderParamsSpecRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} response.getAlertProviderParamsSpecResponse
+// @Failure 400 {object} code.Failure
+// @Router /api/alertinput/source/paramspec [get]
+func (h *handler) GetAlertProviderParamsSpec() core.HandlerFunc {
+	return func(c core.Context) {
+		req := new(request.GetAlertProviderParamsSpecRequest)
+		if err := c.ShouldBindQuery(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+		resp := h.inputService.GetAlertProviderParamsSpec(req.SourceType)
+		c.Payload(resp)
+	}
+}

--- a/backend/pkg/api/alertinput/handler.go
+++ b/backend/pkg/api/alertinput/handler.go
@@ -24,6 +24,11 @@ type Handler interface {
 	// @Router /api/alertinput/event/source [post]
 	SourceHandler() core.HandlerFunc
 
+	// GetAlertProviderParamsSpec Obtain alarm source parameter configuration
+	// @Tags API.alertinput
+	// @Router /api/alertinput/source/paramspec [get]
+	GetAlertProviderParamsSpec() core.HandlerFunc
+
 	// CreateAlertSource Create Alarm Source
 	// @Tags API.alertinput
 	// @Router /api/alertinput/source/create [post]

--- a/backend/pkg/core/context.go
+++ b/backend/pkg/core/context.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/CloudDetail/apo/backend/pkg/code"
 
@@ -40,8 +41,6 @@ func releaseContext(ctx Context) {
 	c.ctx = nil
 	contextPool.Put(c)
 }
-
-var _ Context = (*context)(nil)
 
 type Context interface {
 	ShouldBind(obj interface{}) error
@@ -110,7 +109,14 @@ type Context interface {
 	ErrMessage(errCode string) string
 
 	Clone() Context
+
+	Done() <-chan struct{}
+	Err() error
+	Value(key any) any
+	Deadline() (deadline time.Time, ok bool)
 }
+
+var _ go_context.Context = (*context)(nil)
 
 type context struct {
 	ctx *gin.Context
@@ -298,4 +304,20 @@ func (c *context) Clone() Context {
 			Keys: keys,
 		},
 	}
+}
+
+func (c *context) Done() <-chan struct{} {
+	return c.ctx.Done()
+}
+
+func (c *context) Deadline() (deadline time.Time, ok bool) {
+	return c.ctx.Deadline()
+}
+
+func (c *context) Err() error {
+	return c.ctx.Err()
+}
+
+func (c *context) Value(key any) any {
+	return c.ctx.Value(key)
 }

--- a/backend/pkg/model/integration/alert/alert_source.go
+++ b/backend/pkg/model/integration/alert/alert_source.go
@@ -24,6 +24,8 @@ func (AlertSource) TableName() string {
 
 type AlertSourceParams map[string]any
 
+
+
 type AlertSource2Cluster struct {
 	SourceID  string `gorm:"type:varchar(255);column:source_id"`
 	ClusterID string `gorm:"type:varchar(255);column:cluster_id"`

--- a/backend/pkg/model/integration/alert/alert_source.go
+++ b/backend/pkg/model/integration/alert/alert_source.go
@@ -11,9 +11,18 @@ const ApoVMAlertSourceID = "efc91f08-86c4-3696-aba8-570d4a8dc069"
 
 type AlertSource struct {
 	SourceFrom
-
 	Clusters []integration.Cluster `json:"clusters" gorm:"-"`
+
+	Params         integration.JSONField[AlertSourceParams] `json:"params" gorm:"type:varchar(2000);column:params;default:'{}'"`
+	EnabledPull    bool                                     `json:"enabledPull" gorm:"type:bool;column:enabled_pull;default:false"`
+	LastPullMillTS int64                                    `json:"lastPullMillTS" gorm:"type:bigint;column:last_pull_mill_ts;default:0"`
 }
+
+func (AlertSource) TableName() string {
+	return "alert_sources"
+}
+
+type AlertSourceParams map[string]any
 
 type AlertSource2Cluster struct {
 	SourceID  string `gorm:"type:varchar(255);column:source_id"`

--- a/backend/pkg/model/request/alert_input.go
+++ b/backend/pkg/model/request/alert_input.go
@@ -230,3 +230,7 @@ type CheckAlertRuleRequest struct {
 }
 
 type ForwardToDingTalkRequest InputAlertManagerRequest
+
+type GetAlertProviderParamsSpecRequest struct {
+	SourceType string `json:"sourceType"`
+}

--- a/backend/pkg/model/response/alert_input.go
+++ b/backend/pkg/model/response/alert_input.go
@@ -8,6 +8,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/model/amconfig"
 	"github.com/CloudDetail/apo/backend/pkg/model/request"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
+	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/provider"
 )
 
 type GetAlertRuleFileResponse struct {
@@ -36,4 +37,8 @@ type GetMetricPQLResponse struct {
 
 type CheckAlertRuleResponse struct {
 	Available bool `json:"available"`
+}
+
+type GetAlertProviderParamsSpecResponse struct {
+	ParamSpec *provider.ParamSpec `json:"paramSpec"`
 }

--- a/backend/pkg/model/response/alert_input.go
+++ b/backend/pkg/model/response/alert_input.go
@@ -41,4 +41,6 @@ type CheckAlertRuleResponse struct {
 
 type GetAlertProviderParamsSpecResponse struct {
 	ParamSpec *provider.ParamSpec `json:"paramSpec"`
+
+	WithPullOptions bool `json:"withPullOptions"`
 }

--- a/backend/pkg/repository/database/integration/alert/dao.go
+++ b/backend/pkg/repository/database/integration/alert/dao.go
@@ -4,9 +4,10 @@
 package alert
 
 import (
+	"time"
+
 	sc "github.com/CloudDetail/apo/backend/pkg/model/amconfig/slienceconfig"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
-	dbdriver "github.com/CloudDetail/apo/backend/pkg/repository/database/driver"
 
 	"github.com/CloudDetail/apo/backend/config"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
@@ -19,6 +20,7 @@ type AlertInput interface {
 	CreateAlertSource(ctx core.Context, source *alert.AlertSource) error
 	GetAlertSource(ctx core.Context, sourceId string) (*alert.AlertSource, error)
 	UpdateAlertSource(ctx core.Context, alertSource *alert.AlertSource) error
+	UpdateAlertSourceLastPullTime(ctx core.Context, sourceID string, lastPullTime time.Time) error
 	DeleteAlertSource(ctx core.Context, alertSource alert.SourceFrom) (*alert.AlertSource, error)
 	ListAlertSource(ctx core.Context) ([]alert.AlertSource, error)
 
@@ -79,7 +81,17 @@ func NewAlertInputRepo(db *gorm.DB, cfg *config.Config) (*subRepo, error) {
 		return nil, err
 	}
 
-	err := dbdriver.InitSQL(db, &alert.TargetTag{})
+	err := driver.InitSQL(db, &alert.TargetTag{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = driver.InitSQL(db, &alert.AlertSource{})
+	if err != nil {
+		return nil, err
+	}
+
+	err = driver.InitSQL(db, &alert.AlertEnrichRule{})
 	if err != nil {
 		return nil, err
 	}

--- a/backend/pkg/repository/database/integration/alert/dao_manage_alert_source.go
+++ b/backend/pkg/repository/database/integration/alert/dao_manage_alert_source.go
@@ -4,6 +4,8 @@
 package alert
 
 import (
+	"time"
+
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	input "github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
@@ -132,4 +134,10 @@ func (repo *subRepo) DeleteAlertSource(ctx core.Context, alertSource alert.Sourc
 		return nil, err
 	}
 	return &deletedSource, nil
+}
+
+func (repo *subRepo) UpdateAlertSourceLastPullTime(ctx core.Context, sourceID string, lastPullTime time.Time) error {
+	return repo.GetContextDB(ctx).Model(&alert.AlertSource{}).
+		Where("source_id = ?", sourceID).
+		Update("last_pull_mill_ts", lastPullTime.UnixMilli()).Error
 }

--- a/backend/pkg/router/router_api.go
+++ b/backend/pkg/router/router_api.go
@@ -266,6 +266,7 @@ func setApiRouter(r *resource) {
 		alertInputApi.POST("/event/source", handler.SourceHandler())
 		alertInputApi.POST("/event/json", handler.JsonHandler())
 		alertInputApi.POST("/source/create", handler.CreateAlertSource())
+		alertInputApi.GET("/source/paramspec", handler.GetAlertProviderParamsSpec())
 		alertInputApi.POST("/source/update", handler.UpdateAlertSource())
 		alertInputApi.POST("/source/get", handler.GetAlertSource())
 		alertInputApi.POST("/source/delete", handler.DeleteAlertSource())

--- a/backend/pkg/services/integration/alert/dispatch.go
+++ b/backend/pkg/services/integration/alert/dispatch.go
@@ -53,6 +53,18 @@ func (d *Dispatcher) DispatchEvents(
 	return events, err
 }
 
+func (d *Dispatcher) DispatchDecodedEvents(
+	source *alert.SourceFrom, events []alert.AlertEvent,
+) error {
+	enricherPtr, find := d.EnricherMap.Load(source.SourceID)
+	if !find {
+		return alert.ErrAlertSourceNotExist{}
+	}
+
+	enricher := enricherPtr.(*enrich.AlertEnricher)
+	return enricher.Enrich(events)
+}
+
 // AddOrUpdateAlertSourceRule
 func (d *Dispatcher) AddOrUpdateAlertSourceRule(
 	source alert.SourceFrom, enricher *enrich.AlertEnricher,

--- a/backend/pkg/services/integration/alert/provider.go
+++ b/backend/pkg/services/integration/alert/provider.go
@@ -20,6 +20,7 @@ func (s *service) GetAlertProviderParamsSpec(sourceType string) *response.GetAle
 				Name: "root",
 				Type: provider.JSONTypeObject,
 			},
+			WithPullOptions: false,
 		}
 	}
 	return &response.GetAlertProviderParamsSpecResponse{ParamSpec: &pType.ParamSpec}
@@ -45,7 +46,7 @@ func (s *service) KeepPullAlert(ctx core.Context, source alert.AlertSource, inte
 			if now.Sub(lastPullTime) < interval {
 				continue
 			}
-			events, err := p.GetAlerts(provider.GetAlertParams{
+			events, err := p.PullAlerts(provider.GetAlertParams{
 				From: lastPullTime,
 				To:   now,
 				// UnstructuredParams: map[string]any{},

--- a/backend/pkg/services/integration/alert/provider.go
+++ b/backend/pkg/services/integration/alert/provider.go
@@ -1,0 +1,51 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package alert
+
+import (
+	"time"
+
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/provider"
+)
+
+var providerMap = map[string]func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) provider.Provider{
+	"datadog": provider.NewDatadogProvider,
+}
+
+func (s *service) KeepPullAlert(ctx core.Context, source alert.AlertSource, interval time.Duration, p provider.Provider) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	now := time.Now()
+
+	lastPullTime := time.UnixMilli(source.LastPullMillTS)
+	if lastPullTime.Add(15 * 24 * time.Hour).Before(now) {
+		lastPullTime = now.Add(-15 * 24 * time.Hour)
+	}
+
+	for range ticker.C {
+		now := time.Now()
+		if now.Sub(lastPullTime) < interval {
+			continue
+		}
+		events, err := p.GetAlerts(nil)
+		if err != nil {
+			continue
+		}
+
+		err = s.dispatcher.DispatchDecodedEvents(&source.SourceFrom, events)
+		if err != nil {
+			continue
+		}
+
+		lastPullTime = now
+		s.difyRepo.SubmitAlertEvents(events)
+		err = s.ckRepo.InsertAlertEvent(ctx, events, source.SourceFrom)
+		if err == nil {
+			s.dbRepo.UpdateAlertSourceLastPullTime(ctx, source.SourceID, lastPullTime)
+		}
+	}
+}

--- a/backend/pkg/services/integration/alert/provider.go
+++ b/backend/pkg/services/integration/alert/provider.go
@@ -8,11 +8,21 @@ import (
 
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/model/response"
 	"github.com/CloudDetail/apo/backend/pkg/services/integration/alert/provider"
 )
 
-var providerMap = map[string]func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) provider.Provider{
-	"datadog": provider.NewDatadogProvider,
+func (s *service) GetAlertProviderParamsSpec(sourceType string) *response.GetAlertProviderParamsSpecResponse {
+	pType, find := provider.ProviderRegistry[sourceType]
+	if !find {
+		return &response.GetAlertProviderParamsSpecResponse{
+			ParamSpec: &provider.ParamSpec{
+				Name: "root",
+				Type: provider.JSONTypeObject,
+			},
+		}
+	}
+	return &response.GetAlertProviderParamsSpecResponse{ParamSpec: &pType.ParamSpec}
 }
 
 func (s *service) KeepPullAlert(ctx core.Context, source alert.AlertSource, interval time.Duration, p provider.Provider) {

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -49,15 +49,15 @@ func NewDatadogProvider(sourceFrom alert.SourceFrom, params alert.AlertSourcePar
 	}
 }
 
-func (f *DatadogProvider) GetAlerts(args map[string]any) ([]alert.AlertEvent, error) {
-	lastPullTs := args["from"].(time.Time)
-	now := args["to"].(time.Time)
+func (f *DatadogProvider) GetAlerts(args GetAlertParams) ([]alert.AlertEvent, error) {
+	start := args.From
+	end := args.To
 
 	resChan, cancel := f.api.ListEventsWithPagination(f.ctx, *datadogV2.NewListEventsOptionalParameters().
 		WithPageLimit(1000).
 		WithSort(datadogV2.EVENTSSORT_TIMESTAMP_ASCENDING).
-		WithFilterFrom(strconv.FormatInt(lastPullTs.UnixMilli(), 10)).
-		WithFilterTo(strconv.FormatInt(now.UnixMilli(), 10)).
+		WithFilterFrom(strconv.FormatInt(start.UnixMilli(), 10)).
+		WithFilterTo(strconv.FormatInt(end.UnixMilli(), 10)).
 		WithFilterQuery("source:alert"),
 	)
 	defer cancel()

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -1,0 +1,261 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+	"github.com/CloudDetail/apo/backend/pkg/repository/clickhouse"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
+	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV2"
+)
+
+type DatadogProvider struct {
+	api *datadogV2.EventsApi
+
+	ctx        context.Context
+	sourceFrom alert.SourceFrom
+}
+
+func NewDatadogProvider(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) Provider {
+	configuration := datadog.NewConfiguration()
+	client := datadog.NewAPIClient(configuration)
+
+	ctx := context.WithValue(context.Background(),
+		datadog.ContextServerVariables,
+		map[string]string{
+			"site": params["site"].(string),
+		},
+	)
+
+	ctx = context.WithValue(ctx,
+		datadog.ContextAPIKeys,
+		map[string]datadog.APIKey{
+			"apiKeyAuth": {Key: params["apiKey"].(string)},
+			"appKeyAuth": {Key: params["appKey"].(string)},
+		},
+	)
+
+	return &DatadogProvider{
+		api:        datadogV2.NewEventsApi(client),
+		ctx:        ctx,
+		sourceFrom: sourceFrom,
+	}
+}
+
+func (f *DatadogProvider) GetAlerts(args map[string]any) ([]alert.AlertEvent, error) {
+	lastPullTs := args["from"].(time.Time)
+	now := args["to"].(time.Time)
+
+	resChan, cancel := f.api.ListEventsWithPagination(f.ctx, *datadogV2.NewListEventsOptionalParameters().
+		WithPageLimit(1000).
+		WithSort(datadogV2.EVENTSSORT_TIMESTAMP_ASCENDING).
+		WithFilterFrom(strconv.FormatInt(lastPullTs.UnixMilli(), 10)).
+		WithFilterTo(strconv.FormatInt(now.UnixMilli(), 10)).
+		WithFilterQuery("source:alert"),
+	)
+	defer cancel()
+
+	receivedTime := time.Now()
+
+	var events []alert.AlertEvent
+	var err error
+	for item := range resChan {
+		if item.Error != nil {
+			err = item.Error
+			break
+		}
+
+		attrs := item.Item.Attributes
+		nestedAttrs := item.Item.Attributes.Attributes
+
+		monitor := nestedAttrs.GetMonitor()
+		var priority = alert.SeverityUnknownLevel
+		if priorityLevel, find := monitor.AdditionalProperties["priority"]; find {
+			priority = getDDPriority(priorityLevel.(float64))
+		}
+
+		var status = alert.StatusFiring
+		var createTime, endTime time.Time
+		if transition, find := monitor.AdditionalProperties["transition"]; find {
+			status = getDDStatus(transition)
+
+			if status == alert.StatusResolved {
+				endTime = time.UnixMilli(nestedAttrs.GetTimestamp())
+			}
+		}
+		if nestedAttrs.GetDuration() > 0 {
+			createTime = time.UnixMilli(nestedAttrs.GetTimestamp() - nestedAttrs.GetDuration()/1e6)
+		} else {
+			createTime = time.UnixMilli(nestedAttrs.GetTimestamp())
+		}
+
+		tags := buildDDTags(nestedAttrs, attrs.GetTags())
+		group := getGroup(nestedAttrs, attrs.GetTags())
+
+		events = append(events, alert.AlertEvent{
+			Alert: alert.Alert{
+				Source:     f.sourceFrom.SourceName,
+				SourceID:   f.sourceFrom.SourceID,
+				AlertID:    nestedAttrs.GetAggregationKey(),
+				Group:      group,
+				Name:       nestedAttrs.GetTitle(),
+				EnrichTags: make(map[string]string),
+				Tags:       tags,
+			},
+			// ID:           uuid.UUID{},
+			EventID:      item.Item.GetId(),
+			Detail:       buildDDDetail(attrs.GetMessage(), tags),
+			CreateTime:   createTime,
+			UpdateTime:   time.UnixMilli(nestedAttrs.GetTimestamp()),
+			EndTime:      endTime,
+			ReceivedTime: receivedTime,
+			Severity:     priority,
+			Status:       status,
+		})
+	}
+
+	return events, err
+}
+
+/*
+*
+
+	{
+		... // resp tags to map
+		"attr": {
+			... // attr tags to map
+			"title": attrs.GetTitle(),
+			"service": attrs.GetService(),
+			"monitor": {
+				... // monitor tags to map
+				"id": attrs.GetMonitorId(),
+				"name": monitor.GetName(),
+				"query": monitor.GetQuery(),
+			},
+		},
+	}
+
+*
+*/
+func buildDDTags(attrs *datadogV2.EventAttributes, eventTags []string) map[string]any {
+	tags := make(map[string]any)
+
+	for _, tagStr := range eventTags {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			tags[tag[0]] = tag[1]
+		} else {
+			tags[tagStr] = ""
+		}
+	}
+
+	attrTags := make(map[string]any)
+	attrTags["title"] = attrs.GetTitle()
+	attrTags["service"] = attrs.GetService()
+	attrTags["hostname"] = attrs.GetHostname()
+	for _, tagStr := range attrs.GetTags() {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			attrTags[tag[0]] = tag[1]
+		} else {
+			attrTags[tagStr] = ""
+		}
+	}
+
+	monitor := attrs.GetMonitor()
+
+	monitorTags := make(map[string]any)
+	monitorTags["id"] = attrs.GetMonitorId()
+	monitorTags["name"] = monitor.GetName()
+	monitorTags["query"] = monitor.GetQuery()
+	for _, tagStr := range monitor.GetTags() {
+		tag := strings.Split(tagStr, ":")
+		if len(tag) == 2 {
+			monitorTags[tag[0]] = tag[1]
+		} else {
+			monitorTags[tagStr] = ""
+		}
+	}
+
+	tags["attr"] = attrTags
+	attrTags["monitor"] = monitorTags
+
+	return tags
+}
+
+func getDDPriority(priority float64) string {
+	switch priority {
+	case 1:
+		return alert.SeverityCriticalLevel
+	case 2:
+		return alert.SeverityErrorLevel
+	case 3:
+		return alert.SeverityWarnLevel
+	case 4, 5:
+		return alert.SeverityInfoLevel
+	default:
+		return alert.SeverityUnknownLevel
+	}
+}
+
+func getDDStatus(transition any) string {
+	if transition == nil {
+		return alert.StatusFiring
+	}
+
+	transitionMap := transition.(map[string]any)
+	if status, find := transitionMap["transition_type"]; find {
+		if status == "alert recovery" {
+			return alert.StatusResolved
+		}
+	}
+	return alert.StatusFiring
+}
+
+func buildDDDetail(message string, tags map[string]any) string {
+	detail := make(map[string]any)
+	detail["summary"] = message
+	detail["description"] = tags
+	detailBytes, err := json.Marshal(detail)
+	if err != nil {
+		return ""
+	}
+	return string(detailBytes)
+}
+
+func getGroup(attrs *datadogV2.EventAttributes, eventTags []string) string {
+	for _, tag := range eventTags {
+		if strings.HasPrefix(tag, "apo_group:") {
+			return tag[6:]
+		}
+	}
+
+	tags := attrs.GetTags()
+
+	for _, tag := range tags {
+		if strings.HasPrefix(tag, "apo_group:") {
+			return tag[6:]
+		}
+	}
+
+	monitorTags := attrs.GetTags()
+	if len(monitorTags) > 0 {
+		for _, tag := range monitorTags {
+			if strings.HasPrefix(tag, "apo_group:") {
+				return tag[6:]
+			}
+		}
+	}
+
+	if len(attrs.GetService()) > 0 && attrs.GetService() != "undefined" {
+		return string(clickhouse.APP_GROUP)
+	}
+	return ""
+}

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -259,3 +259,28 @@ func getGroup(attrs *datadogV2.EventAttributes, eventTags []string) string {
 	}
 	return ""
 }
+
+var DatadogParamSpec = ParamSpec{
+	Name: "root",
+	Type: JSONTypeObject,
+	Children: []ParamSpec{
+		{
+			Name:   "site",
+			Type:   JSONTypeString,
+			Desc:   "DataDog地址,示例: datadoghq.com",
+			DescEN: "DataDog site, example: datadoghq.com",
+		},
+		{
+			Name:   "apiKey",
+			Type:   JSONTypeString,
+			Desc:   "DataDog API Key",
+			DescEN: "DataDog API key",
+		},
+		{
+			Name:   "appKey",
+			Type:   JSONTypeString,
+			Desc:   "DataDog APP Key",
+			DescEN: "DataDog APP key",
+		},
+	},
+}

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -231,26 +231,26 @@ func buildDDDetail(message string, tags map[string]any) string {
 }
 
 func getGroup(attrs *datadogV2.EventAttributes, eventTags []string) string {
+	const prefix = "apo_group:"
+	const plen = len(prefix)
+
 	for _, tag := range eventTags {
-		if strings.HasPrefix(tag, "apo_group:") {
-			return tag[6:]
+		if strings.HasPrefix(tag, prefix) {
+			return tag[plen:]
 		}
 	}
 
 	tags := attrs.GetTags()
-
 	for _, tag := range tags {
-		if strings.HasPrefix(tag, "apo_group:") {
-			return tag[6:]
+		if strings.HasPrefix(tag, prefix) {
+			return tag[plen:]
 		}
 	}
 
-	monitorTags := attrs.GetTags()
-	if len(monitorTags) > 0 {
-		for _, tag := range monitorTags {
-			if strings.HasPrefix(tag, "apo_group:") {
-				return tag[6:]
-			}
+	monitorTags := attrs.GetMonitor().Tags
+	for _, tag := range monitorTags {
+		if strings.HasPrefix(tag, prefix) {
+			return tag[plen:]
 		}
 	}
 

--- a/backend/pkg/services/integration/alert/provider/datadog.go
+++ b/backend/pkg/services/integration/alert/provider/datadog.go
@@ -49,7 +49,7 @@ func NewDatadogProvider(sourceFrom alert.SourceFrom, params alert.AlertSourcePar
 	}
 }
 
-func (f *DatadogProvider) GetAlerts(args GetAlertParams) ([]alert.AlertEvent, error) {
+func (f *DatadogProvider) PullAlerts(args GetAlertParams) ([]alert.AlertEvent, error) {
 	start := args.From
 	end := args.To
 

--- a/backend/pkg/services/integration/alert/provider/param_spec.go
+++ b/backend/pkg/services/integration/alert/provider/param_spec.go
@@ -1,0 +1,84 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import "fmt"
+
+type JSONType string
+
+const (
+	JSONTypeObject  JSONType = "object"
+	JSONTypeArray   JSONType = "array"
+	JSONTypeString  JSONType = "string"
+	JSONTypeNumber  JSONType = "number"
+	JSONTypeBoolean JSONType = "boolean"
+	JSONTypeNull    JSONType = "null"
+)
+
+type ParamSpec struct {
+	Name     string      `json:"name"`
+	Type     JSONType    `json:"type"`
+	Optional bool        `json:"optional,omitempty"`
+	Children []ParamSpec `json:"children,omitempty"`
+	Desc     string      `json:"desc,omitempty"`
+	DescEN   string      `json:"desc_en,omitempty"`
+}
+
+func ValidateJSON(value any, schema ParamSpec) error {
+	switch schema.Type {
+	case JSONTypeObject:
+		obj, ok := value.(map[string]any)
+		if !ok {
+			return fmt.Errorf("field '%s' expected object", schema.Name)
+		}
+		for _, child := range schema.Children {
+			val, exists := obj[child.Name]
+			if !exists {
+				if child.Optional {
+					continue
+				}
+				return fmt.Errorf("missing required field: %s", child.Name)
+			}
+			if err := ValidateJSON(val, child); err != nil {
+				return err
+			}
+		}
+	case JSONTypeArray:
+		arr, ok := value.([]any)
+		if !ok {
+			return fmt.Errorf("field '%s' expected array", schema.Name)
+		}
+		for _, item := range arr {
+			// 数组元素类型统一使用 schema.Children[0]
+			if len(schema.Children) == 0 {
+				return fmt.Errorf("field '%s' array has no element type defined", schema.Name)
+			}
+			if err := ValidateJSON(item, schema.Children[0]); err != nil {
+				return err
+			}
+		}
+	case JSONTypeString:
+		if _, ok := value.(string); !ok {
+			return fmt.Errorf("field '%s' expected string", schema.Name)
+		}
+	case JSONTypeNumber:
+		switch value.(type) {
+		case float64, float32, int, int64, int32:
+			// ok
+		default:
+			return fmt.Errorf("field '%s' expected number", schema.Name)
+		}
+	case JSONTypeBoolean:
+		if _, ok := value.(bool); !ok {
+			return fmt.Errorf("field '%s' expected boolean", schema.Name)
+		}
+	case JSONTypeNull:
+		if value != nil {
+			return fmt.Errorf("field '%s' expected null", schema.Name)
+		}
+	default:
+		return fmt.Errorf("unknown type for field '%s'", schema.Name)
+	}
+	return nil
+}

--- a/backend/pkg/services/integration/alert/provider/provider.go
+++ b/backend/pkg/services/integration/alert/provider/provider.go
@@ -1,0 +1,10 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
+package provider
+
+import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+
+type Provider interface {
+	GetAlerts(args map[string]any) ([]alert.AlertEvent, error)
+}

--- a/backend/pkg/services/integration/alert/provider/provider.go
+++ b/backend/pkg/services/integration/alert/provider/provider.go
@@ -13,12 +13,16 @@ type ProviderType struct {
 	Name      string
 	ParamSpec ParamSpec
 	New       ProviderFactory
+
+	WithPullOptions bool
 }
 
 type ProviderFactory func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) Provider
 
 type Provider interface {
-	GetAlerts(args GetAlertParams) ([]alert.AlertEvent, error)
+	PullAlerts(args GetAlertParams) ([]alert.AlertEvent, error)
+
+	// InstallWebhook() error
 }
 
 type GetAlertParams struct {

--- a/backend/pkg/services/integration/alert/provider/provider.go
+++ b/backend/pkg/services/integration/alert/provider/provider.go
@@ -4,6 +4,8 @@
 package provider
 
 import (
+	"time"
+
 	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
 )
 
@@ -16,7 +18,13 @@ type ProviderType struct {
 type ProviderFactory func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) Provider
 
 type Provider interface {
-	GetAlerts(args map[string]any) ([]alert.AlertEvent, error)
+	GetAlerts(args GetAlertParams) ([]alert.AlertEvent, error)
+}
+
+type GetAlertParams struct {
+	From time.Time
+	To   time.Time
+	// UnstructuredParams map[string]any
 }
 
 var ProviderRegistry = map[string]ProviderType{

--- a/backend/pkg/services/integration/alert/provider/provider.go
+++ b/backend/pkg/services/integration/alert/provider/provider.go
@@ -3,8 +3,26 @@
 
 package provider
 
-import "github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+import (
+	"github.com/CloudDetail/apo/backend/pkg/model/integration/alert"
+)
+
+type ProviderType struct {
+	Name      string
+	ParamSpec ParamSpec
+	New       ProviderFactory
+}
+
+type ProviderFactory func(sourceFrom alert.SourceFrom, params alert.AlertSourceParams) Provider
 
 type Provider interface {
 	GetAlerts(args map[string]any) ([]alert.AlertEvent, error)
+}
+
+var ProviderRegistry = map[string]ProviderType{
+	"datadog": {
+		Name:      "Datadog",
+		ParamSpec: DatadogParamSpec,
+		New:       NewDatadogProvider,
+	},
 }

--- a/backend/pkg/services/integration/alert/service.go
+++ b/backend/pkg/services/integration/alert/service.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"strings"
 	"sync"
+	"time"
 
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	input "github.com/CloudDetail/apo/backend/pkg/model/integration"
@@ -76,7 +77,7 @@ func New(
 		ckRepo:   chRepo,
 	}
 
-	_, enrichMaps, err := service.dbRepo.LoadAlertEnrichRule(nil)
+	alertSources, enrichMaps, err := service.dbRepo.LoadAlertEnrichRule(nil)
 	if err != nil {
 		log.Printf("failed to init alertinput module,err: %v", err)
 		return service
@@ -100,6 +101,21 @@ func New(
 			continue
 		}
 		service.dispatcher.AddAlertSource(source, enricher)
+	}
+
+	for _, source := range alertSources {
+		if !source.EnabledPull {
+			continue
+		}
+
+		fetchTemp, find := providerMap[source.SourceType]
+		if !find {
+			log.Printf("failed to init fetcherFor AlertSource,err: %v", err)
+			continue
+		}
+
+		fetcher := fetchTemp(source.SourceFrom, source.Params.Obj)
+		go service.KeepPullAlert(core.EmptyCtx(), source, time.Minute, fetcher)
 	}
 
 	service.difyRepo = difyRepo

--- a/backend/pkg/services/integration/alert/service.go
+++ b/backend/pkg/services/integration/alert/service.go
@@ -118,6 +118,10 @@ func New(
 			continue
 		}
 
+		if !pType.WithPullOptions {
+			continue
+		}
+
 		if err = provider.ValidateJSON(source.Params.Obj, pType.ParamSpec); err != nil {
 			log.Printf("failed to init provider of AlertSource,err: %v", err)
 			continue

--- a/backend/sqlscripts/target_tags.sql
+++ b/backend/sqlscripts/target_tags.sql
@@ -60,7 +60,15 @@ INSERT INTO alert_enrich_rules (enrich_rule_id,source_id,r_type,rule_order,from_
 	 ('c3c86c94-3a98-479b-adb7-a5895d28b6c5','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.db_url','',8,'','',''),
 	 ('6dcbf6b6-ecd5-494f-afcb-3cfbbd2290f2','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_name','([^(]+)$',9,'','',''),
 	 ('763d0d00-c160-4944-80b5-9d0d347841fc','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_name','(\d+\.\d+\.\d+\.\d+)',10,'','',''),
-	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_port','(\d+)',11,'','','');
+	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','tagMapping',0,'.net_host_port','(\d+)',11,'','',''),
+	 ('e6436efb-681c-452d-9364-828877b782b2','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.service','',1,'','',''),
+	 ('e44657d1-2acd-4be0-acb0-31e8899e0761','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.content_key','',2,'','',''),
+	 ('fd96ba9d-9a47-41cc-998c-807add758baf','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.namespace','',3,'','',''),
+	 ('6cb42756-7d9e-4696-b7e9-1a561ac40beb','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pod','',4,'','',''),
+	 ('95d1708b-3328-4f25-8aec-8a0d6be3d010','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.hostname','',5,'','',''),
+	 ('f552f112-b071-4384-afcb-80a7c62da595','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.node','',5,'','',''),
+	 ('2ab88029-72a3-41cb-8490-96d85af93987','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pid','',6,'','','');
+
 
 INSERT INTO alert_enrich_conditions (enrich_rule_id,source_id,from_field,operation,expr) VALUES
 	 ('55df6363-90ef-48c6-9594-9a95b7836fed','825079a8-4d05-3507-b347-1272a078f9ff','.group','match','middleware'),
@@ -76,7 +84,8 @@ INSERT INTO alert_enrich_conditions (enrich_rule_id,source_id,from_field,operati
 	 ('2ae5494b-442a-4858-9615-945c000730e6','efc91f08-86c4-3696-aba8-570d4a8dc069','.group','match','middleware'),
 	 ('e09ff3cc-70b6-4da5-ad60-ab2576bfc522','efc91f08-86c4-3696-aba8-570d4a8dc069','.group','match','infra');
 
-INSERT INTO alert_sources (source_id,source_name,source_type) VALUES
-	 ('825079a8-4d05-3507-b347-1272a078f9ff','APO_DEFAULT_ENRICH_RULE_PROMETHEUS','prometheus'),
-	 ('2213d3d5-41da-32a8-9026-22c2bf6aa448','APO_DEFAULT_ENRICH_RULE_JSON','json'),
-	 ('efc91f08-86c4-3696-aba8-570d4a8dc069','APO-VM-ALERT','prometheus');
+INSERT INTO alert_sources (source_id,source_name,source_type,params,enable_pull,last_pull_mill_ts) VALUES
+	 ('825079a8-4d05-3507-b347-1272a078f9ff','APO_DEFAULT_ENRICH_RULE_PROMETHEUS','prometheus','{}',false,0),
+	 ('2213d3d5-41da-32a8-9026-22c2bf6aa448','APO_DEFAULT_ENRICH_RULE_JSON','json','{}',false,0),
+	 ('563a44a3-839f-3e23-adff-e00ac8a3e18f','APO_DEFAULT_ENRICH_RULE_DATADOG','datadog','{}',false,0),
+	 ('efc91f08-86c4-3696-aba8-570d4a8dc069','APO-VM-ALERT','prometheus','{}',false,0);

--- a/backend/sqlscripts/upgrade/alert_enrich_rules/1.11.0-upgrade.sql
+++ b/backend/sqlscripts/upgrade/alert_enrich_rules/1.11.0-upgrade.sql
@@ -1,0 +1,8 @@
+INSERT INTO alert_enrich_rules (enrich_rule_id,source_id,r_type,rule_order,from_field,from_regex,target_tag_id,custom_tag,"schema",schema_source) VALUES
+    ('e6436efb-681c-452d-9364-828877b782b2','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.service','',1,'','',''),
+	('e44657d1-2acd-4be0-acb0-31e8899e0761','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.content_key','',2,'','',''),
+	('fd96ba9d-9a47-41cc-998c-807add758baf','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.namespace','',3,'','',''),
+	('6cb42756-7d9e-4696-b7e9-1a561ac40beb','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pod','',4,'','',''),
+	('95d1708b-3328-4f25-8aec-8a0d6be3d010','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.hostname','',5,'','',''),
+	('f552f112-b071-4384-afcb-80a7c62da595','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.node','',5,'','',''),
+	('2ab88029-72a3-41cb-8490-96d85af93987','563a44a3-839f-3e23-adff-e00ac8a3e18f','tagMapping',0,'.attr.pid','',6,'','','');

--- a/backend/sqlscripts/upgrade/alert_sources/1.11.0-upgrade.sql
+++ b/backend/sqlscripts/upgrade/alert_sources/1.11.0-upgrade.sql
@@ -1,0 +1,5 @@
+UPDATE alert_sources SET params = '{}',enable_pull = false,last_pull_mill_ts = 0 WHERE params IS NULL;
+
+INSERT INTO alert_sources (source_id,source_name,source_type,params,enable_pull,last_pull_mill_ts) VALUES
+    ('563a44a3-839f-3e23-adff-e00ac8a3e18f','APO_DEFAULT_ENRICH_RULE_DATADOG','datadog','{}',false,0);
+


### PR DESCRIPTION
## Summary by Sourcery

Enable pull mode integration of alert sources by introducing a provider framework, adding Datadog support, extending the AlertSource schema, and starting background pull jobs for enabled sources

New Features:
- Add pull-based alert integration support with a Provider interface and registry
- Implement a Datadog alert provider with parameter schema and pull logic
- Expose a new API endpoint to fetch alert provider parameter specifications

Enhancements:
- Extend AlertSource model to include Params JSON, EnabledPull flag, and last pull timestamp
- Start background pulling of alerts for enabled sources on service initialization and creation
- Introduce ParamSpec validation for provider parameters before starting pull jobs
- Add DispatchDecodedEvents to Dispatcher for handling already-decoded alert events
- Enhance core Context to implement standard context.Context methods

Build:
- Add DataDog API client and zstd dependencies to go.mod

Deployment:
- Add SQL migrations to populate new alert_sources columns and enrich rules for Datadog

Documentation:
- Document GetAlertProviderParamsSpec API handler and request/response models