### PR TITLE
update: probe Installation and Setup Commands

### DIFF
--- a/backend/pkg/model/integration/cluster.go
+++ b/backend/pkg/model/integration/cluster.go
@@ -19,6 +19,7 @@ type Cluster struct {
 	Name         string       `form:"name" json:"name" gorm:"unique;type:varchar(255);column:name"`
 	ClusterType  string       `form:"clusterType" json:"clusterType" gorm:"type:varchar(255);column:cluster_type"`
 	APOCollector APOCollector `json:"apoCollector,omitempty" gorm:"type:json;column:apo_collector"`
+	IsMinimal    bool         `form:"isMinimal" json:"isMinimal"  gorm:"is_minimal"`
 }
 
 type ClusterIntegration struct {

--- a/backend/pkg/services/integration/service_integration_config.go
+++ b/backend/pkg/services/integration/service_integration_config.go
@@ -125,8 +125,8 @@ func init() {
 }
 
 var (
-	apoChartVersion         = "1.10"
-	apoComposeDeployVersion = "v1.3.000"
+	apoChartVersion         = "1.11"
+	apoComposeDeployVersion = "v1.11.000"
 )
 
 func convert2DeployValues(ci *integration.ClusterIntegration) (map[string]any, error) {

--- a/backend/pkg/services/integration/service_integration_config.go
+++ b/backend/pkg/services/integration/service_integration_config.go
@@ -172,6 +172,7 @@ func convert2DeployValues(ci *integration.ClusterIntegration) (map[string]any, e
 	jsonObj["_deploy_version"] = apoComposeDeployVersion
 	jsonObj["_chart_version"] = apoChartVersion
 	jsonObj["_cluster_id"] = ci.Cluster.ID
+	jsonObj["_is_minimal"] = ci.Cluster.IsMinimal
 
 	return jsonObj, nil
 }

--- a/backend/static/integration-tmpl/dockercompose/install.md.tmpl
+++ b/backend/static/integration-tmpl/dockercompose/install.md.tmpl
@@ -19,7 +19,6 @@ curl -Lo installCfg.sh \
 使用下面的命令下载部署包并进行安装
 
 ```bash
-curl -Lo apo-one-agent-compose-{{ ._deploy_version }}.tgz \
-    https://apo-ce.oss-cn-hangzhou.aliyuncs.com/apo-one-agent-compose-{{ ._deploy_version }}.tgz
-bash ./installCfg.sh
+curl -Lo apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz \
+    https://apo-ce.oss-cn-hangzhou.aliyuncs.com/apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz
 ```

--- a/backend/static/integration-tmpl/dockercompose/installCfg.sh.tmpl
+++ b/backend/static/integration-tmpl/dockercompose/installCfg.sh.tmpl
@@ -2,17 +2,32 @@
 
 set -e
 
+case "$(uname -m)" in
+    x86_64)  ARCH="amd64" ;;
+    aarch64) ARCH="arm64" ;;
+    armv7l|armv6l) ARCH="arm" ;;
+    *) ARCH="$(uname -m)" ;;
+esac
+
 # global
 export DEPLOY_VERSION={{ ._deploy_version }}
 export JAVA_AGENT_TYPE={{ default ._java_agent_type "OPENTELEMETRY" }}
 export TRACE_MODE={{ default ._modes.trace "trace" }}
+export APO_SERVER_IP={{ .apoCollector.collectorGatewayAddr }}
+export APO_CLUSTER_ID={{ default ._cluster_id "default" }}
+export APO_DOCKER_COMPOSE_FILE=apo-one-agent-compose-$ARCH-$DEPLOY_VERSION.tgz
 
 # network
 export APO_COLLECTOR_PORT={{ default .apoCollector.ports.apoCollector 30044 }}
 export APO_OTEL_COLLECTOR_GRPCPORT={{ default .apoCollector.ports.apoOtelCollectorGatewayGrpc 30317 }}
 export APO_VECTOR_PORT={{ default .apoCollector.ports.apoVector 30310 }}
 
-echo "Unzip docker compose tarball: apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz"
-tar -zxvf apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz
+echo "Unzip docker compose tarball: $APO_DOCKER_COMPOSE_FILE"
+tar -zxvf $APO_DOCKER_COMPOSE_FILE
+cd apo-one-agent-compose
 
