### PR TITLE
feat: read baseURL from config

### DIFF
--- a/backend/config/apo.yml
+++ b/backend/config/apo.yml
@@ -1,4 +1,6 @@
 server:
+  # baseurl will be used for generate webhook/gateway url
+  baseurl: apo-backend-svc:8080
   port: 8080
   access_token_expire_minutes: 15
   refresh_token_expire_hours: 48

--- a/backend/config/config.go
+++ b/backend/config/config.go
@@ -16,9 +16,10 @@ var config *Config
 
 type Config struct {
 	Server struct {
-		Port                     int `mapstructure:"port"`
-		AccessTokenExpireMinutes int `mapstructure:"access_token_expire_minutes"`
-		RefreshTokenExpireHours  int `mapstructure:"refresh_token_expire_hours"`
+		BaseURL                  string `mapstructure:"baseurl"`
+		Port                     int    `mapstructure:"port"`
+		AccessTokenExpireMinutes int    `mapstructure:"access_token_expire_minutes"`
+		RefreshTokenExpireHours  int    `mapstructure:"refresh_token_expire_hours"`
 	} `mapstructure:"server"`
 	Logger struct {
 		Level         string `mapstructure:"level"`

--- a/backend/pkg/api/integration/func_getintegrationinstalldoc.go
+++ b/backend/pkg/api/integration/func_getintegrationinstalldoc.go
@@ -43,7 +43,7 @@ func (h *handler) GetIntegrationInstallDoc() core.HandlerFunc {
 			return
 		}
 		c.Payload(integration.GetCInstallDocResponse{
-			InstallMD: resp,
+			InstallMD: string(resp),
 		})
 	}
 }

--- a/backend/pkg/api/integration/func_getintegrationvar.go
+++ b/backend/pkg/api/integration/func_getintegrationvar.go
@@ -1,0 +1,52 @@
+// Copyright 2024 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	"github.com/CloudDetail/apo/backend/pkg/core"
+	"github.com/CloudDetail/apo/backend/pkg/model/integration"
+)
+
+// GetIntegrationVar GetIntegrationVar
+// @Summary
+// @Description
+// @Tags API.integration
+// @Accept application/x-www-form-urlencoded
+// @Produce json
+// @Param Request body integration.GetIntegrationVarRequest true "Request information"
+// @Param Authorization header string false "Bearer accessToken"
+// @Success 200 {object} string
+// @Failure 400 {object} code.Failure
+// @Router /api/integration/vars/:variable [get]
+func (h *handler) GetIntegrationVar() core.HandlerFunc {
+	return func(c core.Context) {
+		var req = new(integration.GetIntegrationVarRequest)
+		if err := c.ShouldBindURI(req); err != nil {
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				err,
+			)
+			return
+		}
+
+		switch strings.ToLower(req.Variable) {
+		case "baseurl":
+			c.Payload(h.integrationService.GetBaseURL())
+		case "serveraddr":
+			c.Payload(h.integrationService.GetServerAddr())
+		default:
+			c.AbortWithError(
+				http.StatusBadRequest,
+				code.ParamBindError,
+				fmt.Errorf("variable %s not found", req.Variable),
+			)
+			return
+		}
+	}
+}

