### PR TITLE
fix: split heavy union pql

### DIFF
--- a/backend/pkg/repository/prometheus/dao.go
+++ b/backend/pkg/repository/prometheus/dao.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/CloudDetail/apo/backend/config"
 	"github.com/CloudDetail/apo/backend/pkg/model"
+	pmodel "github.com/prometheus/common/model"
 	prommodel "github.com/prometheus/common/model"
 
 	core "github.com/CloudDetail/apo/backend/pkg/core"
@@ -93,6 +94,8 @@ type Repo interface {
 
 	GetPodList(ctx core.Context, startTime int64, endTime int64, nodeName string, namespace string, podName string) ([]*model.Pod, error)
 	QueryWithPQLFilter
+
+	QueryRangeWithP9xBuilder(ctx core.Context, builder *UnionP9xBuilder, tRange v1.Range) (pmodel.Value, v1.Warnings, error)
 }
 
 type promRepo struct {

--- a/backend/pkg/repository/prometheus/dao_db_duration_bucket.go
+++ b/backend/pkg/repository/prometheus/dao_db_duration_bucket.go
@@ -24,15 +24,15 @@ func (repo *promRepo) QueryDbRangePercentile(ctx core.Context, startTime int64, 
 		Step:  time.Duration(step * 1000),
 	}
 
-	query := getDbP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
-	res, _, err := repo.GetApi().QueryRange(ctx.GetContext(), query, tRange)
+	qb := getDbP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
+	res, _, err := repo.QueryRangeWithP9xBuilder(ctx, qb, tRange)
 	if err != nil {
 		return nil, err
 	}
 	return getDescendantMetrics("db_url", "name", tRange, res), nil
 }
 