-cd apo-one-agent-compose && bash deploy.sh init {{ .apoCollector.collectorGatewayAddr }}
+{{ if ._is_minimal }}
+sed -i -E 's/^(ENABLE_APO_GRAFANA_ALLOY|ENABLE_APO_GRAFANA_BEYLA|ENABLE_APO_ODIGLET|ENABLE_APO_OTEL_COLLECTOR_AGENT|ENABLE_APO_PROFILE_AGENT)=.*/\1=false/' switch.env
+{{ end }}
+
+bash deploy.sh init $APO_SERVER_IP $APO_CLUSTER_ID

--- a/backend/static/integration-tmpl/dockercompose/installCfg.sh.tmpl
+++ b/backend/static/integration-tmpl/dockercompose/installCfg.sh.tmpl
@@ -12,7 +12,7 @@ export APO_COLLECTOR_PORT={{ default .apoCollector.ports.apoCollector 30044 }}
 export APO_OTEL_COLLECTOR_GRPCPORT={{ default .apoCollector.ports.apoOtelCollectorGatewayGrpc 30317 }}
 export APO_VECTOR_PORT={{ default .apoCollector.ports.apoVector 30310 }}
 
-echo "Unzip docker compose tarball: apo-one-agent-compose-{{ ._deploy_version }}.tgz"
-tar -zxvf apo-one-agent-compose-{{ ._deploy_version }}.tgz
+echo "Unzip docker compose tarball: apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz"
+tar -zxvf apo-one-agent-compose-amd64-{{ ._deploy_version }}.tgz
 
 cd apo-one-agent-compose && bash deploy.sh init {{ .apoCollector.collectorGatewayAddr }}

--- a/frontend/public/config.js
+++ b/frontend/public/config.js
@@ -13,5 +13,5 @@ window.__APP_CONFIG__ = {
       colorPrimary: '#1677ff',
     },
   },
-  apoChartVersion: 'v1.2.0',
+  apoChartVersion: 'v1.11.0',
 }

--- a/frontend/src/core/views/IntegrationCenter/DataIntegration/Integration/InstallCmd/index.tsx
+++ b/frontend/src/core/views/IntegrationCenter/DataIntegration/Integration/InstallCmd/index.tsx
@@ -30,9 +30,9 @@ const decodeBase64 = (base64Str: string) => {
 function getAPOChartVersion() {
   try {
     const config = window.__APP_CONFIG__ || {}
-    return config.apoChartVersion || '1.10'
+    return config.apoChartVersion || '1.11'
   } catch (e) {
-    return '1.10'
+    return '1.11'
   }
 }
 const InstallCmd = ({ clusterId, clusterType, apoCollector }) => {
@@ -106,11 +106,10 @@ helm install apo-one-agent apo/apo-one-agent -n apo --create-namespace --version
   const getVmCommand1 = () => {
     return `curl -Lo installCfg.sh http://${apoCollector?.collectorGatewayAddr}:${apoCollector?.ports?.apoBackend || 31363}/api/integration/cluster/install/config?clusterId=${clusterId}`
   }
-  const deployVersion = 'v1.3.000'
-  const appVersion = 'v1.3.0'
+  const deployVersion = 'v1.11.000'
+  const appVersion = 'v1.11.0'
   const getVmCommand2 = () => {
-    return `curl -Lo apo-one-agent-compose-${deployVersion}.tgz https://apo-ce.oss-cn-hangzhou.aliyuncs.com/apo-one-agent-compose-${deployVersion}.tgz
-bash ./installCfg.sh`
+    return `curl -Lo apo-one-agent-compose-amd64-${deployVersion}.tgz https://apo-ce.oss-cn-hangzhou.aliyuncs.com/apo-one-agent-compose-amd64-${deployVersion}.tgz
   }
   return (
     <div className="px-3 mx-auto h-full overflow-auto flex flex-col">


### PR DESCRIPTION
## Summary by Sourcery

Update installation and setup commands and templates to align with APO probe version 1.11

Enhancements:
- Bump default APO chart version from 1.10 to 1.11
- Update agent deployment and application versions to v1.11.000 and v1.11.0
- Adjust VM installation command to download amd64-specific tarball and remove inline script execution

Documentation:
- Update docker-compose installation and configuration templates to use the new version