### PR TITLE
fix: concurrent tagsMap iteration and write

### DIFF
--- a/backend/pkg/model/integration/alert/alert.go
+++ b/backend/pkg/model/integration/alert/alert.go
@@ -49,6 +49,18 @@ func (t *RawTags) Put(key any, value any) {
 	(*t)[strKey] = value
 }
 
+func (t *RawTags) Clone() RawTags {
+	if t == nil {
+		return nil
+	}
+
+	clone := make(RawTags, len(*t))
+	for k, v := range *t {
+		clone[k] = v
+	}
+	return clone
+}
+
 func (t *RawTags) Keys() <-chan any {
 	ch := make(chan any)
 

--- a/backend/pkg/model/integration/alert/alert_event.go
+++ b/backend/pkg/model/integration/alert/alert_event.go
@@ -72,10 +72,11 @@ func FastAlertIDByStringMap(alertName string, tags map[string]string) string {
 }
 
 func (e *AlertEvent) TagsInStr() string {
-	param := e.EnrichTags
-	param["status"] = e.Status
+	params := e.Tags.Clone()
+	params["alertEventId"] = e.EventID
+	// param["status"] = e.Status
 	// param["describe"] =
-	bytes, err := json.Marshal(e.Tags)
+	bytes, err := json.Marshal(params)
 	if err != nil {
 		return "{}"
 	}

--- a/backend/pkg/repository/dify/workflow_worker.go
+++ b/backend/pkg/repository/dify/workflow_worker.go
@@ -242,6 +242,8 @@ func (w *worker) getWorkflowParams(event *alert.AlertEvent) *alert.WorkflowParam
 		}
 	}
 
+	rawTags := event.Tags.Clone()
+	rawTags["alertEventId"] = event.EventID
 	parmas := alert.AlertAnalyzeWorkflowParams{
 		AlertName:    event.Name,
 		Node:         event.GetInfraNodeTag(),
@@ -251,7 +253,7 @@ func (w *worker) getWorkflowParams(event *alert.AlertEvent) *alert.WorkflowParam
 		Detail:       event.Detail,
 		ContainerID:  event.GetContainerIDTag(),
 		Tags:         event.EnrichTags,
-		RawTags:      event.Tags,
+		RawTags:      rawTags,
 		AlertEventId: event.EventID,
 	}
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a Clone method for RawTags and leverage it to avoid concurrent map iteration and writes in alert event serialization and workflow parameter generation

Bug Fixes:
- Prevent concurrent map iteration and write on RawTags by cloning the underlying map before use

Enhancements:
- Add RawTags.Clone() to create a shallow copy of the tags map
- Replace direct usage of RawTags with clones in AlertEvent.TagsInStr and workflow worker’s getWorkflowParams