### PR TITLE
fix: Nil pointer fix when query descendant relevance failed

### DIFF
--- a/backend/pkg/api/service/handler.go
+++ b/backend/pkg/api/service/handler.go
@@ -150,7 +150,7 @@ type handler struct {
 func New(logger *zap.Logger, chRepo clickhouse.Repo, promRepo prometheus.Repo, polRepo polarisanalyzer.Repo, dbRepo database.Repo, k8sRepo kubernetes.Repo) Handler {
 	return &handler{
 		logger:                 logger,
-		serviceInfoService:     service.New(chRepo, promRepo, polRepo, dbRepo),
+		serviceInfoService:     service.New(chRepo, promRepo, polRepo, dbRepo, logger),
 		serviceoverviewService: serviceoverview.New(logger, chRepo, dbRepo, promRepo),
 		dataService:            data.New(dbRepo, promRepo, chRepo, k8sRepo),
 	}

--- a/backend/pkg/repository/prometheus/dao_query.go
+++ b/backend/pkg/repository/prometheus/dao_query.go
@@ -16,7 +16,7 @@ import (
 func (repo *promRepo) QueryData(ctx core.Context, searchTime time.Time, query string) ([]MetricResult, error) {
 	value, warnings, err := repo.GetApi().Query(ctx.GetContext(), query, searchTime)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("query metric failed, err: %w, query: %s, timestamp: %d", err, query, searchTime.Unix())
 	}
 	if len(warnings) > 0 {
 		log.Println("Warnings:", warnings)

--- a/backend/pkg/services/service/service.go
+++ b/backend/pkg/services/service/service.go
@@ -12,6 +12,7 @@ import (
 	"github.com/CloudDetail/apo/backend/pkg/repository/database"
 	"github.com/CloudDetail/apo/backend/pkg/repository/polarisanalyzer"
 	"github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
+	"go.uber.org/zap"
 )
 
 var _ Service = (*service)(nil)
@@ -75,13 +76,16 @@ type service struct {
 	promRepo prometheus.Repo
 	polRepo  polarisanalyzer.Repo
 	dbRepo   database.Repo
+
+	logger *zap.Logger
 }
 
-func New(chRepo clickhouse.Repo, promRepo prometheus.Repo, polRepo polarisanalyzer.Repo, dbRepo database.Repo) Service {
+func New(chRepo clickhouse.Repo, promRepo prometheus.Repo, polRepo polarisanalyzer.Repo, dbRepo database.Repo, logger *zap.Logger) Service {
 	return &service{
 		chRepo:   chRepo,
 		promRepo: promRepo,
 		polRepo:  polRepo,
 		dbRepo:   dbRepo,
+		logger:   logger,
 	}
 }

--- a/backend/pkg/services/service/service_get_descendant_relevance.go
+++ b/backend/pkg/services/service/service_get_descendant_relevance.go
@@ -16,6 +16,7 @@ import (
 	prom "github.com/CloudDetail/apo/backend/pkg/repository/prometheus"
 	"github.com/CloudDetail/apo/backend/pkg/services/common"
 	"github.com/CloudDetail/apo/backend/pkg/services/serviceoverview"
+	"go.uber.org/zap"
 )
 
 // GetDescendantRelevance implements Service.
@@ -97,11 +98,11 @@ func (s *service) GetDescendantRelevance(ctx core.Context, req *request.GetDesce
 
 	descendantStatus, err := s.queryDescendantStatus(ctx, pqlFilter, req.StartTime, req.EndTime)
 	if err != nil {
-		// Failed to query RED metric when adding log to TODO
+		s.logger.Error("Failed to query RED metric", zap.Error(err))
 	}
 	threshold, err := s.dbRepo.GetOrCreateThreshold(ctx, "", "", database.GLOBAL)
 	if err != nil {
-		// Failed to query the threshold when adding logs to TODO
+		s.logger.Error("Failed to query the threshold", zap.Error(err))
 	}
 	for _, descendant := range sortResult {
 		var descendantResp = response.GetDescendantRelevanceResponse{
@@ -124,8 +125,7 @@ func (s *service) GetDescendantRelevance(ctx core.Context, req *request.GetDesce
 		// Get all instances under each endpoint
 		instances, err := s.promRepo.GetInstanceListByPQLFilter(ctx, req.StartTime, req.EndTime, pqlFilter)
 		if err != nil {
-			// TODO deal error
-			continue
+			s.logger.Error("Failed to query instance list", zap.Error(err))
 		}
 
 		startTime := time.UnixMicro(req.StartTime)
@@ -273,81 +273,93 @@ func fillServiceDelaySourceAndREDAlarm(descendantResp *response.GetDescendantRel
 		SvcName:    descendantResp.ServiceName,
 	}
 
-	if status, ok := descendantStatus.MetricGroupMap[descendantKey]; ok {
-		if status.DepLatency != nil && status.Latency != nil {
-			var depRatio = *status.DepLatency / *status.Latency
-			if depRatio > 0.5 {
-				descendantResp.DelaySource = "dependency"
-				delayDistribution := fmt.Sprintf("总延时: %.2f, 外部依赖延时: %.2f(%.2f)", *status.Latency, *status.DepLatency, depRatio)
-				descendantResp.AlertReason.Add(model.DelaySourceAlert, model.AlertDetail{
-					Timestamp:    ts.UnixMicro(),
-					AlertObject:  descendantResp.ServiceName,
-					AlertReason:  "外部依赖延时占总延时超过50%",
-					AlertMessage: delayDistribution,
-				})
-			} else {
-				descendantResp.DelaySource = "self"
-			}
-		} else {
-			descendantResp.DelaySource = "unknown"
-		}
-
-		if status.RequestPerSecondDoD == nil {
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "TPS未采集到数据",
-				AlertMessage: "",
-			})
-		} else if threshold.Tps > 0 && *status.RequestPerSecondDoD > threshold.Tps {
-			descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "TPS变化超过日同比阈值",
-				AlertMessage: fmt.Sprintf("请求TPS日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.RequestPerSecondDoD, threshold.Tps),
-			})
-		}
-
-		if status.LatencyDoD == nil {
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "延迟未采集到数据",
-				AlertMessage: "",
-			})
-		} else if threshold.Latency > 0 && *status.LatencyDoD > threshold.Latency {
-			descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "延时变化超过日同比阈值",
-				AlertMessage: fmt.Sprintf("延迟日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.LatencyDoD, threshold.Latency),
-			})
-		}
-
-		if status.ErrorRateDoD == nil {
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "错误率未采集到数据",
-				AlertMessage: "",
-			})
-		} else if threshold.ErrorRate > 0 && *status.ErrorRateDoD > threshold.ErrorRate {
-			descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
-			descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
-				Timestamp:    ts.UnixMicro(),
-				AlertObject:  descendantResp.ServiceName,
-				AlertReason:  "错误率变化超过日同比阈值",
-				AlertMessage: fmt.Sprintf("错误率日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.ErrorRateDoD, threshold.ErrorRate),
-			})
-		}
-	} else {
+	if descendantStatus == nil {
 		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
 			Timestamp:    ts.UnixMicro(),
 			AlertObject:  descendantResp.ServiceName,
 			AlertReason:  "时间段内未统计到应用延时,应用无请求或未监控,忽略RED告警;",
 			AlertMessage: "",
+		})
+		return
+	}
+
+	status, find := descendantStatus.MetricGroupMap[descendantKey]
+	if !find {
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "时间段内未统计到应用延时,应用无请求或未监控,忽略RED告警;",
+			AlertMessage: "",
+		})
+		return
+	}
+
+	if status.DepLatency != nil && status.Latency != nil {
+		var depRatio = *status.DepLatency / *status.Latency
+		if depRatio > 0.5 {
+			descendantResp.DelaySource = "dependency"
+			delayDistribution := fmt.Sprintf("总延时: %.2f, 外部依赖延时: %.2f(%.2f)", *status.Latency, *status.DepLatency, depRatio)
+			descendantResp.AlertReason.Add(model.DelaySourceAlert, model.AlertDetail{
+				Timestamp:    ts.UnixMicro(),
+				AlertObject:  descendantResp.ServiceName,
+				AlertReason:  "外部依赖延时占总延时超过50%",
+				AlertMessage: delayDistribution,
+			})
+		} else {
+			descendantResp.DelaySource = "self"
+		}
+	} else {
+		descendantResp.DelaySource = "unknown"
+	}
+
+	if status.RequestPerSecondDoD == nil {
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "TPS未采集到数据",
+			AlertMessage: "",
+		})
+	} else if threshold.Tps > 0 && *status.RequestPerSecondDoD > threshold.Tps {
+		descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "TPS变化超过日同比阈值",
+			AlertMessage: fmt.Sprintf("请求TPS日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.RequestPerSecondDoD, threshold.Tps),
+		})
+	}
+
+	if status.LatencyDoD == nil {
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "延迟未采集到数据",
+			AlertMessage: "",
+		})
+	} else if threshold.Latency > 0 && *status.LatencyDoD > threshold.Latency {
+		descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "延时变化超过日同比阈值",
+			AlertMessage: fmt.Sprintf("延迟日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.LatencyDoD, threshold.Latency),
+		})
+	}
+
+	if status.ErrorRateDoD == nil {
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "错误率未采集到数据",
+			AlertMessage: "",
+		})
+	} else if threshold.ErrorRate > 0 && *status.ErrorRateDoD > threshold.ErrorRate {
+		descendantResp.REDMetricsStatus = model.STATUS_CRITICAL
+		descendantResp.AlertReason.Add(model.REDMetricsAlert, model.AlertDetail{
+			Timestamp:    ts.UnixMicro(),
+			AlertObject:  descendantResp.ServiceName,
+			AlertReason:  "错误率变化超过日同比阈值",
+			AlertMessage: fmt.Sprintf("错误率日同比增长: %.2f%% 高于设定阈值 %.2f%%;", *status.ErrorRateDoD, threshold.ErrorRate),
 		})
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Improve robustness and observability in GetDescendantRelevance by adding nil checks, default handling, and structured logging, refactor alert logic to prevent nil pointer panics, and enhance Prometheus query errors with richer context.

Bug Fixes:
- Prevent nil pointer dereferences in descendant relevance flow by adding early nil checks and initializing empty instance maps on failures.
- Fix PQL filter mutation issues by cloning filters before reuse.

Enhancements:
- Inject zap.Logger into service layer and replace TODO comments with structured error logs.
- Refactor RED alert generation logic to flatten nested checks and consolidate duplicate code.
- Augment Prometheus DAO errors with query string and timestamp context for easier debugging.