### PR TITLE
fix: remove no-fullsorted cte in error propagation sql

### DIFF
--- a/backend/pkg/repository/clickhouse/dao_error_propagation.go
+++ b/backend/pkg/repository/clickhouse/dao_error_propagation.go
@@ -12,36 +12,54 @@ import (
 )
 
 const (
-	SQL_GET_INSTANCE_ERROR_PROPAGATION = `
-		WITH found_trace_ids AS
-		(
-			SELECT error_propagation.timestamp as timestamp, error_propagation.trace_id as trace_id, error_propagation.entry_span_id as entry_span_id,
-				nodes.service as service, nodes.instance as instance_id, nodes.path as path, nodes.depth as depth, nodes.error_types as error_types, nodes.error_msgs as error_msgs, nodes.is_error as is_error
-			FROM %s.error_propagation
-			ARRAY JOIN nodes
-			%s %s
-		)
-		SELECT found_trace_ids.timestamp as timestamp, found_trace_ids.service as service, found_trace_ids.instance_id as instance_id, found_trace_ids.trace_id as trace_id, found_trace_ids.error_types as error_types, found_trace_ids.error_msgs as error_msgs,
-			   parent_node.parent_services as parent_services, parent_node.parent_instances as parent_instances, parent_node.parent_traced as parent_traced,
-			   child_node.child_services as child_services, child_node.child_instances as child_instances, child_node.child_traced as child_traced
-		FROM found_trace_ids
-		LEFT JOIN(
-			SELECT error_propagation.trace_id as trace_id, groupArray(nodes.service) as parent_services, groupArray(nodes.instance) as parent_instances, groupArray(nodes.is_traced) as parent_traced
-			FROM error_propagation
-			ARRAY JOIN nodes
-			GLOBAL JOIN found_trace_ids ON error_propagation.trace_id = found_trace_ids.trace_id AND error_propagation.entry_span_id = found_trace_ids.entry_span_id
-			WHERE timestamp BETWEEN %d AND %d AND startsWith(found_trace_ids.path, nodes.path) AND nodes.depth=found_trace_ids.depth - 1 AND nodes.is_error = found_trace_ids.is_error
-			GROUP BY trace_id
-		) AS parent_node ON parent_node.trace_id = found_trace_ids.trace_id
-		LEFT JOIN(
-			SELECT error_propagation.trace_id as trace_id, groupArray(nodes.service) as child_services, groupArray(nodes.instance) as child_instances, groupArray(nodes.is_traced) as child_traced
-			FROM error_propagation
-			ARRAY JOIN nodes
-			GLOBAL JOIN found_trace_ids ON error_propagation.trace_id = found_trace_ids.trace_id AND error_propagation.entry_span_id = found_trace_ids.entry_span_id
-			WHERE timestamp BETWEEN %d AND %d AND startsWith(nodes.path, found_trace_ids.path) AND nodes.depth=found_trace_ids.depth+1 AND nodes.is_error = found_trace_ids.is_error
-			GROUP BY trace_id
-		) AS child_node on child_node.trace_id = found_trace_ids.trace_id
-	`
+	SQL_GET_INSTANCE_ERROR_PROPAGATION = `SELECT
+    sample.1 AS timestamp,
+    sample.2 AS service,
+    sample.3 AS instance_id,
+    sample.4 AS trace_id,
+    sample.5 AS error_types,
+    sample.6 AS error_msgs,
+    arrayMap(x -> x.1, arrayFilter(x -> (x.3 = sample.7 - 1 AND startsWith(sample.8, x.2)), all_nodes)) AS parent_services,
+    arrayMap(x -> x.4, arrayFilter(x -> (x.3 = sample.7 - 1 AND startsWith(sample.8, x.2)), all_nodes)) AS parent_instances,
+    arrayMap(x -> x.5, arrayFilter(x -> (x.3 = sample.7 - 1 AND startsWith(sample.8, x.2)), all_nodes)) AS parent_traced,
+    arrayMap(x -> x.1, arrayFilter(x -> (x.3 = sample.7 + 1 AND startsWith(x.2, sample.8)), all_nodes)) AS child_services,
+    arrayMap(x -> x.4, arrayFilter(x -> (x.3 = sample.7 + 1 AND startsWith(x.2, sample.8)), all_nodes)) AS child_instances,
+    arrayMap(x -> x.5, arrayFilter(x -> (x.3 = sample.7 + 1 AND startsWith(x.2, sample.8)), all_nodes)) AS child_traced
+FROM (
+    SELECT
+        trace_id,
+        groupArray((s, p, d, i, t)) AS all_nodes,
+        groupArrayIf((timestamp, s, i, trace_id, err_t, err_m, d, p), is_err = 1) AS target_samples
+    FROM (
+        SELECT
+            trace_id,
+            timestamp,
+            nodes.service AS s,
+            nodes.path AS p,
+            nodes.depth AS d,
+            nodes.instance AS i,
+            nodes.is_traced AS t,
+            nodes.is_error AS is_err,
+            nodes.error_types AS err_t,
+            nodes.error_msgs AS err_m
+        FROM error_propagation
+        ARRAY JOIN nodes
+        WHERE trace_id GLOBAL IN (
+            SELECT trace_id FROM (
+                SELECT trace_id, timestamp, nodes.is_error as node_is_error
+                FROM error_propagation
+                ARRAY JOIN nodes
+            )
+            %s
+            ORDER BY timestamp DESC
+            LIMIT 1000
+        )
+    )
+    GROUP BY trace_id
+)
+ARRAY JOIN target_samples AS sample
+ORDER BY timestamp DESC
+LIMIT 1000`
 )
 
 // Query instance-related error propagation chain
@@ -57,11 +75,8 @@ func (ch *chRepo) ListErrorPropagation(ctx core.Context, req *request.GetErrorIn
 		EqualsNotEmpty("entry_service", req.EntryService).
 		EqualsNotEmpty("entry_url", req.EntryEndpoint).
 		Statement("LENGTH(nodes.error_types) > 0") // The data returned must be ErrorTypes
-	bySql := NewByLimitBuilder().
-		OrderBy("timestamp", false).
-		Limit(2000).String()
 	var results []ErrorInstancePropagation
-	sql := fmt.Sprintf(SQL_GET_INSTANCE_ERROR_PROPAGATION, ch.database, queryBuilder.String(), bySql, startTime, endTime, startTime, endTime)
+	sql := fmt.Sprintf(SQL_GET_INSTANCE_ERROR_PROPAGATION, queryBuilder.String())
 	if err := ch.GetContextDB(ctx).Select(ctx.GetContext(), &results, sql, queryBuilder.values...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary by Sourcery

Refactor the ClickHouse error propagation query to avoid the previous CTE-based implementation and rely on a single grouped query for parent/child relationships, updating the repository method to use the new SQL shape and limits.

Bug Fixes:
- Resolve issues with instance error propagation retrieval by replacing the previous CTE and joins with a more reliable grouped query over error nodes.

Enhancements:
- Simplify and consolidate error propagation SQL into a single query that computes parent and child relationships via array operations.
- Adjust error propagation listing to rely on the query’s internal ordering and limiting instead of an external limit builder.