### PR TITLE
fix:  Fix the timestamp issue caused by timezone differences when int…

### DIFF
--- a/backend/pkg/services/integration/alert/decoder/json_decoder.go
+++ b/backend/pkg/services/integration/alert/decoder/json_decoder.go
@@ -71,6 +71,9 @@ func ToTimeHookFunc() mapstructure.DecodeHookFunc {
 
 		switch f.Kind() {
 		case reflect.String:
+			if len(data.(string)) == 0 { // accept empty string
+				return time.Time{}, nil
+			}
 			return time.Parse(time.RFC3339, data.(string))
 		case reflect.Float64:
 			return time.Unix(0, int64(data.(float64))*int64(time.Millisecond)), nil


### PR DESCRIPTION
…egrating Zabbix alerts

## Summary by Sourcery

Fix timestamp parsing issues in alert decoders

Bug Fixes:
- Fix Zabbix updateTime and endTime parsing to detect local vs UTC timestamps
- Allow empty timestamp strings in the JSON decoder

Enhancements:
- Capture and reuse a single reference time for parsing and ReceivedTime assignment