-func getDbP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) string {
+func getDbP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) *UnionP9xBuilder {
 	builder := NewUnionP9xBuilder(
 		"0.9",
 		"kindling_db_duration_nanoseconds_bucket",
@@ -42,5 +42,5 @@ func getDbP9xSql(promRange string, step time.Duration, svcs []string, endpoints 
 	builder.AddCondition("db_url", svcs)
 	builder.AddCondition("name", endpoints)
 	builder.AddCondition("db_system", systems)
-	return builder.ToString()
+	return builder
 }

--- a/backend/pkg/repository/prometheus/dao_external_duration_bucket.go
+++ b/backend/pkg/repository/prometheus/dao_external_duration_bucket.go
@@ -23,15 +23,15 @@ func (repo *promRepo) QueryExternalRangePercentile(ctx core.Context, startTime i
 		Step:  time.Duration(step * 1000),
 	}
 
-	query := getExternalP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
-	res, _, err := repo.GetApi().QueryRange(ctx.GetContext(), query, tRange)
+	qb := getExternalP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
+	res, _, err := repo.QueryRangeWithP9xBuilder(ctx, qb, tRange)
 	if err != nil {
 		return nil, err
 	}
 	return getDescendantMetrics("address", "name", tRange, res), nil
 }
 
-func getExternalP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) string {
+func getExternalP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) *UnionP9xBuilder {
 	builder := NewUnionP9xBuilder(
 		"0.9",
 		"kindling_external_duration_nanoseconds_bucket",
@@ -41,5 +41,5 @@ func getExternalP9xSql(promRange string, step time.Duration, svcs []string, endp
 	builder.AddCondition("address", svcs)
 	builder.AddCondition("name", endpoints)
 	builder.AddCondition("system", systems)
-	return builder.ToString()
+	return builder
 }

--- a/backend/pkg/repository/prometheus/dao_mq_duration_bucket.go
+++ b/backend/pkg/repository/prometheus/dao_mq_duration_bucket.go
@@ -22,15 +22,15 @@ func (repo *promRepo) QueryMqRangePercentile(ctx core.Context, startTime int64, 
 		End:   time.UnixMicro(endTime),
 		Step:  time.Duration(step * 1000),
 	}
-	query := getMqP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
-	res, _, err := repo.GetApi().QueryRange(ctx.GetContext(), query, tRange)
+	qb := getMqP9xSql(repo.promRange, tRange.Step, svcs, endpoints, systems)
+	res, _, err := repo.QueryRangeWithP9xBuilder(ctx, qb, tRange)
 	if err != nil {
 		return nil, err
 	}
 	return getDescendantMetrics("address", "name", tRange, res), nil
 }
 
-func getMqP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) string {
+func getMqP9xSql(promRange string, step time.Duration, svcs []string, endpoints []string, systems []string) *UnionP9xBuilder {
 	builder := NewUnionP9xBuilder(
 		"0.9",
 		"kindling_mq_duration_nanoseconds_bucket",
@@ -41,5 +41,5 @@ func getMqP9xSql(promRange string, step time.Duration, svcs []string, endpoints 
 	builder.AddCondition("name", endpoints)
 	builder.AddCondition("system", systems)
 	builder.AddExtraCondition("role!='consumer'")
-	return builder.ToString()
+	return builder
 }

--- a/backend/pkg/repository/prometheus/p9x_builder.go
+++ b/backend/pkg/repository/prometheus/p9x_builder.go
@@ -4,10 +4,17 @@
 package prometheus
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/CloudDetail/apo/backend/pkg/code"
+	core "github.com/CloudDetail/apo/backend/pkg/core"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	pmodel "github.com/prometheus/common/model"
+	prometheus_model "github.com/prometheus/common/model"
 )
 
 type UnionP9xBuilder struct {
@@ -18,6 +25,57 @@ type UnionP9xBuilder struct {
 	count           int
 	conditions      []*P9xCondition
 	extraConditions []string
+}
+
+var (
+	MAX_CONDITIONS_PER_GROUP = 30
+)
+
+func (repo *promRepo) QueryRangeWithP9xBuilder(ctx core.Context, builder *UnionP9xBuilder, tRange v1.Range) (pmodel.Value, v1.Warnings, error) {
+	if builder.count <= MAX_CONDITIONS_PER_GROUP {
+		pql := builder.ToString()
+		return repo.GetApi().QueryRange(ctx.GetContext(), pql, tRange)
+	}
+
+	var res []*pmodel.SampleStream
+	var warnings v1.Warnings
+	var errs []error
+
+	for i := 0; i < builder.count; i += MAX_CONDITIONS_PER_GROUP {
+		end := i + MAX_CONDITIONS_PER_GROUP
+		if end > builder.count {
+			end = builder.count
+		}
+		pql := builder.buildQueryWithCondRange(i, end)
+		subRes, subWarnings, subErr := repo.GetApi().QueryRange(ctx.GetContext(), pql, tRange)
+		if subErr != nil {
+			errs = append(errs, subErr)
+			continue
+		}
+
+		if subWarnings != nil {
+			warnings = append(warnings, subWarnings...)
+		}
+
+		if subRes == nil {
+			continue
+		}
+
+		subMatrix, ok := subRes.(prometheus_model.Matrix)
+		if !ok {
+			return nil, nil,
+				core.Error(
+					code.GetDescendantMetricsError,
+					fmt.Sprintf("invalid query result, expected matrix but got %T, subQuery: %s", subRes, pql),
+				)
+		}
+		if len(subMatrix) <= 0 {
+			continue
+		}
+		res = append(res, subMatrix...)
+	}
+
+	return prometheus_model.Matrix(res), warnings, errors.Join(errs...)
 }
 
 func NewUnionP9xBuilder(value string, tableName string, labels []string, duration time.Duration) *UnionP9xBuilder {
@@ -98,6 +156,57 @@ func (p9x *UnionP9xBuilder) ToString() string {
 		builder.WriteString("])))")
 	}
 	if p9x.count > 1 {
+		builder.WriteString(")")
+	}
+
+	return builder.String()
+}
+
+func (p9x *UnionP9xBuilder) buildQueryWithCondRange(start, end int) string {
+	var builder strings.Builder
+
+	lens := end - start
+	if lens > 1 {
+		builder.WriteString("union(")
+	}
+
+	for i := 0; i < lens; i++ {
+		if i > 0 {
+			builder.WriteString(",")
+		}
+		builder.WriteString("histogram_quantile(")
+		builder.WriteString(p9x.value)
+		builder.WriteString(", sum by(")
+		for j, label := range p9x.labels {
+			if j > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(label)
+		}
+		builder.WriteString(") (increase(")
+		builder.WriteString(p9x.tableName)
+		builder.WriteString("{")
+		for k, condition := range p9x.conditions {
+			if k > 0 {
+				builder.WriteString(", ")
+			}
+
+			builder.WriteString(condition.Key)
+			builder.WriteString("='")
+			builder.WriteString(condition.Values[start+i])
+			builder.WriteString("'")
+		}
+		for n, extraCondition := range p9x.extraConditions {
+			if len(p9x.conditions) > 0 || n > 0 {
+				builder.WriteString(", ")
+			}
+			builder.WriteString(extraCondition)
+		}
+		builder.WriteString("}[")
+		builder.WriteString(getDurationFromStep(p9x.duration))
+		builder.WriteString("])))")
+	}
+	if lens > 1 {
 		builder.WriteString(")")
 	}
 

--- a/backend/pkg/repository/prometheus/p9x_builder_test.go
+++ b/backend/pkg/repository/prometheus/p9x_builder_test.go
@@ -25,7 +25,7 @@ func TestSpanTraceP9x(t *testing.T) {
 	}
 }
 
-func TestSpliteSpanTraceP9x(t *testing.T) {
+func TestSplitSpanTraceP9x(t *testing.T) {
 	svcs := []string{"ts-station-service", "ts-travel2-service", "ts-travel-service"}
 	endpoints := []string{
 		"POST /api/v1/stationservice/stations/idlist",

--- a/backend/pkg/repository/prometheus/p9x_builder_test.go
+++ b/backend/pkg/repository/prometheus/p9x_builder_test.go
@@ -9,15 +9,7 @@ import (
 	"time"
 )
 
-func TestUnionP9xBuilder(t *testing.T) {
-	testSpanTraceP9x(t)
-	testSpanTraceInstanceP9x(t)
-	testExternalP9x(t)
-	testDbP9x(t)
-	testMqP9x(t)
-}
-
-func testSpanTraceP9x(t *testing.T) {
+func TestSpanTraceP9x(t *testing.T) {
 	svcs := []string{"ts-station-service", "ts-travel2-service"}
 	endpoints := []string{
 		"POST /api/v1/stationservice/stations/idlist",
@@ -28,22 +20,57 @@ func testSpanTraceP9x(t *testing.T) {
 		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-station-service', content_key='POST /api/v1/stationservice/stations/idlist'}[5m])))," +
 		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-travel2-service', content_key='POST /api/v1/travel2service/trips/left'}[5m])))" +
 		")"
-	if expect != got {
-		t.Errorf("want=%s, got=%s", expect, got)
+	if expect != got.ToString() {
+		t.Errorf("want=%s, got=%s", expect, got.ToString())
 	}
 }
 
-func testSpanTraceInstanceP9x(t *testing.T) {
+func TestSpliteSpanTraceP9x(t *testing.T) {
+	svcs := []string{"ts-station-service", "ts-travel2-service", "ts-travel-service"}
+	endpoints := []string{
+		"POST /api/v1/stationservice/stations/idlist",
+		"POST /api/v1/travel2service/trips/left",
+		"POST /api/v1/travel/service/trips/left",
+	}
+
+	got := getSpanTraceP9xSql("vmrange", 5*time.Minute, svcs, endpoints)
+
+	res1 := got.buildQueryWithCondRange(0, 1)
+	res2 := got.buildQueryWithCondRange(0, 2)
+	res3 := got.buildQueryWithCondRange(1, 3)
+
+	e1 := "histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-station-service', content_key='POST /api/v1/stationservice/stations/idlist'}[5m])))"
+	e2 := "union(" +
+		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-station-service', content_key='POST /api/v1/stationservice/stations/idlist'}[5m])))," +
+		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-travel2-service', content_key='POST /api/v1/travel2service/trips/left'}[5m])))" +
+		")"
+	e3 := "union(" +
+		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-travel2-service', content_key='POST /api/v1/travel2service/trips/left'}[5m])))," +
+		"histogram_quantile(0.9, sum by(vmrange, content_key, svc_name) (increase(kindling_span_trace_duration_nanoseconds_bucket{svc_name='ts-travel-service', content_key='POST /api/v1/travel/service/trips/left'}[5m])))" +
+		")"
+
+	if e1 != res1 {
+		t.Errorf("want=%s, got=%s", e1, res1)
+	}
+	if e2 != res2 {
+		t.Errorf("want=%s, got=%s", e1, res1)
+	}
+	if e3 != res3 {
+		t.Errorf("want=%s, got=%s", e1, res1)
+	}
+}
+
+func TestSpanTraceInstanceP9x(t *testing.T) {
 	endpoint := "POST /api/v1/stationservice/stations/idlist"
 	extraCondition := fmt.Sprintf("pod='%s'", "ts-station-service-8b76754bc-gbst8")
 	got := getSpanTraceInstanceP9xSql("vmrange", 5*time.Minute, endpoint, extraCondition)
 	expect := "histogram_quantile(0.9, sum by(vmrange) (increase(kindling_span_trace_duration_nanoseconds_bucket{content_key='POST /api/v1/stationservice/stations/idlist', pod='ts-station-service-8b76754bc-gbst8'}[5m])))"
-	if expect != got {
-		t.Errorf("want=%s, got=%s", expect, got)
+	if expect != got.ToString() {
+		t.Errorf("want=%s, got=%s", expect, got.ToString())
 	}
 }
 
-func testExternalP9x(t *testing.T) {
+func TestExternalP9x(t *testing.T) {
 	svcs := []string{"ts-basic-service:15680", "ts-order-service:12031"}
 	endpoints := []string{"POST /api", "GET /api"}
 	systems := []string{"http", "http"}
@@ -52,8 +79,8 @@ func testExternalP9x(t *testing.T) {
 		"histogram_quantile(0.9, sum by(vmrange, address, name) (increase(kindling_external_duration_nanoseconds_bucket{address='ts-basic-service:15680', name='POST /api', system='http'}[5m])))," +
 		"histogram_quantile(0.9, sum by(vmrange, address, name) (increase(kindling_external_duration_nanoseconds_bucket{address='ts-order-service:12031', name='GET /api', system='http'}[5m])))" +
 		")"
-	if expect != got {
-		t.Errorf("want=%s, got=%s", expect, got)
+	if expect != got.ToString() {
+		t.Errorf("want=%s, got=%s", expect, got.ToString())
 	}
 }
 
@@ -66,12 +93,12 @@ func testDbP9x(t *testing.T) {
 		"histogram_quantile(0.9, sum by(vmrange, db_url, name) (increase(kindling_db_duration_nanoseconds_bucket{db_url='train-ticket-mysql:3306', name='SELECT ts.train_type', db_system='mysql'}[5m])))," +
 		"histogram_quantile(0.9, sum by(vmrange, db_url, name) (increase(kindling_db_duration_nanoseconds_bucket{db_url='train-ticket-mysql:3306', name='SELECT ts.trip', db_system='mysql'}[5m])))" +
 		")"
-	if expect != got {
-		t.Errorf("want=%s, got=%s", expect, got)
+	if expect != got.ToString() {
+		t.Errorf("want=%s, got=%s", expect, got.ToString())
 	}
 }
 
-func testMqP9x(t *testing.T) {
+func TestMqP9x(t *testing.T) {
 	svcs := []string{"", ""}
 	endpoints := []string{"topicA", "topicB"}
 	systems := []string{"kafka", "rabbitmq"}
@@ -80,7 +107,7 @@ func testMqP9x(t *testing.T) {
 		"histogram_quantile(0.9, sum by(vmrange, address, name) (increase(kindling_mq_duration_nanoseconds_bucket{address='', name='topicA', system='kafka', role!='consumer'}[5m])))," +
 		"histogram_quantile(0.9, sum by(vmrange, address, name) (increase(kindling_mq_duration_nanoseconds_bucket{address='', name='topicB', system='rabbitmq', role!='consumer'}[5m])))" +
 		")"
-	if expect != got {
-		t.Errorf("want=%s, got=%s", expect, got)
+	if expect != got.ToString() {
+		t.Errorf("want=%s, got=%s", expect, got.ToString())
 	}
 }

--- a/backend/pkg/repository/prometheus/p9x_builder_test.go
+++ b/backend/pkg/repository/prometheus/p9x_builder_test.go
@@ -53,10 +53,10 @@ func TestSpliteSpanTraceP9x(t *testing.T) {
 		t.Errorf("want=%s, got=%s", e1, res1)
 	}
 	if e2 != res2 {
-		t.Errorf("want=%s, got=%s", e1, res1)
+		t.Errorf("want=%s, got=%s", e2, res2)
 	}
 	if e3 != res3 {
-		t.Errorf("want=%s, got=%s", e1, res1)
+		t.Errorf("want=%s, got=%s", e3, res3)
 	}
 }
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a query builder-based Prometheus range query helper to safely execute large union percentile queries by splitting them into smaller chunks and merging results.

New Features:
- Add QueryRangeWithP9xBuilder to execute UnionP9xBuilder-based Prometheus range queries with automatic result aggregation.
- Extend UnionP9xBuilder with support for building sub-queries over a subset of conditions to enable query splitting.

Bug Fixes:
- Avoid oversized Prometheus union queries for percentile metrics by splitting large condition sets into bounded groups before querying.

Enhancements:
- Refactor percentile query helpers to return UnionP9xBuilder instances instead of raw PQL strings for span, external, DB, and MQ duration metrics.
- Improve error handling for percentile range queries by validating matrix results and aggregating multiple sub-query errors.

Tests:
- Update existing percentile PQL builder tests to work with UnionP9xBuilder objects and add coverage for query splitting behavior.