--- a/backend/pkg/api/integration/handler.go
+++ b/backend/pkg/api/integration/handler.go
@@ -15,6 +15,11 @@ type Handler interface {
 	// @Router /api/integration/configuration [get]
 	GetStaticIntegration() core.HandlerFunc
 
+	// GetIntegrationVar GetIntegrationVar
+	// @Tags API.integration
+	// @Router /api/integration/vars/:variable [get]
+	GetIntegrationVar() core.HandlerFunc
+
 	// ListCluster ListCluster
 	// @Tags API.integration
 	// @Router /api/integration/cluster/list [get]

--- a/backend/pkg/model/integration/req.go
+++ b/backend/pkg/model/integration/req.go
@@ -10,3 +10,7 @@ type GetCInstallRequest struct {
 type TriggerAdapterUpdateRequest struct {
 	LastUpdateTS int64 `form:"lastUpdateTS" json:"lastUpdateTS"`
 }
+
+type GetIntegrationVarRequest struct {
+	Variable string `uri:"variable" binding:"required,max=64" `
+}

--- a/backend/pkg/model/integration/resp.go
+++ b/backend/pkg/model/integration/resp.go
@@ -8,7 +8,7 @@ type ListClusterResponse struct {
 }
 
 type GetCInstallDocResponse struct {
-	InstallMD []byte `json:"installMd"`
+	InstallMD string `json:"installMd"`
 }
 
 type GetCInstallConfigResponse struct {

--- a/backend/pkg/router/router_api.go
+++ b/backend/pkg/router/router_api.go
@@ -299,6 +299,7 @@ func setApiRouter(r *resource) {
 	{
 		handler := integration.New(r.pkg_db)
 		integrationAPI.GET("/configuration", handler.GetStaticIntegration())
+		integrationAPI.GET("/vars/:variable", handler.GetIntegrationVar())
 
 		integrationAPI.GET("/cluster/list", handler.ListCluster())
 		integrationAPI.GET("/cluster/get", handler.GetCluster())

--- a/backend/pkg/services/integration/service.go
+++ b/backend/pkg/services/integration/service.go
@@ -4,6 +4,9 @@
 package integration
 
 import (
+	"regexp"
+
+	"github.com/CloudDetail/apo/backend/config"
 	core "github.com/CloudDetail/apo/backend/pkg/core"
 	"github.com/CloudDetail/apo/backend/pkg/model/integration"
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
@@ -15,6 +18,9 @@ type Service interface {
 	CreateCluster(ctx core.Context, cluster *integration.ClusterIntegration) (*integration.Cluster, error)
 	GetClusterIntegration(ctx core.Context, clusterID string) (*integration.ClusterIntegrationVO, error)
 	UpdateClusterIntegration(ctx core.Context, cluster *integration.ClusterIntegration) error
+
+	GetBaseURL() string
+	GetServerAddr() string
 
 	ListCluster(ctx core.Context) ([]integration.Cluster, error)
 	DeleteCluster(ctx core.Context, cluster *integration.Cluster) error
@@ -30,10 +36,33 @@ var _ Service = &service{}
 
 type service struct {
 	dbRepo database.Repo
+
+	serverAddr string
+	baseURL    string
 }
 
+var baseSchema = regexp.MustCompile(`^(?:https?:\/\/)?([^:/]+)`)
+
 func New(database database.Repo) Service {
-	return &service{
+
+	cfg := config.Get().Server
+
+	service := &service{
 		dbRepo: database,
 	}
+
+	if len(cfg.BaseURL) == 0 {
+		service.baseURL = "http://apo-backend-svc.apo:8080"
+		service.serverAddr = "apo-backend-svc.apo"
+	} else {
+		match := baseSchema.FindStringSubmatch(cfg.BaseURL)
+		if len(match) > 1 {
+			service.serverAddr = match[1]
+		} else {
+			service.serverAddr = cfg.BaseURL
+		}
+		service.baseURL = cfg.BaseURL
+	}
+
+	return service
 }

--- a/backend/pkg/services/integration/service_config.go
+++ b/backend/pkg/services/integration/service_config.go
@@ -1,0 +1,9 @@
+package integration
+
+func (s *service) GetBaseURL() string {
+	return s.baseURL
+}
+
+func (s *service) GetServerAddr() string {
+	return s.serverAddr
+}

--- a/backend/pkg/services/integration/service_config.go
+++ b/backend/pkg/services/integration/service_config.go
@@ -1,3 +1,6 @@
+// Copyright 2025 CloudDetail
+// SPDX-License-Identifier: Apache-2.0
+
 package integration
 
 func (s *service) GetBaseURL() string {

--- a/backend/pkg/services/integration/service_integration_config.go
+++ b/backend/pkg/services/integration/service_integration_config.go
@@ -84,11 +84,11 @@ func (s *service) GetIntegrationInstallConfigFile(ctx core.Context, req *integra
 		return nil, err
 	}
 
-	return getIntegrationConfigFile(clusterConfig)
+	return s.getIntegrationConfigFile(clusterConfig)
 }
 
-func getIntegrationConfigFile(clusterConfig *integration.ClusterIntegration) (*integration.GetCInstallConfigResponse, error) {
-	jsonObj, err := convert2DeployValues(clusterConfig)
+func (s *service) getIntegrationConfigFile(clusterConfig *integration.ClusterIntegration) (*integration.GetCInstallConfigResponse, error) {
+	jsonObj, err := s.convert2DeployValues(clusterConfig)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config failed: %w", err)
 	}
@@ -98,7 +98,7 @@ func getIntegrationConfigFile(clusterConfig *integration.ClusterIntegration) (*i
 	switch clusterConfig.ClusterType {
 	case integration.ClusterTypeK8s:
 		err = k8sTmpl.ExecuteTemplate(&buf, "apo-one-agent-values.yaml.tmpl", jsonObj)
-		fileName = "apo-one-agent-values.yaml"
+		fileName = "agent-values.yaml"
 	case integration.ClusterTypeVM:
 		err = dockerComposeTmpl.ExecuteTemplate(&buf, "installCfg.sh.tmpl", jsonObj)
 		fileName = "installCfg.sh"
@@ -129,7 +129,7 @@ var (
 	apoComposeDeployVersion = "v1.11.000"
 )
 
-func convert2DeployValues(ci *integration.ClusterIntegration) (map[string]any, error) {
+func (s *service) convert2DeployValues(ci *integration.ClusterIntegration) (map[string]any, error) {
 	jsonStr, err := json.Marshal(ci)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config failed: %w", err)
@@ -173,6 +173,7 @@ func convert2DeployValues(ci *integration.ClusterIntegration) (map[string]any, e
 	jsonObj["_chart_version"] = apoChartVersion
 	jsonObj["_cluster_id"] = ci.Cluster.ID
 	jsonObj["_is_minimal"] = ci.Cluster.IsMinimal
+	jsonObj["_base_url_"] = s.baseURL
 
 	return jsonObj, nil
 }

--- a/backend/pkg/services/integration/service_integration_doc.go
+++ b/backend/pkg/services/integration/service_integration_doc.go
@@ -23,7 +23,7 @@ func (s *service) GetIntegrationInstallDoc(ctx core.Context, req *integration.Ge
 		return nil, err
 	}
 
-	jsonObj, err := convert2DeployValues(clusterConfig)
+	jsonObj, err := s.convert2DeployValues(clusterConfig)
 	if err != nil {
 		return nil, fmt.Errorf("marshal config failed: %w", err)
 	}


### PR DESCRIPTION
## Summary by Sourcery

Read BaseURL from configuration, store corresponding server address, inject it into integration templates, and expose it via a new API endpoint while updating related service methods and response types

New Features:
- Expose API endpoint GET /api/integration/vars/:variable to fetch baseURL and server address
- Add GetBaseURL and GetServerAddr methods to integration service

Enhancements:
- Read BaseURL from server config with default fallback and store server address accordingly
- Inject baseURL into integration deployment template values
- Rename integration values output file to agent-values.yaml
- Refactor getIntegrationConfigFile and convert2DeployValues into service methods

Documentation:
- Add baseurl field to server config and update apo.yml example